### PR TITLE
Support mustache tags in instructions. Closes #456

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
@@ -93,7 +93,10 @@ export default defineMessages({
       "a task is loaded, and is the primary piece of information for the mapper " +
       "about how to solve the task, so think about this field carefully. You can " +
       "include links to the OSM wiki or any other hyperlink if you want, because " +
-      "this field supports Markdown. This field is required.",
+      "this field supports Markdown. You can also reference feature properties " +
+      "from your GeoJSON with simple mustache tags: e.g. `\\{\\{address\\}\\}` would be " +
+      "replaced with the value of the `address` property, allowing for basic " +
+      "customization of instructions for each task. This field is required.",
   },
 
   checkinCommentLabel: {

--- a/src/components/TaskPane/TaskInstructions/TaskInstructions.js
+++ b/src/components/TaskPane/TaskInstructions/TaskInstructions.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import _get from 'lodash/get'
+import _keys from 'lodash/keys'
 import _isEmpty from 'lodash/isEmpty'
+import AsMappableTask from '../../../interactions/Task/AsMappableTask'
 import MarkdownContent from '../../MarkdownContent/MarkdownContent'
 
 /**
@@ -12,6 +14,24 @@ import MarkdownContent from '../../MarkdownContent/MarkdownContent'
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default class TaskInstructions extends Component {
+  /**
+   * Very basic mustache-tag replacement. The results need to be escaped, e.g.
+   * via MarkdownContent component.
+   */
+  substitutePropertyTags(instructions) {
+    if (!/{{/.test(instructions)) { // no tags present
+      return instructions
+    }
+
+    const properties = AsMappableTask(this.props.task).allFeatureProperties()
+    let substituted = instructions
+    _keys(properties).forEach(key => {
+      substituted = substituted.replace(RegExp(`{{\\s*${key}\\s*}}`, "g"), properties[key])
+    })
+
+    return substituted
+  }
+
   render() {
     const taskInstructions = !_isEmpty(this.props.task.instruction) ?
                              this.props.task.instruction :
@@ -21,7 +41,7 @@ export default class TaskInstructions extends Component {
       return null
     }
 
-    return <MarkdownContent markdown={taskInstructions} />
+    return <MarkdownContent markdown={this.substitutePropertyTags(taskInstructions)} />
   }
 }
 

--- a/src/interactions/Task/AsMappableTask.js
+++ b/src/interactions/Task/AsMappableTask.js
@@ -14,6 +14,10 @@ export class AsMappableTask {
     Object.assign(this, task)
   }
 
+  /**
+   * Determines if this task contains geometries with features and returns
+   * true if so, false if not.
+   */
   hasGeometries() {
     if (!_isObject(this.geometries)) {
       return false
@@ -29,6 +33,32 @@ export class AsMappableTask {
     return true
   }
 
+  /**
+   * Generates a single object containing all feature properties found in the
+   * task's geometries. Later properties will overwrite earlier properties with
+   * the same name.
+   */
+  allFeatureProperties() {
+    if (!this.hasGeometries()) {
+      return []
+    }
+
+    let allProperties = {}
+
+    this.geometries.features.forEach(feature => {
+      if (feature && feature.properties) {
+        allProperties = Object.assign(allProperties, feature.properties)
+      }
+    })
+
+    return allProperties
+  }
+
+  /**
+   * Returns the task centerpoint as a leaflet LatLng object, calculating it if
+   * necessary (and possible). If the centerpoint can't be determined it will
+   * default to (0, 0).
+   */
   calculateCenterPoint() {
     let centerPoint = _get(this, 'location.coordinates')
 
@@ -48,6 +78,9 @@ export class AsMappableTask {
     return latLng(centerPoint[1], centerPoint[0])
   }
 
+  /**
+   * Calculates and returns the bounding box of the task.
+   */
   calculateBBox() {
     if (this.hasGeometries()) {
       return bbox(this.geometries)

--- a/src/interactions/Task/AsMappableTask.test.js
+++ b/src/interactions/Task/AsMappableTask.test.js
@@ -35,6 +35,44 @@ describe("hasGeometries", () => {
   })
 })
 
+describe("allFeatureProperties", () => {
+  test("returns empty array if there are no features", () => {
+    task.geometries = {"type": "FeatureCollection", features: null}
+    const wrappedTask = AsMappableTask(task)
+
+    expect(wrappedTask.allFeatureProperties()).toHaveLength(0)
+  })
+
+  test("returns an object containing the task's feature properties", () => {
+    task.geometries = {"type": "FeatureCollection", features: [{
+      properties: {
+        foo: "abc",
+        bar: "def",
+      },
+    }, {
+      properties: {
+        baz: "ghi",
+      }
+    }]}
+
+    const wrappedTask = AsMappableTask(task)
+    expect(wrappedTask.allFeatureProperties()).toEqual({
+      foo: "abc",
+      bar: "def",
+      baz: "ghi",
+    })
+  })
+
+  test("later feature properties overwrite earlier ones with same name", () => {
+    task.geometries = {"type": "FeatureCollection", features: [
+      { properties: { foo: "abc" } }, { properties: { foo: "xyz" } }
+    ]}
+
+    const wrappedTask = AsMappableTask(task)
+    expect(wrappedTask.allFeatureProperties()).toEqual({ foo: "xyz" })
+  })
+})
+
 describe("calculateCenterPoint()", () => {
   test("the task's location is returned as (Lat,Lng)", () => {
     task.location = {

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -44,7 +44,7 @@
   "Admin.EditChallenge.form.blurb.label": "Blurb",
   "Admin.EditChallenge.form.blurb.description": "A very brief description of your challenge suitable for small spaces, such as a map marker popup. This field supports Markdown.",
   "Admin.EditChallenge.form.instruction.label": "Instructions",
-  "Admin.EditChallenge.form.instruction.description": "The instruction tells a mapper how to resolve a Task in your Challenge. This is what mappers see in the Instructions box every time a task is loaded, and is the primary piece of information for the mapper about how to solve the task, so think about this field carefully. You can include links to the OSM wiki or any other hyperlink if you want, because this field supports Markdown. This field is required.",
+  "Admin.EditChallenge.form.instruction.description": "The instruction tells a mapper how to resolve a Task in your Challenge. This is what mappers see in the Instructions box every time a task is loaded, and is the primary piece of information for the mapper about how to solve the task, so think about this field carefully. You can include links to the OSM wiki or any other hyperlink if you want, because this field supports Markdown. You can also reference feature properties from your GeoJSON with simple mustache tags: e.g. `\\{\\{address\\}\\}` would be replaced with the value of the `address` property, allowing for basic customization of instructions for each task. This field is required.",
   "Admin.EditChallenge.form.checkinComment.label": "Changeset Description",
   "Admin.EditChallenge.form.checkinComment.description": "Comment to be associated with changes made by users in editor",
   "Admin.EditChallenge.form.checkinSource.label": "Changeset Source",


### PR DESCRIPTION
Support basic customization of instructions on a per-task basis through the use of mustache tags in the challenge instructions that will be substituted with matching feature properties on the task. For example, an `{{address}}` tag would replaced with the value of the `address` property from the task features. Only basic tag substitution is supported.