### PR TITLE
Restrict project controls needing admin role.

### DIFF
--- a/src/components/AdminPane/Manage/ChallengeList/ChallengeList.js
+++ b/src/components/AdminPane/Manage/ChallengeList/ChallengeList.js
@@ -6,6 +6,7 @@ import _map from 'lodash/map'
 import _get from 'lodash/get'
 import _compact from 'lodash/compact'
 import { Link } from 'react-router-dom'
+import AsManager from '../../../../interactions/User/AsManager'
 import SvgSymbol from '../../../SvgSymbol/SvgSymbol'
 import messages from './Messages'
 import './ChallengeList.css'
@@ -19,6 +20,8 @@ import './ChallengeList.css'
  */
 export default class ChallengeList extends Component {
   render() {
+    const manager = AsManager(this.props.user)
+
     const challengeItems = _compact(_map(this.props.challenges, challenge => {
       if (challenge.deleted) {
         return null
@@ -54,7 +57,7 @@ export default class ChallengeList extends Component {
          challengeItems
         }
 
-        {!this.props.suppressControls &&
+        {!this.props.suppressControls && manager.canWriteProject(this.props.project) &&
          <div className="challenge-list__controls has-centered-children">
            <button className="button is-green is-outlined new-challenge"
                    onClick={() => this.props.history.push(

--- a/src/components/AdminPane/Manage/ChallengeList/ChallengeList.scss
+++ b/src/components/AdminPane/Manage/ChallengeList/ChallengeList.scss
@@ -2,11 +2,25 @@
 
 .admin__manage__managed-item-list.challenge-list {
   .challenge-list-item {
-    border-bottom: 2px solid $grey-lightest-less;
-    margin-bottom: 0.25rem;
+    border-top: 2px solid $grey-lightest-less;
+    margin-top: 0px;
 
     .challenge-name {
       word-break: break-word;
+    }
+  }
+
+  .item-entry:not(:last-child) {
+    margin-bottom: 0;
+
+    &:first-child {
+      .challenge-list-item {
+        border-top: none;
+
+        .column {
+          padding-top: 0;
+        }
+      }
     }
   }
 

--- a/src/components/AdminPane/Manage/ProjectList/ProjectList.js
+++ b/src/components/AdminPane/Manage/ProjectList/ProjectList.js
@@ -155,7 +155,6 @@ export default class ProjectList extends Component {
                           {..._omit(this.props, 'challenges')} />,
           [this.props.intl.formatMessage(messages.detailsTabLabel)]:
            <ProjectOverview managesSingleProject={this.managesSingleProject(this.props)}
-                            suppressControls={!manager.canWriteProject(project)}
                             {...this.props} />,
           [this.props.intl.formatMessage(messages.managersTabLabel)]:
            <ProjectManagers {...this.props} />,

--- a/src/components/AdminPane/Manage/ProjectManagers/ProjectManagers.js
+++ b/src/components/AdminPane/Manage/ProjectManagers/ProjectManagers.js
@@ -121,14 +121,14 @@ export default class ProjectManagers extends Component {
                <FormattedMessage {...messages.projectOwner} />
              </div> :
              <select value={managerRole}
-                     disabled={!user.canWriteProject(this.props.project)}
+                     disabled={!user.canAdministrateProject(this.props.project)}
                      onChange={e => this.updateManagerRole(manager.osmId, e.target.value)}
                      className="select project-managers__manager__role">
                {groupTypeOptions}
              </select>
             }
 
-            {manager.osmId !== this.props.project.owner && user.canWriteProject(this.props.project) &&
+            {manager.osmId !== this.props.project.owner && user.canAdministrateProject(this.props.project) &&
               <ConfirmAction prompt={this.props.intl.formatMessage(messages.removeManagerConfirmation)}>
                 <a className="button is-clear project-managers__manager__remove-control"
                    onClick={() => this.removeManager(manager.osmId)}
@@ -154,7 +154,7 @@ export default class ProjectManagers extends Component {
       <div className="project-managers">
         {managers}
 
-        {user.canWriteProject(this.props.project) &&
+        {user.canAdministrateProject(this.props.project) &&
           <div className="project-managers__add-manager">
             <h3><FormattedMessage {...messages.addManager} /></h3>
 

--- a/src/components/AdminPane/Manage/ProjectOverview/ProjectOverview.js
+++ b/src/components/AdminPane/Manage/ProjectOverview/ProjectOverview.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage,
          FormattedDate } from 'react-intl'
+import AsManager from '../../../../interactions/User/AsManager'
 import MarkdownContent from '../../../MarkdownContent/MarkdownContent'
 import ConfirmAction from '../../../ConfirmAction/ConfirmAction'
 import messages from './Messages'
@@ -22,6 +23,8 @@ export default class ProjectOverview extends Component {
   }
 
   render() {
+    const manager = AsManager(this.props.user)
+
     return (
       <div className="project-overview">
         <div className="project-overview__status status-section">
@@ -57,7 +60,7 @@ export default class ProjectOverview extends Component {
             </div>
           </div>
 
-          {!this.props.suppressControls &&
+          {manager.canAdministrateProject(this.props.project) &&
            <div className="project-overview__controls">
              <ConfirmAction>
                <div className="button is-outlined is-danger project-overview__controls__delete-project"
@@ -78,8 +81,6 @@ ProjectOverview.propTypes = {
   project: PropTypes.object,
   /** Set to true if the user manages only a single project */
   managesSingleProject: PropTypes.bool.isRequired,
-  /** Set to true to hide project controls */
-  suppressControls: PropTypes.bool,
   /** Invoked if the user wishes to delete the project */
   deleteProject: PropTypes.func.isRequired,
 }

--- a/src/interactions/User/AsManager.js
+++ b/src/interactions/User/AsManager.js
@@ -105,7 +105,7 @@ export class AsManager extends AsEndUser {
    *
    * @returns true if the user can administrate the project, false otherwise.
    */
-  canAdministrate(project) {
+  canAdministrateProject(project) {
     return this.satisfiesProjectGroupType(project, GroupType.admin)
   }
 

--- a/src/interactions/User/AsManager.test.js
+++ b/src/interactions/User/AsManager.test.js
@@ -86,43 +86,43 @@ describe('canManage', () => {
   })
 })
 
-describe('canAdministrate', () => {
+describe('canAdministrateProject', () => {
   it("always returns true if the user is a superuser", () => {
     const manager = AsManager(superUser)
 
-    expect(manager.canAdministrate(project123)).toBe(true)
-    expect(manager.canAdministrate(project456)).toBe(true)
+    expect(manager.canAdministrateProject(project123)).toBe(true)
+    expect(manager.canAdministrateProject(project456)).toBe(true)
   })
 
   it("returns true if the user is the project owner", () => {
     const manager = AsManager(normalUser)
 
-    expect(manager.canAdministrate(project101)).toBe(true)
-    expect(manager.canAdministrate(project789)).toBe(false)
+    expect(manager.canAdministrateProject(project101)).toBe(true)
+    expect(manager.canAdministrateProject(project789)).toBe(false)
   })
 
   it("returns false if user and project owner ids match but are are undefined", () => {
     const manager = AsManager(powerUser)
 
-    expect(manager.canAdministrate(project789)).toBe(false)
+    expect(manager.canAdministrateProject(project789)).toBe(false)
   })
 
   it("returns true if the user possesses the project's admin group", () => {
     const manager = AsManager(powerUser)
 
-    expect(manager.canAdministrate(project123)).toBe(true)
+    expect(manager.canAdministrateProject(project123)).toBe(true)
   })
 
   it("returns false if the user merely contains non-admin project group", () => {
     const manager = AsManager(powerUser)
 
-    expect(manager.canAdministrate(project456)).toBe(false)
+    expect(manager.canAdministrateProject(project456)).toBe(false)
   })
 
   it("returns false if the user is undefined", () => {
     const missingUser = AsManager(undefined)
 
-    expect(missingUser.canAdministrate(project123)).toBe(false)
+    expect(missingUser.canAdministrateProject(project123)).toBe(false)
   })
 })
 


### PR DESCRIPTION
Disable or hide controls to delete project and administrate project
managers from project managers who do not have admin access.