### PR TITLE
Don't import css files into sass files.

### DIFF
--- a/src/components/AdminPane/Manage/ChallengeAnalysisTable/ChallengeAnalysisTable.js
+++ b/src/components/AdminPane/Manage/ChallengeAnalysisTable/ChallengeAnalysisTable.js
@@ -20,6 +20,7 @@ import AsManageableChallenge
        from '../../../../interactions/Challenge/AsManageableChallenge'
 import VisibilitySwitch from '../VisibilitySwitch/VisibilitySwitch'
 import messages from './Messages'
+import '../../../../../node_modules/react-table/react-table.css'
 import './ChallengeAnalysisTable.css'
 
 const DeactivatableDropdownButton = WithDeactivateOnOutsideClick(DropdownButton)

--- a/src/components/AdminPane/Manage/ChallengeAnalysisTable/ChallengeAnalysisTable.scss
+++ b/src/components/AdminPane/Manage/ChallengeAnalysisTable/ChallengeAnalysisTable.scss
@@ -1,5 +1,4 @@
 @import 'theme.scss';
-@import 'react-table/react-table';
 
 .challenge-analysis-table {
   @include styled-react-table()

--- a/src/components/AdminPane/Manage/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/AdminPane/Manage/TaskAnalysisTable/TaskAnalysisTable.js
@@ -20,6 +20,7 @@ import ViewTask from '../ViewTask/ViewTask'
 import SvgSymbol from '../../../SvgSymbol/SvgSymbol'
 import AsyncCSVExport from './AsyncCSVExport'
 import messages from './Messages'
+import '../../../../../node_modules/react-table/react-table.css'
 import './TaskAnalysisTable.css'
 
 // Setup child components with necessary HOCs

--- a/src/components/AdminPane/Manage/TaskAnalysisTable/TaskAnalysisTable.scss
+++ b/src/components/AdminPane/Manage/TaskAnalysisTable/TaskAnalysisTable.scss
@@ -1,5 +1,4 @@
 @import 'theme.scss';
-@import 'react-table/react-table';
 
 .task-analysis-table {
   @include styled-react-table()


### PR DESCRIPTION
Address new deprecation warnings arising from import of CSS files into
sass files. CSS files from node modules needed by a component are now
imported directly by the component.