### PR TITLE
Show only writeable projects in move-challenge.

### DIFF
--- a/src/components/AdminPane/Manage/ViewChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ViewChallenge/Messages.js
@@ -34,6 +34,11 @@ export default defineMessages({
     defaultMessage: "Move",
   },
 
+  noProjects: {
+    id: "Admin.Challenge.controls.move.none",
+    defaultMessage: "No permitted projects",
+  },
+
   rebuildChallengeLabel: {
     id: "Admin.Challenge.controls.rebuild.label",
     defaultMessage: "Rebuild",

--- a/src/components/AdminPane/Manage/ViewChallenge/ViewChallenge.js
+++ b/src/components/AdminPane/Manage/ViewChallenge/ViewChallenge.js
@@ -62,7 +62,7 @@ export class ViewChallenge extends Component {
     const projectId = _get(this.props, 'challenge.parent.id')
 
     const managedProjectOptions = _compact(_map(this.props.projects, project => {
-      if (project.id === projectId) {
+      if (project.id === projectId || !manager.canWriteProject(project)) {
         return null
       }
 
@@ -124,7 +124,8 @@ export class ViewChallenge extends Component {
              {_get(this.props, 'projects.length', 0) > 1 &&
               <div className="column is-narrow admin__manage__controls--control">
                 <DeactivatableDropdownButton options={managedProjectOptions}
-                                             onSelect={this.moveChallenge}>
+                                             onSelect={this.moveChallenge}
+                                             emptyContent={<FormattedMessage {...messages.noProjects} />}>
                   <a>
                     <FormattedMessage {...messages.moveChallengeLabel} />
                     <div className="basic-dropdown-indicator" />

--- a/src/components/Bulma/DropdownButton.js
+++ b/src/components/Bulma/DropdownButton.js
@@ -46,7 +46,7 @@ export class DropdownButton extends Component {
                       label={this.props.children}
                       isActive={this.props.isActive()}
                       toggleActive={this.props.toggleActive}>
-        {options}
+        {options.length > 0 ? options : this.props.emptyContent}
       </SimpleDropdown>
     )
   }
@@ -62,6 +62,8 @@ DropdownButton.propTypes = {
     className: PropTypes.string,
     confirm: PropTypes.bool,
   })),
+  /** Optional content to display if dropdown is empty (no options) */
+  emptyContent: PropTypes.element,
   /** Invoked when a menu option is selected by the user */
   onSelect: PropTypes.func,
   /** Invoked to toggle the current active/inactive state of the dropdown */

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -177,6 +177,7 @@
   "Admin.Challenge.status.asOf.label": "as of",
   "Admin.Challenge.controls.edit.label": "Edit",
   "Admin.Challenge.controls.move.label": "Move",
+  "Admin.Challenge.controls.move.none": "No permitted projects",
   "Admin.Challenge.controls.rebuild.label": "Rebuild",
   "Admin.Challenge.controls.rebuild.prompt": "Rebuilding will re-run the Overpass query and refresh your challenge with the latest data. Tasks marked as fixed will be removed from your challenge (affecting your metrics), while tasks for new data will be added. In some situations tasks may be duplicated if matching up old data with new data is unsuccessful. Do you wish to proceed?",
   "Admin.Challenge.controls.clone.label": "Clone",


### PR DESCRIPTION
Filter the destination projects displayed in the admin move-challenge
dropdown to only include projects to which the manager has write access.