### PR TITLE
Add "Intersecting Map Bounds" filter. Closes #88

### DIFF
--- a/src/components/AdminPane/Manage/ManageProjects/ManageProjects.js
+++ b/src/components/AdminPane/Manage/ManageProjects/ManageProjects.js
@@ -99,9 +99,9 @@ ManageProjects.defaultProps = {
 
 export default
   WithManageableProjects(
-    WithSearchResults(
-      WithSearchResults(
-        WithCurrentProject(  // in case normal user has only 1 project
+    WithSearchResults( // for projects
+      WithSearchResults( // for challenges
+        WithCurrentProject( // in case user has only 1 project, load it up
           injectIntl(ManageProjects), {
             includeChallenges: true,
             includeActivity: true,
@@ -118,5 +118,5 @@ export default
       'projects',
       'filteredProjects'
     ),
-    true
+    true // include challenges
   )

--- a/src/components/ChallengePane/ChallengeFilterSubnav/FilterByLocation.js
+++ b/src/components/ChallengePane/ChallengeFilterSubnav/FilterByLocation.js
@@ -30,17 +30,18 @@ export class FilterByLocation extends Component {
       this.props.removeChallengeFilters(['location'])
     }
     else {
-      // For both nearMe and withinMapBounds options, we actually use the
-      // withinMapBounds filter -- we just also set the map bounds to be near
-      // the user in the nearMe case.
-      this.props.setChallengeFilters({location: ChallengeLocation.withinMapBounds})
+      this.props.setChallengeFilters({location: value})
 
+      // For nearMe, we actually use the withinMapBounds setting -- we just
+      // also set the map bounds to be near the user.
       if (value === ChallengeLocation.nearMe) {
         // Note: repositioning the map will automatically trigger an update of the
         // bounded challenges, so we don't need to request an update here.
+        this.props.setChallengeFilters({location: ChallengeLocation.withinMapBounds})
         this.props.locateMapToUser(this.props.user)
       }
-      else if (value === ChallengeLocation.withinMapBounds) {
+      else {
+        this.props.setChallengeFilters({location: value})
         this.props.updateBoundedChallenges(
           _get(this.props, 'mapBounds.locator.bounds'))
       }

--- a/src/components/ChallengePane/ChallengeFilterSubnav/__snapshots__/FilterByLocation.test.js.snap
+++ b/src/components/ChallengePane/ChallengeFilterSubnav/__snapshots__/FilterByLocation.test.js.snap
@@ -87,6 +87,11 @@ ShallowWrapper {
           "value": "withinMapBounds",
         },
         Object {
+          "key": "intersectingMapBounds",
+          "text": undefined,
+          "value": "intersectingMapBounds",
+        },
+        Object {
           "key": "nearMe",
           "text": undefined,
           "value": "nearMe",
@@ -125,6 +130,11 @@ ShallowWrapper {
             "key": "withinMapBounds",
             "text": undefined,
             "value": "withinMapBounds",
+          },
+          Object {
+            "key": "intersectingMapBounds",
+            "text": undefined,
+            "value": "intersectingMapBounds",
           },
           Object {
             "key": "nearMe",

--- a/src/components/HOCs/WithFilteredChallenges/WithFilteredChallenges.js
+++ b/src/components/HOCs/WithFilteredChallenges/WithFilteredChallenges.js
@@ -16,6 +16,14 @@ const allFilters = [
   challengePassesLocationFilter,
 ]
 
+/**
+ * The WithFilteredChallenges HOC applies all of the configured challenge
+ * filters to the given challenges, passing down those that pass the filter to
+ * the WrappedComponent.  The prop containing the challenges, as well as the
+ * output prop for passing them down, can be customized.
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
 export default function WithFilteredChallenges(WrappedComponent,
                                                challengesProp='challenges',
                                                outputProp) {

--- a/src/components/HOCs/WithMapBoundedTasks/WithMapBoundedTasks.js
+++ b/src/components/HOCs/WithMapBoundedTasks/WithMapBoundedTasks.js
@@ -48,9 +48,9 @@ const doUpdateBoundedTasks =
   }, 500) : _noop
 
 /**
- * WithMapBoundedTasks retrieves map-bounded task clusters
- * (regardless of challenge) within the given mapBounds bounding box when it's
- * of an appropriately small size as determiend by the
+ * WithMapBoundedTasks retrieves map-bounded task clusters (regardless of
+ * challenge) within the given mapBounds bounding box when it's of an
+ * appropriately small size as determiend by the
  * REACT_APP_BOUNDED_TASKS_MAX_DIMENSION .env setting.
  *
  * @author [Neil Rotstan](https://github.com/nrotstan)
@@ -70,8 +70,8 @@ export const WithMapBoundedTasks = function(WrappedComponent,
       toLatLngBounds(_get(props, `mapBounds.${mapType}.bounds`))
 
     /**
-     * Applies bounds and challenge filters to the map-bounded tasks, as appropriate,
-     * returning only those tasks that pass the filters.
+     * Applies bounds and challenge filters to the map-bounded tasks, as
+     * appropriate, returning only those tasks that pass the filters.
      */
     allowedTasks = () => {
       const bounds = this.normalizedBounds(this.props)
@@ -97,8 +97,8 @@ export const WithMapBoundedTasks = function(WrappedComponent,
     }
 
     /**
-     * Invoked when the user wishes to start work on the mapped tasks,
-     * creating a virtual challenge.
+     * Invoked when the user wishes to start work on the mapped tasks, creating
+     * a virtual challenge.
      */
     startMapBoundedTasks = name => {
       const tasks = _get(this.allowedTasks(), 'tasks')

--- a/src/components/HOCs/WithMapBounds/WithMapBounds.js
+++ b/src/components/HOCs/WithMapBounds/WithMapBounds.js
@@ -18,6 +18,12 @@ import { addError } from '../../../services/Error/Error'
 import AppErrors from '../../../services/Error/AppErrors'
 import { toLatLngBounds } from '../../../services/MapBounds/MapBounds'
 
+/**
+ * The WithMapBounds HOC passes down to the WrappedComponent the various
+ * bounding box settings of the maps, as well as functions for updating them.
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
 const WithMapBounds =
   WrappedComponent => connect(mapStateToProps, mapDispatchToProps)(WrappedComponent)
 
@@ -33,6 +39,9 @@ const convertBounds = (boundsObject) => {
   )
 }
 
+/**
+ * Retrieves challenges with tasks within the given bounding box
+ */
 const updateChallenges = _debounce((dispatch, bounds) => {
   const fetchId = _uniqueId('fetch')
   dispatch(pushFetchChallenges(fetchId))

--- a/src/components/HOCs/WithSearchResults/WithSearchResults.js
+++ b/src/components/HOCs/WithSearchResults/WithSearchResults.js
@@ -11,6 +11,17 @@ import _omit from 'lodash/omit'
 import WithSearchQuery from '../WithSearchQuery/WithSearchQuery'
 import { parseQueryString } from '../../../services/Search/Search'
 
+// Local fuzzy search configuration. See fusejs.io for details.
+const fuzzySearchOptions = {
+  shouldSort: true, // sort results best to worst
+  threshold: 0.4, // score: 0.0 is perfect, 1.0 terrible
+  location: 0, // ideal location of query match in string (0 = beginning of string)
+  distance: 500, // allowed distance from "location" (higher = less penalty for matches near end of string)
+  maxPatternLength: 64, // max query length
+  minMatchCharLength: 3,
+  keys: ["name", "displayName", "blurb"], // fields to search
+}
+
 /**
  * WithSearchResults acts as a filter that applies the named search query to an
  * array of candidate items, presenting to the wrapped component only those
@@ -23,24 +34,7 @@ import { parseQueryString } from '../../../services/Search/Search'
  *        down the filtered results. By default it will be the same as
  *        itemsProp.
  */
-const WithSearchResults = (WrappedComponent, searchName, itemsProp, outputProp) =>
-  WithSearchQuery(
-    _WithSearchResults(WrappedComponent, searchName, itemsProp, outputProp),
-    searchName
-  )
-
-// Setup local fuzzy search configuration. See fusejs.io for details.
-const searchOptions = {
-  shouldSort: true, // sort results best to worst
-  threshold: 0.4, // score: 0.0 is perfect, 1.0 terrible
-  location: 0, // ideal location of query match in string (0 = beginning of string)
-  distance: 500, // allowed distance from "location" (higher = less penalty for matches near end of string)
-  maxPatternLength: 64, // max query length
-  minMatchCharLength: 3,
-  keys: ["name", "displayName", "blurb"], // fields to search
-}
-
-export const _WithSearchResults = function(WrappedComponent, searchName, itemsProp, outputProp) {
+export const WithSearchResults = function(WrappedComponent, searchName, itemsProp, outputProp) {
   return class extends Component {
     /**
      * @private
@@ -74,7 +68,7 @@ export const _WithSearchResults = function(WrappedComponent, searchName, itemsPr
         }
 
         if (items.length > 0 && queryParts.query.length > 0) {
-          const fuzzySearch = new Fuse(items, searchOptions)
+          const fuzzySearch = new Fuse(items, fuzzySearchOptions)
           searchResults = fuzzySearch.search(queryParts.query)
         }
         else {
@@ -92,4 +86,8 @@ export const _WithSearchResults = function(WrappedComponent, searchName, itemsPr
   }
 }
 
-export default WithSearchResults
+export default (WrappedComponent, searchName, itemsProp, outputProp) =>
+  WithSearchQuery(
+    WithSearchResults(WrappedComponent, searchName, itemsProp, outputProp),
+    searchName
+  )

--- a/src/components/HOCs/WithSearchResults/WithSearchResults.test.js
+++ b/src/components/HOCs/WithSearchResults/WithSearchResults.test.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { _WithSearchResults } from './WithSearchResults'
+import { WithSearchResults } from './WithSearchResults'
 
 let basicProps = null
 let WrappedComponent = null
@@ -28,7 +28,7 @@ beforeEach(() => {
     ]
   }
 
-  WrappedComponent = _WithSearchResults(
+  WrappedComponent = WithSearchResults(
     () => <div className="child" />,
     "mySearchName",
     "myItems"
@@ -59,7 +59,7 @@ test("Search Results with tags are passed first in search results", () => {
 })
 
 test("Search Results are passed back as the 'outputProp' if provided", () => {
-  WrappedComponent = _WithSearchResults(
+  WrappedComponent = WithSearchResults(
     () => <div className="child" />,
     "mySearchName",
     "myItems",

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -334,6 +334,7 @@
   "Challenge.keywords.any": "Anything",
   "Challenge.location.nearMe": "Near Me",
   "Challenge.location.withinMapBounds": "Within Map Bounds",
+  "Challenge.location.intersectingMapBounds": "Intersecting Map Bounds",
   "Challenge.location.any": "Anywhere",
   "Challenge.status.none": "Not Applicable",
   "Challenge.status.building": "Building",

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -214,7 +214,7 @@ export const searchChallenges = function(queryString, filters={}, onlyEnabled=tr
  *                 values.
  * @param {number} limit
  */
-export const fetchChallengesWithinBoundingBox = function(bounds, limit=50) {
+export const fetchChallengesWithinBoundingBox = function(bounds, limit=100) {
   const boundsObject = toLatLngBounds(bounds)
 
   return function(dispatch) {
@@ -222,7 +222,7 @@ export const fetchChallengesWithinBoundingBox = function(bounds, limit=50) {
       api.challenges.withinBounds,
       {
         schema: [ challengeSchema() ],
-        params: {tbb: boundsObject.toBBoxString(), limit}
+        params: {bb: boundsObject.toBBoxString(), limit}
       }
     ).execute().then(normalizedResults => {
       dispatch(receiveChallenges(normalizedResults.entities))

--- a/src/services/Challenge/ChallengeLocation/Messages.js
+++ b/src/services/Challenge/ChallengeLocation/Messages.js
@@ -12,6 +12,10 @@ export default defineMessages({
     id: "Challenge.location.withinMapBounds",
     defaultMessage: "Within Map Bounds",
   },
+  intersectingMapBounds: {
+    id: "Challenge.location.intersectingMapBounds",
+    defaultMessage: "Intersecting Map Bounds",
+  },
   any: {
     id: "Challenge.location.any",
     defaultMessage: "Anywhere",


### PR DESCRIPTION
Change behavior of "Within Map Bounds" location filter to only display
challenges located within the current map bounds, and add new
"Intersecting Map Bounds" location filter that will also include
challenges with a bounding that intersects the current map bounds.