### PR TITLE
Jump to desired step when editing challenge.

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
@@ -183,6 +183,18 @@ export class EditChallenge extends Component {
     }
   }
 
+  /** Jump to the given step number */
+  jumpToStep = stepNumber => {
+    if (stepNumber !== this.state.activeStep &&
+        stepNumber >= 0 && stepNumber < challengeSteps.length) {
+      this.setState({
+        activeStep: stepNumber,
+        formContext: {},
+      })
+      window.scrollTo(0, 0)
+    }
+  }
+
   /** Complete the workflow, saving the challenge data */
   finish = () => {
     const formData = this.prepareFormDataForSaving()
@@ -403,7 +415,9 @@ export class EditChallenge extends Component {
               </nav>
             </div>
 
-            <Steps steps={challengeSteps} activeStep={this.state.activeStep} />
+            <Steps steps={challengeSteps} activeStep={this.state.activeStep}
+                   onStepClick={AsEditableChallenge(challengeData).isNew() ? undefined : this.jumpToStep}
+            />
             <Form schema={currentStep.jsSchema(this.props.intl, this.props.user, challengeData)}
                   validate={this.additionalValidation}
                   uiSchema={currentStep.uiSchema(this.props.intl, this.props.user, challengeData)}

--- a/src/components/Bulma/Steps.js
+++ b/src/components/Bulma/Steps.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import _map from 'lodash/map'
 import _isString from 'lodash/isString'
+import './Steps.css'
 
 /**
- * Steps renders a Bulma Steps (extension) component with the given steps.  It
+ * Steps renders a Bulma Steps (extension) component with the given steps. It
  * numbers the steps from 1 based off the index of each step. An optional name
  * can be given for each step, in which case it'll be displayed as well.
  *
@@ -17,9 +18,12 @@ export default class Steps extends Component {
   render() {
     const steps = _map(this.props.steps, (step, index) => (
       <li key={`step-${index}`}
-          className={classNames('steps-segment',
-                                {'is-active': this.props.activeStep === index})}>
-        <span className="steps-marker" />
+          className={classNames("steps-segment",
+                                {"is-active": this.props.activeStep === index})}
+          onClick={() => this.props.onStepClick && this.props.onStepClick(index)}
+      >
+        <span className={classNames("steps-marker",
+                                    {clickable: !!this.props.onStepClick})} />
         <div className="steps-content">
           {_isString(step.name) && <p className="is-size-6">{step.name}</p>}
         </div>
@@ -37,6 +41,8 @@ Steps.propTypes = {
   })).isRequired,
   /** The (zero-based) index of the currently active step. */
   activeStep: PropTypes.number,
+  /** Invoked on step click, passing the step number */
+  onStepClick: PropTypes.func,
 }
 
 Steps.defaultProps = {

--- a/src/components/Bulma/Steps.scss
+++ b/src/components/Bulma/Steps.scss
@@ -1,0 +1,13 @@
+@import 'variables.scss';
+
+.steps:not(.is-hollow) {
+  .steps-segment {
+    .steps-marker.clickable:not(.is-hollow) {
+      &:hover {
+        cursor: pointer;
+        box-shadow: 0px 2px 6px 0px $box-shadow-color;
+        transition: box-shadow .25s ease-in-out;
+      }
+    } 
+  }
+}


### PR DESCRIPTION
Allow challenge owners to jump to desired workflow step when editing an
existing challenge by clicking on step markers.