### PR TITLE
Reuse task completion map. Closes #298

### DIFF
--- a/src/components/ChallengeMap/__snapshots__/ChallengeMap.test.js.snap
+++ b/src/components/ChallengeMap/__snapshots__/ChallengeMap.test.js.snap
@@ -77,6 +77,7 @@ ShallowWrapper {
 />,
         <EnhancedMap
           animate={true}
+          animateFeatures={false}
           center={
                     Object {
                               "lat": 0,
@@ -172,6 +173,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "animate": true,
+          "animateFeatures": false,
           "center": Object {
             "lat": 0,
             "lng": 45,
@@ -323,6 +325,7 @@ ShallowWrapper {
 />,
           <EnhancedMap
             animate={true}
+            animateFeatures={false}
             center={
                         Object {
                                     "lat": 0,
@@ -418,6 +421,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "animate": true,
+            "animateFeatures": false,
             "center": Object {
               "lat": 0,
               "lng": 45,
@@ -617,6 +621,7 @@ ShallowWrapper {
 />,
         <EnhancedMap
           animate={true}
+          animateFeatures={false}
           center={
                     Object {
                               "lat": 0,
@@ -710,6 +715,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "animate": true,
+          "animateFeatures": false,
           "center": Object {
             "lat": 0,
             "lng": 45,
@@ -850,6 +856,7 @@ ShallowWrapper {
 />,
           <EnhancedMap
             animate={true}
+            animateFeatures={false}
             center={
                         Object {
                                     "lat": 0,
@@ -943,6 +950,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "animate": true,
+            "animateFeatures": false,
             "center": Object {
               "lat": 0,
               "lng": 45,
@@ -1134,6 +1142,7 @@ ShallowWrapper {
 />,
         <EnhancedMap
           animate={true}
+          animateFeatures={false}
           center={
                     Object {
                               "lat": 0,
@@ -1229,6 +1238,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "animate": true,
+          "animateFeatures": false,
           "center": Object {
             "lat": 0,
             "lng": 45,
@@ -1372,6 +1382,7 @@ ShallowWrapper {
 />,
           <EnhancedMap
             animate={true}
+            animateFeatures={false}
             center={
                         Object {
                                     "lat": 0,
@@ -1467,6 +1478,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "animate": true,
+            "animateFeatures": false,
             "center": Object {
               "lat": 0,
               "lng": 45,

--- a/src/components/EnhancedMap/MapPane/MapPane.scss
+++ b/src/components/EnhancedMap/MapPane/MapPane.scss
@@ -8,6 +8,21 @@
   .leaflet-container {
     .leaflet-pane {
       z-index: $layer-map;
+
+      path.leaflet-interactive {
+        opacity: 0; // hide by default so we can control appearance.
+      }
+
+      &.leaflet-marker-pane.animated {
+        @keyframes marker-bounce {
+          0%   { transform: translate3d(0px, 0px, 0px); }
+          30%  { transform: translate3d(0px, -50px, 0px); }
+          50%  { transform: translate3d(0px, 0px, 0px); }
+          100% { transform: translate3d(0px, 0px, 0px); }
+        }
+
+        animation: marker-bounce 2s cubic-bezier(0.175, 0.885, 0.32, 1.275); // easeOutBack
+      }
     }
 
     .leaflet-control-container {

--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
@@ -129,7 +129,7 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
       })
 
       // Load the next task from the challenge.
-      nextRandomTask(dispatch, ownProps, taskId, taskLoadBy).then(newTask =>
+      return nextRandomTask(dispatch, ownProps, taskId, taskLoadBy).then(newTask =>
         visitNewTask(ownProps, taskId, newTask)
       )
     },

--- a/src/components/LocatorMap/__snapshots__/LocatorMap.test.js.snap
+++ b/src/components/LocatorMap/__snapshots__/LocatorMap.test.js.snap
@@ -61,6 +61,7 @@ ShallowWrapper {
 />,
         <EnhancedMap
           animate={true}
+          animateFeatures={false}
           center={
                     Object {
                               "lat": 0,
@@ -133,6 +134,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "animate": true,
+          "animateFeatures": false,
           "center": Object {
             "lat": 0,
             "lng": 45,
@@ -226,6 +228,7 @@ ShallowWrapper {
 />,
           <EnhancedMap
             animate={true}
+            animateFeatures={false}
             center={
                         Object {
                                     "lat": 0,
@@ -298,6 +301,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "animate": true,
+            "animateFeatures": false,
             "center": Object {
               "lat": 0,
               "lng": 45,

--- a/src/components/TaskPane/TaskMap/TaskMap.js
+++ b/src/components/TaskPane/TaskMap/TaskMap.js
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { ZoomControl } from 'react-leaflet'
 import _isObject from 'lodash/isObject'
 import _get from 'lodash/get'
+import _isEqual from 'lodash/isEqual'
 import EnhancedMap from '../../EnhancedMap/EnhancedMap'
 import SourcedTileLayer from '../../EnhancedMap/SourcedTileLayer/SourcedTileLayer'
 import LayerToggle from '../../EnhancedMap/LayerToggle/LayerToggle'
@@ -56,7 +57,11 @@ export default class TaskMap extends Component {
 
     if (_get(nextProps, 'task.geometries') !==
         _get(this.props, 'task.geometries')) {
-      return true
+      // Do a deep comparison to make sure geometries really changed
+      if (!_isEqual(_get(nextProps, 'task.geometries'),
+                    _get(this.props, 'task.geometries'))) {
+        return true
+      }
     }
 
     return false
@@ -89,12 +94,12 @@ export default class TaskMap extends Component {
         <LayerToggle showTaskFeatures={this.state.showTaskFeatures}
                      toggleTaskFeatures={this.toggleTaskFeatureVisibility}
                      {...this.props} />
-        <EnhancedMap key={this.props.task.id}
-                     center={this.props.centerPoint} zoom={zoom} zoomControl={false}
+        <EnhancedMap center={this.props.centerPoint} zoom={zoom} zoomControl={false}
                      minZoom={minZoom} maxZoom={maxZoom}
                      features={_get(this.props.task, 'geometries.features')}
                      justFitFeatures={!this.state.showTaskFeatures}
                      fitFeaturesOnlyOnce
+                     animateFeatures
                      onBoundsChange={this.updateTaskBounds}
         >
           <ZoomControl position='topright' />

--- a/src/components/TaskPane/TaskMap/__snapshots__/TaskMap.test.js.snap
+++ b/src/components/TaskPane/TaskMap/__snapshots__/TaskMap.test.js.snap
@@ -64,6 +64,7 @@ ShallowWrapper {
           toggleTaskFeatures={[Function]}
 />,
         <EnhancedMap
+          animateFeatures={true}
           center={
                     Object {
                               "lat": 0,
@@ -142,9 +143,10 @@ ShallowWrapper {
       },
       Object {
         "instance": null,
-        "key": "2",
+        "key": undefined,
         "nodeType": "class",
         "props": Object {
+          "animateFeatures": true,
           "center": Object {
             "lat": 0,
             "lng": 0,
@@ -265,6 +267,7 @@ ShallowWrapper {
             toggleTaskFeatures={[Function]}
 />,
           <EnhancedMap
+            animateFeatures={true}
             center={
                         Object {
                                     "lat": 0,
@@ -343,9 +346,10 @@ ShallowWrapper {
         },
         Object {
           "instance": null,
-          "key": "2",
+          "key": undefined,
           "nodeType": "class",
           "props": Object {
+            "animateFeatures": true,
             "center": Object {
               "lat": 0,
               "lng": 0,

--- a/src/components/TaskPane/TaskPane.js
+++ b/src/components/TaskPane/TaskPane.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { CSSTransition } from 'react-transition-group'
 import MediaQuery from 'react-responsive'
 import _isFinite from 'lodash/isFinite'
 import _get from 'lodash/get'
@@ -78,14 +77,9 @@ export class TaskPane extends Component {
                               {..._omit(this.props, 'completeTask')} />
         </MediaQuery>
         <MapPane completingTask={this.state.completingTask}>
-          <CSSTransition key={this.props.task.id} timeout={{exit: 300, enter: 1500}}
-                         classNames="animate-slide"
-                         in={this.state.completingTask !== this.props.task.id}
-                         onExited={this.clearCompletingTask}>
-            <DetailMap task={this.props.task}
-                       challenge={this.props.task.parent}
-                       {...this.props} />
-          </CSSTransition>
+          <DetailMap task={this.props.task}
+                     challenge={this.props.task.parent}
+                     {...this.props} />
         </MapPane>
         <MediaQuery query="(max-width: 1023px)">
           <MobileTabBar {...this.props} />


### PR DESCRIPTION
Reuse task completion map across tasks when completing a challenge. To
prevent potential confusion when a user moves to a new task within the
same geographic area that results in very little change to the map,
animate rendering of the task paths and markers to provide a visual cue
that a new task has been rendered on the map.