### PR TITLE
Allow user to copy and reset API key.

### DIFF
--- a/src/components/HOCs/WithCurrentUser/WithCurrentUser.js
+++ b/src/components/HOCs/WithCurrentUser/WithCurrentUser.js
@@ -6,6 +6,7 @@ import { logoutUser,
          saveTask, unsaveTask,
          updateUserSettings,
          fetchTopChallenges,
+         resetAPIKey,
          userDenormalizationSchema } from '../../../services/User/User'
 import AsEndUser from '../../../interactions/User/AsEndUser'
 
@@ -61,6 +62,9 @@ export const mapDispatchToProps = dispatch => {
 
     fetchUserTopChallenges: (userId, startDate) =>
       dispatch(fetchTopChallenges(userId, startDate)),
+
+    resetAPIKey: userId =>
+      dispatch(resetAPIKey(userId)),
   }
 }
 

--- a/src/components/UserProfile/ApiKey.js
+++ b/src/components/UserProfile/ApiKey.js
@@ -2,15 +2,34 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { FormattedMessage } from 'react-intl'
+import { CopyToClipboard } from 'react-copy-to-clipboard'
+import SvgSymbol from '../SvgSymbol/SvgSymbol'
+import ConfirmAction from '../ConfirmAction/ConfirmAction'
 import messages from './Messages'
 
 export default class ApiKey extends Component {
   render() {
     return (
       <div className={classNames("user-profile__api-key", this.props.className)}>
-        <h2 className="subtitle">
-          <FormattedMessage {...messages.apiKey} />
-        </h2>
+        <div className="user-profile__api-key__header">
+          <h2 className="subtitle">
+            <FormattedMessage {...messages.apiKey} />
+
+            <CopyToClipboard text={this.props.user.apiKey}>
+              <button className="button is-clear has-svg-icon user-profile__api-key__copy-button">
+                <SvgSymbol viewBox='0 0 20 20' sym="clipboard-icon" />
+                <FormattedMessage {...messages.apiKeyCopyLabel} />
+              </button>
+            </CopyToClipboard>
+          </h2>
+
+          <ConfirmAction>
+            <button className="button is-danger is-outlined user-profile__api-key__reset-button"
+                    onClick={() => this.props.resetAPIKey(this.props.user.id)}>
+                <FormattedMessage {...messages.apiKeyResetLabel} />
+            </button>
+          </ConfirmAction>
+        </div>
 
         <pre className="user-profile__api-key--current-key">
           {this.props.user.apiKey}
@@ -22,4 +41,5 @@ export default class ApiKey extends Component {
 
 ApiKey.propTypes = {
   user: PropTypes.object,
+  resetAPIKey: PropTypes.func.isRequired,
 }

--- a/src/components/UserProfile/Messages.js
+++ b/src/components/UserProfile/Messages.js
@@ -9,6 +9,16 @@ export default defineMessages({
     defaultMessage: "API Key",
   },
 
+  apiKeyCopyLabel: {
+    id: "UserProfile.apiKey.controls.copy.label",
+    defaultMessage: "Copy",
+  },
+
+  apiKeyResetLabel: {
+    id: "UserProfile.apiKey.controls.reset.label",
+    defaultMessage: "Reset",
+  },
+
   overviewTab: {
     id: "UserProfile.tabs.overview",
     defaultMessage: "Overview",

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -1,4 +1,4 @@
-@import 'variables.scss';
+@import 'mixins.scss';
 
 .grey-backdrop {
   color: $green;
@@ -254,8 +254,23 @@
     @extend .grey-backdrop;
     padding: 20px 15px;
 
-    h2.subtitle {
+    &__header {
+      display: flex;
+      justify-content: space-between;
       margin-bottom: 30px;
+    }
+
+    &__copy-button.button.is-clear {
+      @include invert-on-hover($green, $white)
+      background-color: transparent;
+      margin-left: 10px;
+      font-size: $size-7;
+      padding: 0px 10px 0px 5px;
+
+      svg {
+        width: 15px;
+        margin-bottom: 1px;
+      }
     }
 
     pre {

--- a/src/components/UserProfile/UserProfile.test.js
+++ b/src/components/UserProfile/UserProfile.test.js
@@ -15,6 +15,7 @@ beforeEach(() => {
       }
     },
     intl: {formatMessage: jest.fn(m => m.defaultMessage)},
+    resetAPIKey: () => null,
   }
 })
 

--- a/src/components/UserProfile/__snapshots__/UserProfile.test.js.snap
+++ b/src/components/UserProfile/__snapshots__/UserProfile.test.js.snap
@@ -10,6 +10,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    resetAPIKey={[Function]}
     user={
         Object {
             "created": 1487808000000,
@@ -40,6 +41,7 @@ ShallowWrapper {
                         "formatMessage": [Function],
                       }
         }
+        resetAPIKey={[Function]}
         user={
                 Object {
                         "created": 1487808000000,
@@ -63,6 +65,7 @@ ShallowWrapper {
         "intl": Object {
           "formatMessage": [Function],
         },
+        "resetAPIKey": [Function],
         "user": Object {
           "created": 1487808000000,
           "id": 357,
@@ -91,6 +94,7 @@ ShallowWrapper {
                               "formatMessage": [Function],
                             }
           }
+          resetAPIKey={[Function]}
           user={
                     Object {
                               "created": 1487808000000,
@@ -114,6 +118,7 @@ ShallowWrapper {
           "intl": Object {
             "formatMessage": [Function],
           },
+          "resetAPIKey": [Function],
           "user": Object {
             "created": 1487808000000,
             "id": 357,
@@ -150,6 +155,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    resetAPIKey={[Function]}
     user={
         Object {
             "created": 1487808000000,
@@ -191,6 +197,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                                         }
+                                        resetAPIKey={[Function]}
                                         user={
                                                   Object {
                                                             "created": 1487808000000,
@@ -217,6 +224,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                                         }
+                                        resetAPIKey={[Function]}
                                         user={
                                                   Object {
                                                             "created": 1487808000000,
@@ -235,6 +243,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                                         }
+                                        resetAPIKey={[Function]}
                                         user={
                                                   Object {
                                                             "created": 1487808000000,
@@ -253,6 +262,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                                         }
+                                        resetAPIKey={[Function]}
                                         user={
                                                   Object {
                                                             "created": 1487808000000,
@@ -271,6 +281,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                                         }
+                                        resetAPIKey={[Function]}
                                         user={
                                                   Object {
                                                             "created": 1487808000000,
@@ -288,6 +299,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                                         }
+                                        resetAPIKey={[Function]}
                                         user={
                                                   Object {
                                                             "created": 1487808000000,
@@ -313,6 +325,7 @@ ShallowWrapper {
                                         "formatMessage": [Function],
                                       }
                     }
+                    resetAPIKey={[Function]}
                     user={
                               Object {
                                         "created": 1487808000000,
@@ -342,6 +355,7 @@ ShallowWrapper {
                                                                               "formatMessage": [Function],
                                                                             }
                                                       }
+                                                      resetAPIKey={[Function]}
                                                       user={
                                                                   Object {
                                                                               "created": 1487808000000,
@@ -360,6 +374,7 @@ ShallowWrapper {
                                                                               "formatMessage": [Function],
                                                                             }
                                                       }
+                                                      resetAPIKey={[Function]}
                                                       user={
                                                                   Object {
                                                                               "created": 1487808000000,
@@ -378,6 +393,7 @@ ShallowWrapper {
                                                                               "formatMessage": [Function],
                                                                             }
                                                       }
+                                                      resetAPIKey={[Function]}
                                                       user={
                                                                   Object {
                                                                               "created": 1487808000000,
@@ -398,6 +414,7 @@ ShallowWrapper {
                                                                               "formatMessage": [Function],
                                                                             }
                                                       }
+                                                      resetAPIKey={[Function]}
                                                       user={
                                                                   Object {
                                                                               "created": 1487808000000,
@@ -415,6 +432,7 @@ ShallowWrapper {
                                                                               "formatMessage": [Function],
                                                                             }
                                                       }
+                                                      resetAPIKey={[Function]}
                                                       user={
                                                                   Object {
                                                                               "created": 1487808000000,
@@ -454,6 +472,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                 Object {
                                                             "created": 1487808000000,
@@ -480,6 +499,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                 Object {
                                                             "created": 1487808000000,
@@ -498,6 +518,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                 Object {
                                                             "created": 1487808000000,
@@ -516,6 +537,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                 Object {
                                                             "created": 1487808000000,
@@ -534,6 +556,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                 Object {
                                                             "created": 1487808000000,
@@ -551,6 +574,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                 Object {
                                                             "created": 1487808000000,
@@ -584,6 +608,7 @@ ShallowWrapper {
                                                                 "formatMessage": [Function],
                                                               }
                                 }
+                                resetAPIKey={[Function]}
                                 user={
                                                 Object {
                                                                 "created": 1487808000000,
@@ -610,6 +635,7 @@ ShallowWrapper {
                                                                 "formatMessage": [Function],
                                                               }
                                 }
+                                resetAPIKey={[Function]}
                                 user={
                                                 Object {
                                                                 "created": 1487808000000,
@@ -628,6 +654,7 @@ ShallowWrapper {
                                                                 "formatMessage": [Function],
                                                               }
                                 }
+                                resetAPIKey={[Function]}
                                 user={
                                                 Object {
                                                                 "created": 1487808000000,
@@ -646,6 +673,7 @@ ShallowWrapper {
                                                                 "formatMessage": [Function],
                                                               }
                                 }
+                                resetAPIKey={[Function]}
                                 user={
                                                 Object {
                                                                 "created": 1487808000000,
@@ -664,6 +692,7 @@ ShallowWrapper {
                                                                 "formatMessage": [Function],
                                                               }
                                 }
+                                resetAPIKey={[Function]}
                                 user={
                                                 Object {
                                                                 "created": 1487808000000,
@@ -681,6 +710,7 @@ ShallowWrapper {
                                                                 "formatMessage": [Function],
                                                               }
                                 }
+                                resetAPIKey={[Function]}
                                 user={
                                                 Object {
                                                                 "created": 1487808000000,
@@ -711,6 +741,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                     }
+                    resetAPIKey={[Function]}
                     user={
                                         Object {
                                                             "created": 1487808000000,
@@ -740,6 +771,7 @@ ShallowWrapper {
                     "intl": Object {
                       "formatMessage": [Function],
                     },
+                    "resetAPIKey": [Function],
                     "user": Object {
                       "created": 1487808000000,
                       "id": 357,
@@ -781,6 +813,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                     }
+                    resetAPIKey={[Function]}
                     user={
                                         Object {
                                                             "created": 1487808000000,
@@ -799,6 +832,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                     }
+                    resetAPIKey={[Function]}
                     user={
                                         Object {
                                                             "created": 1487808000000,
@@ -817,6 +851,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                     }
+                    resetAPIKey={[Function]}
                     user={
                                         Object {
                                                             "created": 1487808000000,
@@ -835,6 +870,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                     }
+                    resetAPIKey={[Function]}
                     user={
                                         Object {
                                                             "created": 1487808000000,
@@ -852,6 +888,7 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                     }
+                    resetAPIKey={[Function]}
                     user={
                                         Object {
                                                             "created": 1487808000000,
@@ -877,6 +914,7 @@ ShallowWrapper {
                     "intl": Object {
                       "formatMessage": [Function],
                     },
+                    "resetAPIKey": [Function],
                     "user": Object {
                       "created": 1487808000000,
                       "id": 357,
@@ -899,6 +937,7 @@ ShallowWrapper {
                     "intl": Object {
                       "formatMessage": [Function],
                     },
+                    "resetAPIKey": [Function],
                     "user": Object {
                       "created": 1487808000000,
                       "id": 357,
@@ -921,6 +960,7 @@ ShallowWrapper {
                     "intl": Object {
                       "formatMessage": [Function],
                     },
+                    "resetAPIKey": [Function],
                     "user": Object {
                       "created": 1487808000000,
                       "id": 357,
@@ -943,6 +983,7 @@ ShallowWrapper {
                     "intl": Object {
                       "formatMessage": [Function],
                     },
+                    "resetAPIKey": [Function],
                     "user": Object {
                       "created": 1487808000000,
                       "id": 357,
@@ -964,6 +1005,7 @@ ShallowWrapper {
                     "intl": Object {
                       "formatMessage": [Function],
                     },
+                    "resetAPIKey": [Function],
                     "user": Object {
                       "created": 1487808000000,
                       "id": 357,
@@ -998,6 +1040,7 @@ ShallowWrapper {
                                           "formatMessage": [Function],
                                         }
               }
+              resetAPIKey={[Function]}
               user={
                             Object {
                                           "created": 1487808000000,
@@ -1027,6 +1070,7 @@ ShallowWrapper {
                                                                                             "formatMessage": [Function],
                                                                                           }
                                                             }
+                                                            resetAPIKey={[Function]}
                                                             user={
                                                                             Object {
                                                                                             "created": 1487808000000,
@@ -1045,6 +1089,7 @@ ShallowWrapper {
                                                                                             "formatMessage": [Function],
                                                                                           }
                                                             }
+                                                            resetAPIKey={[Function]}
                                                             user={
                                                                             Object {
                                                                                             "created": 1487808000000,
@@ -1063,6 +1108,7 @@ ShallowWrapper {
                                                                                             "formatMessage": [Function],
                                                                                           }
                                                             }
+                                                            resetAPIKey={[Function]}
                                                             user={
                                                                             Object {
                                                                                             "created": 1487808000000,
@@ -1083,6 +1129,7 @@ ShallowWrapper {
                                                                                             "formatMessage": [Function],
                                                                                           }
                                                             }
+                                                            resetAPIKey={[Function]}
                                                             user={
                                                                             Object {
                                                                                             "created": 1487808000000,
@@ -1100,6 +1147,7 @@ ShallowWrapper {
                                                                                             "formatMessage": [Function],
                                                                                           }
                                                             }
+                                                            resetAPIKey={[Function]}
                                                             user={
                                                                             Object {
                                                                                             "created": 1487808000000,
@@ -1130,6 +1178,7 @@ ShallowWrapper {
               "intl": Object {
                 "formatMessage": [Function],
               },
+              "resetAPIKey": [Function],
               "user": Object {
                 "created": 1487808000000,
                 "id": 357,
@@ -1164,6 +1213,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                       Object {
                                                                         "created": 1487808000000,
@@ -1182,6 +1232,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                       Object {
                                                                         "created": 1487808000000,
@@ -1200,6 +1251,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                       Object {
                                                                         "created": 1487808000000,
@@ -1220,6 +1272,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                       Object {
                                                                         "created": 1487808000000,
@@ -1237,6 +1290,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                       Object {
                                                                         "created": 1487808000000,
@@ -1285,6 +1339,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                                 }
+                                                resetAPIKey={[Function]}
                                                 user={
                                                             Object {
                                                                         "created": 1487808000000,
@@ -1311,6 +1366,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                                 }
+                                                resetAPIKey={[Function]}
                                                 user={
                                                             Object {
                                                                         "created": 1487808000000,
@@ -1329,6 +1385,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                                 }
+                                                resetAPIKey={[Function]}
                                                 user={
                                                             Object {
                                                                         "created": 1487808000000,
@@ -1347,6 +1404,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                                 }
+                                                resetAPIKey={[Function]}
                                                 user={
                                                             Object {
                                                                         "created": 1487808000000,
@@ -1365,6 +1423,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                                 }
+                                                resetAPIKey={[Function]}
                                                 user={
                                                             Object {
                                                                         "created": 1487808000000,
@@ -1382,6 +1441,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                                 }
+                                                resetAPIKey={[Function]}
                                                 user={
                                                             Object {
                                                                         "created": 1487808000000,
@@ -1407,6 +1467,7 @@ ShallowWrapper {
                                                 "formatMessage": [Function],
                                               }
                         }
+                        resetAPIKey={[Function]}
                         user={
                                     Object {
                                                 "created": 1487808000000,
@@ -1436,6 +1497,7 @@ ShallowWrapper {
                                                                                             "formatMessage": [Function],
                                                                                           }
                                                                 }
+                                                                resetAPIKey={[Function]}
                                                                 user={
                                                                               Object {
                                                                                             "created": 1487808000000,
@@ -1454,6 +1516,7 @@ ShallowWrapper {
                                                                                             "formatMessage": [Function],
                                                                                           }
                                                                 }
+                                                                resetAPIKey={[Function]}
                                                                 user={
                                                                               Object {
                                                                                             "created": 1487808000000,
@@ -1472,6 +1535,7 @@ ShallowWrapper {
                                                                                             "formatMessage": [Function],
                                                                                           }
                                                                 }
+                                                                resetAPIKey={[Function]}
                                                                 user={
                                                                               Object {
                                                                                             "created": 1487808000000,
@@ -1492,6 +1556,7 @@ ShallowWrapper {
                                                                                             "formatMessage": [Function],
                                                                                           }
                                                                 }
+                                                                resetAPIKey={[Function]}
                                                                 user={
                                                                               Object {
                                                                                             "created": 1487808000000,
@@ -1509,6 +1574,7 @@ ShallowWrapper {
                                                                                             "formatMessage": [Function],
                                                                                           }
                                                                 }
+                                                                resetAPIKey={[Function]}
                                                                 user={
                                                                               Object {
                                                                                             "created": 1487808000000,
@@ -1548,6 +1614,7 @@ ShallowWrapper {
                                                                       "formatMessage": [Function],
                                                                     }
                                           }
+                                          resetAPIKey={[Function]}
                                           user={
                                                         Object {
                                                                       "created": 1487808000000,
@@ -1574,6 +1641,7 @@ ShallowWrapper {
                                                                       "formatMessage": [Function],
                                                                     }
                                           }
+                                          resetAPIKey={[Function]}
                                           user={
                                                         Object {
                                                                       "created": 1487808000000,
@@ -1592,6 +1660,7 @@ ShallowWrapper {
                                                                       "formatMessage": [Function],
                                                                     }
                                           }
+                                          resetAPIKey={[Function]}
                                           user={
                                                         Object {
                                                                       "created": 1487808000000,
@@ -1610,6 +1679,7 @@ ShallowWrapper {
                                                                       "formatMessage": [Function],
                                                                     }
                                           }
+                                          resetAPIKey={[Function]}
                                           user={
                                                         Object {
                                                                       "created": 1487808000000,
@@ -1628,6 +1698,7 @@ ShallowWrapper {
                                                                       "formatMessage": [Function],
                                                                     }
                                           }
+                                          resetAPIKey={[Function]}
                                           user={
                                                         Object {
                                                                       "created": 1487808000000,
@@ -1645,6 +1716,7 @@ ShallowWrapper {
                                                                       "formatMessage": [Function],
                                                                     }
                                           }
+                                          resetAPIKey={[Function]}
                                           user={
                                                         Object {
                                                                       "created": 1487808000000,
@@ -1678,6 +1750,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                       Object {
                                                                         "created": 1487808000000,
@@ -1704,6 +1777,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                       Object {
                                                                         "created": 1487808000000,
@@ -1722,6 +1796,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                       Object {
                                                                         "created": 1487808000000,
@@ -1740,6 +1815,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                       Object {
                                                                         "created": 1487808000000,
@@ -1758,6 +1834,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                       Object {
                                                                         "created": 1487808000000,
@@ -1775,6 +1852,7 @@ ShallowWrapper {
                                                                         "formatMessage": [Function],
                                                                       }
                                     }
+                                    resetAPIKey={[Function]}
                                     user={
                                                       Object {
                                                                         "created": 1487808000000,
@@ -1805,6 +1883,7 @@ ShallowWrapper {
                                                                   "formatMessage": [Function],
                                                                 }
                       }
+                      resetAPIKey={[Function]}
                       user={
                                             Object {
                                                                   "created": 1487808000000,
@@ -1834,6 +1913,7 @@ ShallowWrapper {
                       "intl": Object {
                         "formatMessage": [Function],
                       },
+                      "resetAPIKey": [Function],
                       "user": Object {
                         "created": 1487808000000,
                         "id": 357,
@@ -1875,6 +1955,7 @@ ShallowWrapper {
                                                                   "formatMessage": [Function],
                                                                 }
                       }
+                      resetAPIKey={[Function]}
                       user={
                                             Object {
                                                                   "created": 1487808000000,
@@ -1893,6 +1974,7 @@ ShallowWrapper {
                                                                   "formatMessage": [Function],
                                                                 }
                       }
+                      resetAPIKey={[Function]}
                       user={
                                             Object {
                                                                   "created": 1487808000000,
@@ -1911,6 +1993,7 @@ ShallowWrapper {
                                                                   "formatMessage": [Function],
                                                                 }
                       }
+                      resetAPIKey={[Function]}
                       user={
                                             Object {
                                                                   "created": 1487808000000,
@@ -1929,6 +2012,7 @@ ShallowWrapper {
                                                                   "formatMessage": [Function],
                                                                 }
                       }
+                      resetAPIKey={[Function]}
                       user={
                                             Object {
                                                                   "created": 1487808000000,
@@ -1946,6 +2030,7 @@ ShallowWrapper {
                                                                   "formatMessage": [Function],
                                                                 }
                       }
+                      resetAPIKey={[Function]}
                       user={
                                             Object {
                                                                   "created": 1487808000000,
@@ -1971,6 +2056,7 @@ ShallowWrapper {
                       "intl": Object {
                         "formatMessage": [Function],
                       },
+                      "resetAPIKey": [Function],
                       "user": Object {
                         "created": 1487808000000,
                         "id": 357,
@@ -1993,6 +2079,7 @@ ShallowWrapper {
                       "intl": Object {
                         "formatMessage": [Function],
                       },
+                      "resetAPIKey": [Function],
                       "user": Object {
                         "created": 1487808000000,
                         "id": 357,
@@ -2015,6 +2102,7 @@ ShallowWrapper {
                       "intl": Object {
                         "formatMessage": [Function],
                       },
+                      "resetAPIKey": [Function],
                       "user": Object {
                         "created": 1487808000000,
                         "id": 357,
@@ -2037,6 +2125,7 @@ ShallowWrapper {
                       "intl": Object {
                         "formatMessage": [Function],
                       },
+                      "resetAPIKey": [Function],
                       "user": Object {
                         "created": 1487808000000,
                         "id": 357,
@@ -2058,6 +2147,7 @@ ShallowWrapper {
                       "intl": Object {
                         "formatMessage": [Function],
                       },
+                      "resetAPIKey": [Function],
                       "user": Object {
                         "created": 1487808000000,
                         "id": 357,
@@ -2092,6 +2182,7 @@ ShallowWrapper {
                                                 "formatMessage": [Function],
                                               }
                 }
+                resetAPIKey={[Function]}
                 user={
                                 Object {
                                                 "created": 1487808000000,
@@ -2121,6 +2212,7 @@ ShallowWrapper {
                                                                                                         "formatMessage": [Function],
                                                                                                       }
                                                                     }
+                                                                    resetAPIKey={[Function]}
                                                                     user={
                                                                                       Object {
                                                                                                         "created": 1487808000000,
@@ -2139,6 +2231,7 @@ ShallowWrapper {
                                                                                                         "formatMessage": [Function],
                                                                                                       }
                                                                     }
+                                                                    resetAPIKey={[Function]}
                                                                     user={
                                                                                       Object {
                                                                                                         "created": 1487808000000,
@@ -2157,6 +2250,7 @@ ShallowWrapper {
                                                                                                         "formatMessage": [Function],
                                                                                                       }
                                                                     }
+                                                                    resetAPIKey={[Function]}
                                                                     user={
                                                                                       Object {
                                                                                                         "created": 1487808000000,
@@ -2177,6 +2271,7 @@ ShallowWrapper {
                                                                                                         "formatMessage": [Function],
                                                                                                       }
                                                                     }
+                                                                    resetAPIKey={[Function]}
                                                                     user={
                                                                                       Object {
                                                                                                         "created": 1487808000000,
@@ -2194,6 +2289,7 @@ ShallowWrapper {
                                                                                                         "formatMessage": [Function],
                                                                                                       }
                                                                     }
+                                                                    resetAPIKey={[Function]}
                                                                     user={
                                                                                       Object {
                                                                                                         "created": 1487808000000,
@@ -2224,6 +2320,7 @@ ShallowWrapper {
                 "intl": Object {
                   "formatMessage": [Function],
                 },
+                "resetAPIKey": [Function],
                 "user": Object {
                   "created": 1487808000000,
                   "id": 357,
@@ -2258,6 +2355,7 @@ ShallowWrapper {
                                                                                 "formatMessage": [Function],
                                                                               }
                                         }
+                                        resetAPIKey={[Function]}
                                         user={
                                                             Object {
                                                                                 "created": 1487808000000,
@@ -2276,6 +2374,7 @@ ShallowWrapper {
                                                                                 "formatMessage": [Function],
                                                                               }
                                         }
+                                        resetAPIKey={[Function]}
                                         user={
                                                             Object {
                                                                                 "created": 1487808000000,
@@ -2294,6 +2393,7 @@ ShallowWrapper {
                                                                                 "formatMessage": [Function],
                                                                               }
                                         }
+                                        resetAPIKey={[Function]}
                                         user={
                                                             Object {
                                                                                 "created": 1487808000000,
@@ -2314,6 +2414,7 @@ ShallowWrapper {
                                                                                 "formatMessage": [Function],
                                                                               }
                                         }
+                                        resetAPIKey={[Function]}
                                         user={
                                                             Object {
                                                                                 "created": 1487808000000,
@@ -2331,6 +2432,7 @@ ShallowWrapper {
                                                                                 "formatMessage": [Function],
                                                                               }
                                         }
+                                        resetAPIKey={[Function]}
                                         user={
                                                             Object {
                                                                                 "created": 1487808000000,

--- a/src/services/User/User.js
+++ b/src/services/User/User.js
@@ -300,6 +300,28 @@ export const updateUserSettings = function(userId, settings) {
 }
 
 /**
+ * Reset the user's API key
+ */
+export const resetAPIKey = function(userId) {
+  return function(dispatch) {
+    const resetURI = `/auth/generateAPIKey?userId=${userId}`
+
+    fetch(resetURI, {credentials: 'same-origin'}).then(() => {
+      return fetchUser(userId)(dispatch)
+    }).catch(error => {
+      // a 401 (unauthorized) indicates that the user is not logged in.
+      // Logout the current user to reflect that.
+      if (error.response && error.response.status === 401) {
+        dispatch(logoutUser())
+      }
+      else {
+        console.log(error.response || error)
+      }
+    })
+  }
+}
+
+/**
  * Add the given challenge to the given user's list of saved challenges.
  */
 export const saveChallenge = function(userId, challengeId) {


### PR DESCRIPTION
Add new buttons to API key section of user profile page to copy API key
to clipboard and to reset API key (requires confirmation).