### PR TITLE
Role check for admin task-map popup edit link.

### DIFF
--- a/src/components/AdminPane/Manage/ChallengeTaskMap/ChallengeTaskMap.js
+++ b/src/components/AdminPane/Manage/ChallengeTaskMap/ChallengeTaskMap.js
@@ -20,6 +20,7 @@ import { messagesByStatus }
 import { MAPBOX_LIGHT,
          OPEN_STREET_MAP }
        from '../../../../services/VisibleLayer/LayerSources'
+import AsManager from '../../../../interactions/User/AsManager'
 import EnhancedMap from '../../../EnhancedMap/EnhancedMap'
 import SourcedTileLayer from '../../../EnhancedMap/SourcedTileLayer/SourcedTileLayer'
 import LayerToggle from '../../../EnhancedMap/LayerToggle/LayerToggle'
@@ -154,6 +155,8 @@ export class ChallengeTaskMap extends Component {
    * Invoked to request popup content when a task marker on the map is clicked
    */
   popupContent = marker => {
+    const manager = AsManager(this.props.user)
+
     const taskBaseRoute =
       `/admin/project/${this.props.challenge.parent.id}` +
       `/challenge/${this.props.challenge.id}/task/${marker.options.taskId}`
@@ -174,11 +177,13 @@ export class ChallengeTaskMap extends Component {
             </a>
           </div>
 
-          <div>
-            <a onClick={() => this.props.history.push(`${taskBaseRoute}/edit`)}>
-              {this.props.intl.formatMessage(messages.editTaskLabel)}
-            </a>
-          </div>
+          {manager.canWriteProject(this.props.challenge.parent) &&
+           <div>
+             <a onClick={() => this.props.history.push(`${taskBaseRoute}/edit`)}>
+               {this.props.intl.formatMessage(messages.editTaskLabel)}
+             </a>
+           </div>
+          }
         </div>
       </div>
     )

--- a/src/interactions/User/AsManager.js
+++ b/src/interactions/User/AsManager.js
@@ -26,7 +26,7 @@ export class AsManager extends AsEndUser {
   }
 
   /**
-   * Returns the user's group types (permissions) for the given project.
+   * Returns the user's group types (roles) for the given project.
    */
   projectGroupTypes(project) {
     return _map(
@@ -63,7 +63,7 @@ export class AsManager extends AsEndUser {
    * is considered to have read access if any of the following are true:
    * - They are a superuser
    * - They are the project owner
-   * - They posesss any of the project's group types (read, write, or admin).
+   * - They possess any of the project's group types (read, write, or admin).
    *
    * @returns true if the user has read access, false otherwise.
    */
@@ -101,7 +101,7 @@ export class AsManager extends AsEndUser {
    * a project administrator if any of the following are true:
    * - They are a superuser
    * - They are the project owner
-   * - They posesss the project's admin group
+   * - They possess the project's admin group
    *
    * @returns true if the user can administrate the project, false otherwise.
    */
@@ -110,8 +110,7 @@ export class AsManager extends AsEndUser {
   }
 
   /**
-   * Determines if the given user has permissions to manage the given
-   * challenge.
+   * Determines if the given user has permission to manage the given challenge.
    *
    * > Note that if challenge is not denormalized with a parent object field,
    * > this method will return false.


### PR DESCRIPTION
Don't show Edit Task link on admin task-map popups to project managers
who don't have Write access to the project.