### PR TITLE
Finish-early option when editing challenge.

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
@@ -105,6 +105,8 @@ export class EditChallenge extends Component {
     isSaving: false,
   }
 
+  isFinishing = false
+
   /**
    * Returns true if this challenge's data is being cloned from another
    * challenge.
@@ -192,6 +194,7 @@ export class EditChallenge extends Component {
           `/admin/project/${challenge.parent}/challenge/${challenge.id}`)
       }
       else {
+        this.finishing = false
         this.setState({isSaving: false})
       }
     })
@@ -412,11 +415,13 @@ export class EditChallenge extends Component {
                   formData={challengeData}
                   formContext={this.state.formContext}
                   onChange={this.changeHandler}
-                  onSubmit={this.nextStep}
-                  onError={this.errorHandler}>
-
+                  onSubmit={() => this.isFinishing ? this.finish() : this.nextStep()}
+                  onError={this.errorHandler}
+            >
               <StepNavigation steps={challengeSteps} activeStep={this.state.activeStep}
-                              prevStep={this.prevStep} cancel={this.cancel} />
+                              prevStep={this.prevStep} cancel={this.cancel}
+                              finish={() => this.isFinishing = true}
+                              canFinishEarly={!AsEditableChallenge(challengeData).isNew()} />
             </Form>
           </div>
         </div>

--- a/src/components/AdminPane/Manage/StepNavigation/StepNavigation.js
+++ b/src/components/AdminPane/Manage/StepNavigation/StepNavigation.js
@@ -37,9 +37,11 @@ export default class StepNavigation extends Component {
             </button>
           }
 
-          {this.props.activeStep === this.props.steps.length - 1 &&
+          {(this.props.activeStep === this.props.steps.length - 1 ||
+            this.props.canFinishEarly) &&
             <button type="submit"
-                    className="button is-primary is-outlined has-svg-icon">
+                    className="button is-green is-outlined has-svg-icon"
+                    onClick={() => this.props.finish && this.props.finish()}>
               <SvgSymbol viewBox='0 0 20 20' sym="check-icon" />
               <FormattedMessage {...messages.finish} />
             </button>
@@ -59,9 +61,14 @@ StepNavigation.propTypes = {
   prevStep: PropTypes.func.isRequired,
   /** Invoked when the user clicks the cancel button */
   cancel: PropTypes.func.isRequired,
+  /** Invoked, if provided, when user finishes workflow */
+  finish: PropTypes.func,
+  /** Set to true to allow users to finish the workflow early */
+  canFinishEarly: PropTypes.bool,
 }
 
 StepNavigation.defaultProps = {
   steps: [],
   activeStep: 0,
+  canFinishEarly: false,
 }


### PR DESCRIPTION
Offer finish option at each step when editing an existing challenge so
that challenge owners don't have to unnecessarily click through each
step in the workflow simply to finish it.