### PR TITLE
Refresh bulk-task selections after task update.

### DIFF
--- a/src/components/AdminPane/HOCs/WithCurrentChallenge/WithCurrentChallenge.js
+++ b/src/components/AdminPane/HOCs/WithCurrentChallenge/WithCurrentChallenge.js
@@ -45,7 +45,7 @@ const WithCurrentChallenge = function(WrappedComponent,
         this.setState({loadingChallenge: true})
 
         // Start by fetching the challenge. Then fetch follow-up data.
-        this.props.fetchChallenge(challengeId).then(normalizedChallengeData => {
+        return this.props.fetchChallenge(challengeId).then(normalizedChallengeData => {
           const challenge = challengeResultEntity(normalizedChallengeData)
 
           Promise.all([
@@ -58,6 +58,7 @@ const WithCurrentChallenge = function(WrappedComponent,
             // Only fetch tasks if the challenge is in a usable status. Otherwise
             // we risk errors if the tasks are still building or failed to build.
             if (isUsableChallengeStatus(challenge.status)) {
+              this.setState({loadingTasks: true})
               this.props.fetchClusteredTasks(challengeId).then(() =>
                 this.setState({loadingTasks: false})
               )

--- a/src/components/AdminPane/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
+++ b/src/components/AdminPane/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
@@ -75,6 +75,10 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
       })
     }
 
+    /**
+     * Filters the tasks, returning only those that match both the given
+     * statuses and priorites.
+     */
     filterTasks = (includeStatuses, includePriorities) => {
       let results = null
       if (_isArray(_get(this.props[tasksProp], 'tasks'))) {
@@ -123,6 +127,12 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
       return this.state.selectedTasks.size > 0 && !this.allTasksAreSelected()
     }
 
+    /**
+     * Removes from the currently selected tasks any tasks that are no longer
+     * present in the given filtered tasks.
+     *
+     * @private
+     */
     unselectExcludedTasks = filteredTasks => {
       const excludedTasks = _differenceBy([...this.state.selectedTasks.values()],
                                           filteredTasks.tasks,
@@ -133,6 +143,18 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
       }
 
       return this.state.selectedTasks
+    }
+
+    /**
+     * Refresh the selected tasks to ensure they don't include tasks that don't
+     * pass the current filters. This is intended for wrapped components to use
+     * if they do something that alters the status of tasks.
+     */
+    refreshSelectedTasks = () => {
+      const filteredTasks = this.filterTasks(this.state.includeStatuses,
+                                             this.state.includePriorities)
+      const selectedTasks = this.unselectExcludedTasks(filteredTasks)
+      this.setState({filteredTasks, selectedTasks})
     }
 
     /**
@@ -218,6 +240,7 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
                                toggleIncludedTaskPriority={this.toggleIncludedPriority}
                                toggleTaskSelection={this.toggleTaskSelection}
                                toggleAllTasksSelection={this.toggleAllTasksSelection}
+                               refreshSelectedTasks={this.refreshSelectedTasks}
                                selectTasksWithStatus={this.selectTasksWithStatus}
                                selectTasksWithPriority={this.selectTasksWithPriority}
                                allTasksAreSelected={this.allTasksAreSelected}

--- a/src/components/AdminPane/Manage/ViewChallenge/ViewChallengeTasks.js
+++ b/src/components/AdminPane/Manage/ViewChallenge/ViewChallengeTasks.js
@@ -47,6 +47,15 @@ export class ViewChallengeTasks extends Component {
     bulkUpdating: false,
   }
 
+  componentDidUpdate(prevProps) {
+    // When bulk updating, wait until the tasks have been reloaded before turning
+    // off the bulkUpdating flag and refreshing any selected tasks.
+    if (this.state.bulkUpdating && prevProps.loadingTasks && !this.props.loadingTasks) {
+      this.props.refreshSelectedTasks()
+      this.setState({bulkUpdating: false})
+    }
+  }
+
   takeTaskSelectionAction = action => {
     if (action.statusAction) {
       this.props.selectTasksWithStatus(action.status)
@@ -69,7 +78,6 @@ export class ViewChallengeTasks extends Component {
         this.setState({bulkUpdating: true})
         this.props.bulkUpdateTasks(tasks, true).then(() => {
           this.props.refreshChallenge()
-          this.setState({bulkUpdating: false})
         })
         break
       default:


### PR DESCRIPTION
Ensure that selected tasks are refreshed after a bulk update so that
tasks no longer matching the current filters post-update (and therefore
no longer displayed) are unselected.