### PR TITLE
Add help link to top nav. Closes #72

### DIFF
--- a/src/components/Navbar/Messages.js
+++ b/src/components/Navbar/Messages.js
@@ -24,6 +24,11 @@ export default defineMessages({
     defaultMessage: "Create",
   },
 
+  help: {
+    id: 'Navbar.links.help',
+    defaultMessage: "Help",
+  },
+
   profile: {
     id: 'Navbar.links.mobile.userProfile',
     defaultMessage: "User Profile",

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -153,6 +153,16 @@ const NavbarPrimaryLinks = function(props) {
           </span>
         </Link>
       }
+
+      <a href="https://github.com/osmlab/maproulette3/wiki/Help-and-Resources"
+         className="navbar-item top-nav__help-link"
+         target="_blank"
+         rel="noopener noreferrer"
+         onClick={props.onLinkClick}>
+        <span className='item-text'>
+          <FormattedMessage {...messages.help} />
+        </span>
+      </a>
     </React.Fragment>
   )
 }

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -250,6 +250,7 @@
   "Navbar.links.challengeResults": "Challenges",
   "Navbar.links.leaderboard": "Leaderboard",
   "Navbar.links.admin": "Create",
+  "Navbar.links.help": "Help",
   "Navbar.links.mobile.userProfile": "User Profile",
   "Navbar.mobile.links.signout": "Sign out",
   "PageNotFound.message": "Sorry, nothing here but open ocean.",


### PR DESCRIPTION
Add a help link to the top nav. This link temporarily points to the [Help-and-Resources](https://github.com/osmlab/maproulette3/wiki/Help-and-Resources) wiki page until we integrate more comprehensive user documentation.