### PR TITLE
Allow source edit on failed challenge. Fixes #436

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
@@ -248,7 +248,7 @@ export class EditChallenge extends Component {
   prepareChallengeDataForForm = () => {
     let challengeData = Object.assign(
       {parent: _get(this.props, 'project.id')},
-      _omit(this.props.challenge, ['actions', 'activity', 'comments']),
+      _omit(this.props.challenge, ['activity', 'comments']),
       this.state.formData
     )
 
@@ -308,7 +308,8 @@ export class EditChallenge extends Component {
       this.state.formData,
     ))
 
-    // Remove control fields that do not represent data
+    // Remove extraneous fields that should not be saved.
+    delete challengeData.actions
     delete challengeData.ignoreSourceErrors
 
     // Parent field should just be id, not object.

--- a/src/interactions/Challenge/AsEditableChallenge.js
+++ b/src/interactions/Challenge/AsEditableChallenge.js
@@ -20,19 +20,16 @@ export class AsEditableChallenge {
   }
 
   /**
-   * Returns true if the challenge is determined to have zero tasks. Note that
-   * this will return false if the number of tasks cannot be determined, so
-   * false does not necessarily mean the challenge has tasks.
+   * Returns true if the challenge is determined to have zero tasks.
    */
   hasZeroTasks() {
-    return _get(this, 'actions.total') === 0
+    return _get(this, 'actions.total', 0) === 0
   }
 
   /**
    * Returns true if the source (overpass, local GeoJSON, remote URL) should be
    * treated as read-only. This will return true for existing challenges that
-   * do not have zero tasks. Note that if the number of tasks cannot be
-   * determined, this will return true.
+   * do not have zero tasks.
    */
   isSourceReadOnly() {
     return !this.isNew() && !this.hasZeroTasks()

--- a/src/interactions/Challenge/AsEditableChallenge.test.js
+++ b/src/interactions/Challenge/AsEditableChallenge.test.js
@@ -23,11 +23,6 @@ describe("isNew", () => {
 })
 
 describe("hasZeroTasks", () => {
-  test("returns false if the challenge actions haven't been loaded", () => {
-    const wrappedChallenge = AsEditableChallenge(challenge)
-    expect(wrappedChallenge.hasZeroTasks()).toBe(false)
-  })
-
   test("returns false if the challenge actions total is non-zero", () => {
     challenge.actions = {total: 1}
 
@@ -41,6 +36,11 @@ describe("hasZeroTasks", () => {
     const wrappedChallenge = AsEditableChallenge(challenge)
     expect(wrappedChallenge.hasZeroTasks()).toBe(true)
   })
+
+  test("returns true if there are no actions", () => {
+    const wrappedChallenge = AsEditableChallenge(challenge)
+    expect(wrappedChallenge.hasZeroTasks()).toBe(true)
+  })
 })
 
 describe("isSourceReadOnly", () => {
@@ -51,11 +51,6 @@ describe("isSourceReadOnly", () => {
     expect(wrappedChallenge.isSourceReadOnly()).toBe(false)
   })
 
-  test("returns true for an existing challenge if the actions haven't been loaded", () => {
-    const wrappedChallenge = AsEditableChallenge(challenge)
-    expect(wrappedChallenge.isSourceReadOnly()).toBe(true)
-  })
-
   test("returns true for an existing challenge with actions total of at least 1", () => {
     challenge.actions = {total: 1}
     const wrappedChallenge = AsEditableChallenge(challenge)
@@ -64,6 +59,11 @@ describe("isSourceReadOnly", () => {
 
   test("returns false for an existing challenge with actions total of 0", () => {
     challenge.actions = {total: 0}
+    const wrappedChallenge = AsEditableChallenge(challenge)
+    expect(wrappedChallenge.isSourceReadOnly()).toBe(false)
+  })
+
+  test("returns false if there are no actions", () => {
     const wrappedChallenge = AsEditableChallenge(challenge)
     expect(wrappedChallenge.isSourceReadOnly()).toBe(false)
   })


### PR DESCRIPTION
If a new challenge fails to build and generates no tasks, allow the
source (such as Overpass query) to be edited and fixed.