### PR TITLE
Show long y-axis burndown chart labels. Fixes #448

### DIFF
--- a/src/components/AdminPane/Manage/BurndownChart/BurndownChart.js
+++ b/src/components/AdminPane/Manage/BurndownChart/BurndownChart.js
@@ -71,7 +71,7 @@ export class BurndownChart extends Component {
                           top: 20,
                           right: 20,
                           bottom: 85,
-                          left: 50
+                          left: 63,
                         }}
                         minY={0}
                         lineWidth={0}


### PR DESCRIPTION
Ensure most significant digits on y-axis burndown chart labels aren't
cut off for larger values.