### PR TITLE
Ensure numeric parent when saving challenge.

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
@@ -283,6 +283,11 @@ export class EditChallenge extends Component {
       this.state.formData,
     ))
 
+    // Parent field should just be id, not object.
+    if (_isObject(challengeData.parent)) {
+      challengeData.parent = challengeData.parent.id
+    }
+
     // For new challenges, append the #maproulette hashtag to the changeset comment
     // if user allows it.
     if (challengeData.isNew() && challengeData.includeCheckinHashtag) {


### PR DESCRIPTION
When saving or cloning a challenge, ensure the parent project is
submitted to the API as a numeric id and not a project object.