### PR TITLE
Add error landing page.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,8 @@ import { GUEST_USER_ID } from './services/User/User'
 import { resetCache } from './services/Server/RequestCache'
 import WithCurrentUser from './components/HOCs/WithCurrentUser/WithCurrentUser'
 import WithCurrentTask from './components/HOCs/WithCurrentTask/WithCurrentTask'
+import WithExternalError
+       from './components/HOCs/WithExternalError/WithExternalError'
 import WithVirtualChallenge
        from './components/HOCs/WithVirtualChallenge/WithVirtualChallenge'
 import LoadRandomChallengeTask
@@ -31,6 +33,7 @@ const CurrentTaskPane = WithCurrentTask(TaskPane)
 const CurrentVirtualChallengeTaskPane =
   WithVirtualChallenge(WithCurrentTask(TaskPane))
 const VirtualChallengePane = WithVirtualChallenge(ChallengePane)
+const ErrorPane = WithExternalError(ChallengePane)
 
 /**
  * App represents the top level component of the application.  It renders a
@@ -89,6 +92,7 @@ export class App extends Component {
           <CachedRoute path='/user/profile' component={UserProfile} />
           <CachedRoute path='/leaderboard' component={Leaderboard} />
           <CachedRoute path='/admin' component={AdminPane} />
+          <CachedRoute path='/error' component={ErrorPane} />
         </Switch>
 
         {firstTimeModal}

--- a/src/components/HOCs/WithExternalError/WithExternalError.js
+++ b/src/components/HOCs/WithExternalError/WithExternalError.js
@@ -1,0 +1,42 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import queryString from 'query-string'
+import _omit from 'lodash/omit'
+import { addError } from '../../../services/Error/Error'
+
+/**
+ * WithExternalError generates an error on mount passed via `errormsg` query
+ * string param in the URL, causing an error modal to be immediately displayed.
+ * This component is intended to be used to wrap landing pages that may receive
+ * external errors (e.g. during an oauth failure). This should *not* be used
+ * for displaying errors within the app -- use the error service for that.
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
+export const WithExternalError = function(WrappedComponent) {
+  return class extends Component {
+    componentDidMount() {
+      const params = queryString.parse(this.props.location.search)
+
+      if (params.errormsg) {
+        this.props.addExternalError(params.errormsg)
+      }
+      else {
+        this.props.addExternalError("An unknown error occurred.")
+      }
+    }
+
+    render() {
+      return <WrappedComponent {..._omit(this.props, 'addExternalError')} />
+    }
+  }
+}
+
+const mapDispatchToProps = dispatch => ({
+  addExternalError: message => {
+    dispatch(addError({id: "Errors.external", defaultMessage: message}))
+  }
+})
+
+export default WrappedComponent =>
+  connect(null, mapDispatchToProps)(WithExternalError(WrappedComponent))


### PR DESCRIPTION
New `/error` landing page allows the server to load the app with an
initial error to be displayed to the user (e.g. a failure during oauth
negotiation) via `errormsg` query-string param in URL.