### PR TITLE
Option to ignore errors in challenge source data

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
@@ -148,6 +148,12 @@ export class EditChallenge extends Component {
    * we check Overpass queries and GeoJSON.
    */
   additionalValidation = (formData, errors) => {
+    // Skip additional source data validation if user has indicated they wish
+    // to ignore source errors.
+    if (formData.ignoreSourceErrors) {
+      return errors
+    }
+
     if (!_isEmpty(formData.overpassQL)) {
       this.validateOverpass(formData.overpassQL, errors)
     }
@@ -301,6 +307,9 @@ export class EditChallenge extends Component {
       this.prepareChallengeDataForForm(this.props.challenge),
       this.state.formData,
     ))
+
+    // Remove control fields that do not represent data
+    delete challengeData.ignoreSourceErrors
 
     // Parent field should just be id, not object.
     if (_isObject(challengeData.parent)) {

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
@@ -280,6 +280,18 @@ will not be able to make sense of it.
     defaultMessage: "https://www.example.com/geojson.json",
   },
 
+  ignoreSourceErrorsLabel: {
+    id: 'Admin.EditChallenge.form.ignoreSourceErrors.label',
+    defaultMessage: "Ignore Errors",
+  },
+
+  ignoreSourceErrorsDescription: {
+    id: 'Admin.EditChallenge.form.ignoreSourceErrors.description',
+    defaultMessage: "Proceed despite detected errors in source data. " +
+      "Only expert users who fully understand the implications should " +
+      "attempt this.",
+  },
+
   step3Label: {
     id: 'Admin.EditChallenge.form.step3.label',
     defaultMessage: "Priorities",

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step2Schema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step2Schema.js
@@ -65,7 +65,7 @@ export const jsSchema = (intl, user, challengeData) => {
   }
 
   if (!sourceReadOnly) {
-    schema.properties.source= {
+    schema.properties.source = {
       title: intl.formatMessage(messages.sourceLabel),
       type: "string",
       enum: [
@@ -75,6 +75,14 @@ export const jsSchema = (intl, user, challengeData) => {
       ],
       default: "Overpass Query",
     }
+
+    schema.properties.ignoreSourceErrors = {
+      title: intl.formatMessage(messages.ignoreSourceErrorsLabel),
+      description: intl.formatMessage(messages.ignoreSourceErrorsDescription),
+      type: "boolean",
+      default: false,
+    }
+
     schema.dependencies = {
       source: {
         oneOf: [
@@ -128,5 +136,9 @@ export const uiSchema = (intl, user, challengeData) => {
       "ui:placeholder": intl.formatMessage(messages.remoteGeoJsonPlaceholder),
       "ui:readonly": sourceReadOnly,
     },
+    ignoreSourceErrors: {
+      "ui:widget": "radio",
+    },
+    "ui:order": sourceReadOnly ? undefined : [ "*", "ignoreSourceErrors" ],
   }
 }

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -71,6 +71,8 @@
   "Admin.EditChallenge.form.remoteGeoJson.label": "Remote URL",
   "Admin.EditChallenge.form.remoteGeoJson.description": "Remote URL location from which to retrieve the GeoJSON",
   "Admin.EditChallenge.form.remoteGeoJson.placeholder": "https://www.example.com/geojson.json",
+  "Admin.EditChallenge.form.ignoreSourceErrors.label": "Ignore Errors",
+  "Admin.EditChallenge.form.ignoreSourceErrors.description": "Proceed despite detected errors in source data. Only expert users who fully understand the implications should attempt this.",
   "Admin.EditChallenge.form.step3.label": "Priorities",
   "Admin.EditChallenge.form.step3.description": "The priority of tasks can be defined as High, Medium and Low. All high priority tasks will be shown first, then medium and finally low.",
   "Admin.EditChallenge.form.defaultPriority.label": "Default Priority",


### PR DESCRIPTION
Add an option to ignore detected errors in source data (such as a local
GeoJSON file) when creating a new challenge. Some of the validation can
be rather strict, and this provides the ability for advanced users to
proceed anyway.