### PR TITLE
Offer skip-task option after editing. Closes #469

### DIFF
--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep1/__snapshots__/TaskCompletionStep1.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep1/__snapshots__/TaskCompletionStep1.test.js.snap
@@ -1096,6 +1096,7 @@ ShallowWrapper {
                             }
           }
           pickEditor={[Function]}
+          suppressIcon={false}
           task={
                     Object {
                               "id": 123,
@@ -1493,6 +1494,7 @@ ShallowWrapper {
             },
           },
           "pickEditor": [Function],
+          "suppressIcon": false,
           "task": Object {
             "id": 123,
             "parent": Object {
@@ -1907,6 +1909,7 @@ ShallowWrapper {
                                   }
             }
             pickEditor={[Function]}
+            suppressIcon={false}
             task={
                         Object {
                                     "id": 123,
@@ -2304,6 +2307,7 @@ ShallowWrapper {
               },
             },
             "pickEditor": [Function],
+            "suppressIcon": false,
             "task": Object {
               "id": 123,
               "parent": Object {
@@ -2872,6 +2876,7 @@ ShallowWrapper {
                             }
           }
           pickEditor={[Function]}
+          suppressIcon={false}
           task={
                     Object {
                               "id": 123,
@@ -3269,6 +3274,7 @@ ShallowWrapper {
             },
           },
           "pickEditor": [Function],
+          "suppressIcon": false,
           "task": Object {
             "id": 123,
             "parent": Object {
@@ -3683,6 +3689,7 @@ ShallowWrapper {
                                   }
             }
             pickEditor={[Function]}
+            suppressIcon={false}
             task={
                         Object {
                                     "id": 123,
@@ -4080,6 +4087,7 @@ ShallowWrapper {
               },
             },
             "pickEditor": [Function],
+            "suppressIcon": false,
             "task": Object {
               "id": 123,
               "parent": Object {
@@ -4648,6 +4656,7 @@ ShallowWrapper {
                             }
           }
           pickEditor={[Function]}
+          suppressIcon={false}
           task={
                     Object {
                               "id": 123,
@@ -5045,6 +5054,7 @@ ShallowWrapper {
             },
           },
           "pickEditor": [Function],
+          "suppressIcon": false,
           "task": Object {
             "id": 123,
             "parent": Object {
@@ -5459,6 +5469,7 @@ ShallowWrapper {
                                   }
             }
             pickEditor={[Function]}
+            suppressIcon={false}
             task={
                         Object {
                                     "id": 123,
@@ -5856,6 +5867,7 @@ ShallowWrapper {
               },
             },
             "pickEditor": [Function],
+            "suppressIcon": false,
             "task": Object {
               "id": 123,
               "parent": Object {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep2/TaskCompletionStep2.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep2/TaskCompletionStep2.js
@@ -4,6 +4,7 @@ import { TaskStatus } from '../../../../../services/Task/TaskStatus/TaskStatus'
 import TaskFixedControl from '../TaskFixedControl/TaskFixedControl'
 import TaskTooHardControl from '../TaskTooHardControl/TaskTooHardControl'
 import TaskAlreadyFixedControl from '../TaskAlreadyFixedControl/TaskAlreadyFixedControl'
+import TaskSkipControl from '../TaskSkipControl/TaskSkipControl'
 import TaskCancelEditingControl from '../TaskCancelEditingControl/TaskCancelEditingControl'
 import './TaskCompletionStep2.css'
 
@@ -29,6 +30,10 @@ export default class TaskCompletionStep2 extends Component {
 
         {this.props.allowedProgressions.has(TaskStatus.alreadyFixed) &&
           <TaskAlreadyFixedControl {...this.props} />
+        }
+
+        {this.props.allowedProgressions.has(TaskStatus.skipped) &&
+          <TaskSkipControl {...this.props} suppressIcon />
         }
 
         <TaskCancelEditingControl {...this.props} />

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep2/TaskCompletionStep2.test.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep2/TaskCompletionStep2.test.js
@@ -121,3 +121,27 @@ test("shows cancel editing control", () => {
 
   expect(wrapper).toMatchSnapshot()
 })
+
+test("shows skip control for appropriate status", () => {
+  const wrapper = shallow(
+    <TaskCompletionStep2 {...basicProps} />
+  )
+
+  expect(wrapper.find('TaskSkipControl').exists()).toBe(true)
+
+  expect(wrapper).toMatchSnapshot()
+})
+
+test("doesn't show the skip control if status not appropriate", () => {
+  basicProps.task.status = TaskStatus.fixed
+  basicProps.allowedProgressions =
+    allowedStatusProgressions(basicProps.task.status)
+
+  const wrapper = shallow(
+    <TaskCompletionStep2 {...basicProps} />
+  )
+
+  expect(wrapper.find('TaskSkipControl').exists()).toBe(false)
+
+  expect(wrapper).toMatchSnapshot()
+})

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep2/__snapshots__/TaskCompletionStep2.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep2/__snapshots__/TaskCompletionStep2.test.js.snap
@@ -144,6 +144,7 @@ ShallowWrapper {
         false,
         false,
         false,
+        false,
         <TaskCancelEditingControl
           activateKeyboardShortcut={[Function]}
           activateKeyboardShortcutGroup={[Function]}
@@ -273,6 +274,7 @@ ShallowWrapper {
     },
     "ref": null,
     "rendered": Array [
+      false,
       false,
       false,
       false,
@@ -411,6 +413,7 @@ ShallowWrapper {
           false,
           false,
           false,
+          false,
           <TaskCancelEditingControl
             activateKeyboardShortcut={[Function]}
             activateKeyboardShortcutGroup={[Function]}
@@ -540,6 +543,7 @@ ShallowWrapper {
       },
       "ref": null,
       "rendered": Array [
+        false,
         false,
         false,
         false,
@@ -823,6 +827,7 @@ ShallowWrapper {
         false,
         false,
         false,
+        false,
         <TaskCancelEditingControl
           activateKeyboardShortcut={[Function]}
           activateKeyboardShortcutGroup={[Function]}
@@ -952,6 +957,7 @@ ShallowWrapper {
     },
     "ref": null,
     "rendered": Array [
+      false,
       false,
       false,
       false,
@@ -1090,6 +1096,7 @@ ShallowWrapper {
           false,
           false,
           false,
+          false,
           <TaskCancelEditingControl
             activateKeyboardShortcut={[Function]}
             activateKeyboardShortcutGroup={[Function]}
@@ -1219,6 +1226,690 @@ ShallowWrapper {
       },
       "ref": null,
       "rendered": Array [
+        false,
+        false,
+        false,
+        false,
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {},
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 1,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`doesn't show the skip control if status not appropriate 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <TaskCompletionStep2
+    activateKeyboardShortcut={[Function]}
+    activateKeyboardShortcutGroup={[Function]}
+    allowedProgressions={Set {}}
+    cancelEditing={[Function]}
+    comment="Foo"
+    complete={[Function]}
+    deactivateKeyboardShortcut={[Function]}
+    deactivateKeyboardShortcutGroup={[Function]}
+    intl={
+        Object {
+            "formatMessage": [Function],
+          }
+    }
+    keyboardShortcutGroups={
+        Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          }
+    }
+    mapBounds={
+        Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          }
+    }
+    task={
+        Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 1,
+          }
+    }
+    user={
+        Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          }
+    }
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        false,
+        false,
+        false,
+        false,
+        <TaskCancelEditingControl
+          activateKeyboardShortcut={[Function]}
+          activateKeyboardShortcutGroup={[Function]}
+          allowedProgressions={Set {}}
+          cancelEditing={[Function]}
+          comment="Foo"
+          complete={[Function]}
+          deactivateKeyboardShortcut={[Function]}
+          deactivateKeyboardShortcutGroup={[Function]}
+          intl={
+                    Object {
+                              "formatMessage": [Function],
+                            }
+          }
+          keyboardShortcutGroups={
+                    Object {
+                              "openEditor": Object {
+                                "editId": Object {
+                                  "key": "e",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Id",
+                                    "id": "KeyMapping.openEditor.editId",
+                                  },
+                                },
+                                "editJosm": Object {
+                                  "key": "r",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in JOSM",
+                                    "id": "KeyMapping.openEditor.editJosm",
+                                  },
+                                },
+                                "editJosmLayer": Object {
+                                  "key": "t",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in new JOSM layer",
+                                    "id": "KeyMapping.openEditor.editJosmLayer",
+                                  },
+                                },
+                                "editLevel0": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Level0",
+                                    "id": "KeyMapping.openEditor.editLevel0",
+                                  },
+                                },
+                              },
+                              "taskCompletion": Object {
+                                "falsePositive": Object {
+                                  "key": "q",
+                                  "label": Object {
+                                    "defaultMessage": "Not an Issue",
+                                    "id": "KeyMapping.taskCompletion.falsePositive",
+                                  },
+                                },
+                                "skip": Object {
+                                  "key": "w",
+                                  "label": Object {
+                                    "defaultMessage": "Skip",
+                                    "id": "KeyMapping.taskCompletion.skip",
+                                  },
+                                },
+                              },
+                              "taskEditing": Object {
+                                "cancel": Object {
+                                  "key": "Escape",
+                                  "keyLabel": Object {
+                                    "defaultMessage": "ESC",
+                                    "id": "KeyMapping.taskEditing.escapeLabel",
+                                  },
+                                  "label": Object {
+                                    "defaultMessage": "Cancel Editing",
+                                    "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                              },
+                              "taskReview": Object {
+                                "nextTask": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Next Task",
+                                    "id": "KeyMapping.taskReview.nextTask",
+                                  },
+                                },
+                                "prevTask": Object {
+                                  "key": "h",
+                                  "label": Object {
+                                    "defaultMessage": "Previous Task",
+                                    "id": "KeyMapping.taskReview.prevTask",
+                                  },
+                                },
+                              },
+                            }
+          }
+          mapBounds={
+                    Object {
+                              "task": Object {
+                                "bounds": Array [
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                ],
+                              },
+                            }
+          }
+          task={
+                    Object {
+                              "id": 123,
+                              "parent": Object {
+                                "id": 321,
+                              },
+                              "status": 1,
+                            }
+          }
+          user={
+                    Object {
+                              "id": 357,
+                              "isLoggedIn": true,
+                              "settings": Object {
+                                "defaultEditor": 1,
+                              },
+                            }
+          }
+/>,
+      ],
+      "className": "active-task-controls__step2 active-task-controls__vertical-control-block",
+    },
+    "ref": null,
+    "rendered": Array [
+      false,
+      false,
+      false,
+      false,
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {},
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 1,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          false,
+          false,
+          false,
+          false,
+          <TaskCancelEditingControl
+            activateKeyboardShortcut={[Function]}
+            activateKeyboardShortcutGroup={[Function]}
+            allowedProgressions={Set {}}
+            cancelEditing={[Function]}
+            comment="Foo"
+            complete={[Function]}
+            deactivateKeyboardShortcut={[Function]}
+            deactivateKeyboardShortcutGroup={[Function]}
+            intl={
+                        Object {
+                                    "formatMessage": [Function],
+                                  }
+            }
+            keyboardShortcutGroups={
+                        Object {
+                                    "openEditor": Object {
+                                      "editId": Object {
+                                        "key": "e",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Id",
+                                          "id": "KeyMapping.openEditor.editId",
+                                        },
+                                      },
+                                      "editJosm": Object {
+                                        "key": "r",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in JOSM",
+                                          "id": "KeyMapping.openEditor.editJosm",
+                                        },
+                                      },
+                                      "editJosmLayer": Object {
+                                        "key": "t",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in new JOSM layer",
+                                          "id": "KeyMapping.openEditor.editJosmLayer",
+                                        },
+                                      },
+                                      "editLevel0": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Level0",
+                                          "id": "KeyMapping.openEditor.editLevel0",
+                                        },
+                                      },
+                                    },
+                                    "taskCompletion": Object {
+                                      "falsePositive": Object {
+                                        "key": "q",
+                                        "label": Object {
+                                          "defaultMessage": "Not an Issue",
+                                          "id": "KeyMapping.taskCompletion.falsePositive",
+                                        },
+                                      },
+                                      "skip": Object {
+                                        "key": "w",
+                                        "label": Object {
+                                          "defaultMessage": "Skip",
+                                          "id": "KeyMapping.taskCompletion.skip",
+                                        },
+                                      },
+                                    },
+                                    "taskEditing": Object {
+                                      "cancel": Object {
+                                        "key": "Escape",
+                                        "keyLabel": Object {
+                                          "defaultMessage": "ESC",
+                                          "id": "KeyMapping.taskEditing.escapeLabel",
+                                        },
+                                        "label": Object {
+                                          "defaultMessage": "Cancel Editing",
+                                          "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                    },
+                                    "taskReview": Object {
+                                      "nextTask": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Next Task",
+                                          "id": "KeyMapping.taskReview.nextTask",
+                                        },
+                                      },
+                                      "prevTask": Object {
+                                        "key": "h",
+                                        "label": Object {
+                                          "defaultMessage": "Previous Task",
+                                          "id": "KeyMapping.taskReview.prevTask",
+                                        },
+                                      },
+                                    },
+                                  }
+            }
+            mapBounds={
+                        Object {
+                                    "task": Object {
+                                      "bounds": Array [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                      ],
+                                    },
+                                  }
+            }
+            task={
+                        Object {
+                                    "id": 123,
+                                    "parent": Object {
+                                      "id": 321,
+                                    },
+                                    "status": 1,
+                                  }
+            }
+            user={
+                        Object {
+                                    "id": 357,
+                                    "isLoggedIn": true,
+                                    "settings": Object {
+                                      "defaultEditor": 1,
+                                    },
+                                  }
+            }
+/>,
+        ],
+        "className": "active-task-controls__step2 active-task-controls__vertical-control-block",
+      },
+      "ref": null,
+      "rendered": Array [
+        false,
         false,
         false,
         false,
@@ -1502,6 +2193,7 @@ ShallowWrapper {
         false,
         false,
         false,
+        false,
         <TaskCancelEditingControl
           activateKeyboardShortcut={[Function]}
           activateKeyboardShortcutGroup={[Function]}
@@ -1631,6 +2323,7 @@ ShallowWrapper {
     },
     "ref": null,
     "rendered": Array [
+      false,
       false,
       false,
       false,
@@ -1769,6 +2462,7 @@ ShallowWrapper {
           false,
           false,
           false,
+          false,
           <TaskCancelEditingControl
             activateKeyboardShortcut={[Function]}
             activateKeyboardShortcutGroup={[Function]}
@@ -1898,6 +2592,7 @@ ShallowWrapper {
       },
       "ref": null,
       "rendered": Array [
+        false,
         false,
         false,
         false,
@@ -2586,6 +3281,141 @@ ShallowWrapper {
                             }
           }
 />,
+        <TaskSkipControl
+          activateKeyboardShortcut={[Function]}
+          activateKeyboardShortcutGroup={[Function]}
+          allowedProgressions={
+                    Set {
+                              1,
+                              2,
+                              3,
+                              4,
+                              5,
+                              6,
+                            }
+          }
+          cancelEditing={[Function]}
+          comment="Foo"
+          complete={[Function]}
+          deactivateKeyboardShortcut={[Function]}
+          deactivateKeyboardShortcutGroup={[Function]}
+          intl={
+                    Object {
+                              "formatMessage": [Function],
+                            }
+          }
+          isMinimized={false}
+          keyboardShortcutGroups={
+                    Object {
+                              "openEditor": Object {
+                                "editId": Object {
+                                  "key": "e",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Id",
+                                    "id": "KeyMapping.openEditor.editId",
+                                  },
+                                },
+                                "editJosm": Object {
+                                  "key": "r",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in JOSM",
+                                    "id": "KeyMapping.openEditor.editJosm",
+                                  },
+                                },
+                                "editJosmLayer": Object {
+                                  "key": "t",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in new JOSM layer",
+                                    "id": "KeyMapping.openEditor.editJosmLayer",
+                                  },
+                                },
+                                "editLevel0": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Level0",
+                                    "id": "KeyMapping.openEditor.editLevel0",
+                                  },
+                                },
+                              },
+                              "taskCompletion": Object {
+                                "falsePositive": Object {
+                                  "key": "q",
+                                  "label": Object {
+                                    "defaultMessage": "Not an Issue",
+                                    "id": "KeyMapping.taskCompletion.falsePositive",
+                                  },
+                                },
+                                "skip": Object {
+                                  "key": "w",
+                                  "label": Object {
+                                    "defaultMessage": "Skip",
+                                    "id": "KeyMapping.taskCompletion.skip",
+                                  },
+                                },
+                              },
+                              "taskEditing": Object {
+                                "cancel": Object {
+                                  "key": "Escape",
+                                  "keyLabel": Object {
+                                    "defaultMessage": "ESC",
+                                    "id": "KeyMapping.taskEditing.escapeLabel",
+                                  },
+                                  "label": Object {
+                                    "defaultMessage": "Cancel Editing",
+                                    "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                              },
+                              "taskReview": Object {
+                                "nextTask": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Next Task",
+                                    "id": "KeyMapping.taskReview.nextTask",
+                                  },
+                                },
+                                "prevTask": Object {
+                                  "key": "h",
+                                  "label": Object {
+                                    "defaultMessage": "Previous Task",
+                                    "id": "KeyMapping.taskReview.prevTask",
+                                  },
+                                },
+                              },
+                            }
+          }
+          mapBounds={
+                    Object {
+                              "task": Object {
+                                "bounds": Array [
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                ],
+                              },
+                            }
+          }
+          suppressIcon={true}
+          task={
+                    Object {
+                              "id": 123,
+                              "parent": Object {
+                                "id": 321,
+                              },
+                              "status": 0,
+                            }
+          }
+          user={
+                    Object {
+                              "id": 357,
+                              "isLoggedIn": true,
+                              "settings": Object {
+                                "defaultEditor": 1,
+                              },
+                            }
+          }
+/>,
         <TaskCancelEditingControl
           activateKeyboardShortcut={[Function]}
           activateKeyboardShortcutGroup={[Function]}
@@ -3092,6 +3922,137 @@ ShallowWrapper {
               ],
             },
           },
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          },
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "isMinimized": false,
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "suppressIcon": true,
           "task": Object {
             "id": 123,
             "parent": Object {
@@ -3649,6 +4610,141 @@ ShallowWrapper {
                                   }
             }
 />,
+          <TaskSkipControl
+            activateKeyboardShortcut={[Function]}
+            activateKeyboardShortcutGroup={[Function]}
+            allowedProgressions={
+                        Set {
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                  }
+            }
+            cancelEditing={[Function]}
+            comment="Foo"
+            complete={[Function]}
+            deactivateKeyboardShortcut={[Function]}
+            deactivateKeyboardShortcutGroup={[Function]}
+            intl={
+                        Object {
+                                    "formatMessage": [Function],
+                                  }
+            }
+            isMinimized={false}
+            keyboardShortcutGroups={
+                        Object {
+                                    "openEditor": Object {
+                                      "editId": Object {
+                                        "key": "e",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Id",
+                                          "id": "KeyMapping.openEditor.editId",
+                                        },
+                                      },
+                                      "editJosm": Object {
+                                        "key": "r",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in JOSM",
+                                          "id": "KeyMapping.openEditor.editJosm",
+                                        },
+                                      },
+                                      "editJosmLayer": Object {
+                                        "key": "t",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in new JOSM layer",
+                                          "id": "KeyMapping.openEditor.editJosmLayer",
+                                        },
+                                      },
+                                      "editLevel0": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Level0",
+                                          "id": "KeyMapping.openEditor.editLevel0",
+                                        },
+                                      },
+                                    },
+                                    "taskCompletion": Object {
+                                      "falsePositive": Object {
+                                        "key": "q",
+                                        "label": Object {
+                                          "defaultMessage": "Not an Issue",
+                                          "id": "KeyMapping.taskCompletion.falsePositive",
+                                        },
+                                      },
+                                      "skip": Object {
+                                        "key": "w",
+                                        "label": Object {
+                                          "defaultMessage": "Skip",
+                                          "id": "KeyMapping.taskCompletion.skip",
+                                        },
+                                      },
+                                    },
+                                    "taskEditing": Object {
+                                      "cancel": Object {
+                                        "key": "Escape",
+                                        "keyLabel": Object {
+                                          "defaultMessage": "ESC",
+                                          "id": "KeyMapping.taskEditing.escapeLabel",
+                                        },
+                                        "label": Object {
+                                          "defaultMessage": "Cancel Editing",
+                                          "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                    },
+                                    "taskReview": Object {
+                                      "nextTask": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Next Task",
+                                          "id": "KeyMapping.taskReview.nextTask",
+                                        },
+                                      },
+                                      "prevTask": Object {
+                                        "key": "h",
+                                        "label": Object {
+                                          "defaultMessage": "Previous Task",
+                                          "id": "KeyMapping.taskReview.prevTask",
+                                        },
+                                      },
+                                    },
+                                  }
+            }
+            mapBounds={
+                        Object {
+                                    "task": Object {
+                                      "bounds": Array [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                      ],
+                                    },
+                                  }
+            }
+            suppressIcon={true}
+            task={
+                        Object {
+                                    "id": 123,
+                                    "parent": Object {
+                                      "id": 321,
+                                    },
+                                    "status": 0,
+                                  }
+            }
+            user={
+                        Object {
+                                    "id": 357,
+                                    "isLoggedIn": true,
+                                    "settings": Object {
+                                      "defaultEditor": 1,
+                                    },
+                                  }
+            }
+/>,
           <TaskCancelEditingControl
             activateKeyboardShortcut={[Function]}
             activateKeyboardShortcutGroup={[Function]}
@@ -4155,6 +5251,137 @@ ShallowWrapper {
                 ],
               },
             },
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 0,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+            },
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "isMinimized": false,
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "suppressIcon": true,
             "task": Object {
               "id": 123,
               "parent": Object {
@@ -4866,6 +6093,141 @@ ShallowWrapper {
                             }
           }
 />,
+        <TaskSkipControl
+          activateKeyboardShortcut={[Function]}
+          activateKeyboardShortcutGroup={[Function]}
+          allowedProgressions={
+                    Set {
+                              1,
+                              2,
+                              3,
+                              4,
+                              5,
+                              6,
+                            }
+          }
+          cancelEditing={[Function]}
+          comment="Foo"
+          complete={[Function]}
+          deactivateKeyboardShortcut={[Function]}
+          deactivateKeyboardShortcutGroup={[Function]}
+          intl={
+                    Object {
+                              "formatMessage": [Function],
+                            }
+          }
+          isMinimized={false}
+          keyboardShortcutGroups={
+                    Object {
+                              "openEditor": Object {
+                                "editId": Object {
+                                  "key": "e",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Id",
+                                    "id": "KeyMapping.openEditor.editId",
+                                  },
+                                },
+                                "editJosm": Object {
+                                  "key": "r",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in JOSM",
+                                    "id": "KeyMapping.openEditor.editJosm",
+                                  },
+                                },
+                                "editJosmLayer": Object {
+                                  "key": "t",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in new JOSM layer",
+                                    "id": "KeyMapping.openEditor.editJosmLayer",
+                                  },
+                                },
+                                "editLevel0": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Level0",
+                                    "id": "KeyMapping.openEditor.editLevel0",
+                                  },
+                                },
+                              },
+                              "taskCompletion": Object {
+                                "falsePositive": Object {
+                                  "key": "q",
+                                  "label": Object {
+                                    "defaultMessage": "Not an Issue",
+                                    "id": "KeyMapping.taskCompletion.falsePositive",
+                                  },
+                                },
+                                "skip": Object {
+                                  "key": "w",
+                                  "label": Object {
+                                    "defaultMessage": "Skip",
+                                    "id": "KeyMapping.taskCompletion.skip",
+                                  },
+                                },
+                              },
+                              "taskEditing": Object {
+                                "cancel": Object {
+                                  "key": "Escape",
+                                  "keyLabel": Object {
+                                    "defaultMessage": "ESC",
+                                    "id": "KeyMapping.taskEditing.escapeLabel",
+                                  },
+                                  "label": Object {
+                                    "defaultMessage": "Cancel Editing",
+                                    "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                              },
+                              "taskReview": Object {
+                                "nextTask": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Next Task",
+                                    "id": "KeyMapping.taskReview.nextTask",
+                                  },
+                                },
+                                "prevTask": Object {
+                                  "key": "h",
+                                  "label": Object {
+                                    "defaultMessage": "Previous Task",
+                                    "id": "KeyMapping.taskReview.prevTask",
+                                  },
+                                },
+                              },
+                            }
+          }
+          mapBounds={
+                    Object {
+                              "task": Object {
+                                "bounds": Array [
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                ],
+                              },
+                            }
+          }
+          suppressIcon={true}
+          task={
+                    Object {
+                              "id": 123,
+                              "parent": Object {
+                                "id": 321,
+                              },
+                              "status": 0,
+                            }
+          }
+          user={
+                    Object {
+                              "id": 357,
+                              "isLoggedIn": true,
+                              "settings": Object {
+                                "defaultEditor": 1,
+                              },
+                            }
+          }
+/>,
         <TaskCancelEditingControl
           activateKeyboardShortcut={[Function]}
           activateKeyboardShortcutGroup={[Function]}
@@ -5372,6 +6734,137 @@ ShallowWrapper {
               ],
             },
           },
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          },
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "isMinimized": false,
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "suppressIcon": true,
           "task": Object {
             "id": 123,
             "parent": Object {
@@ -5929,6 +7422,141 @@ ShallowWrapper {
                                   }
             }
 />,
+          <TaskSkipControl
+            activateKeyboardShortcut={[Function]}
+            activateKeyboardShortcutGroup={[Function]}
+            allowedProgressions={
+                        Set {
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                  }
+            }
+            cancelEditing={[Function]}
+            comment="Foo"
+            complete={[Function]}
+            deactivateKeyboardShortcut={[Function]}
+            deactivateKeyboardShortcutGroup={[Function]}
+            intl={
+                        Object {
+                                    "formatMessage": [Function],
+                                  }
+            }
+            isMinimized={false}
+            keyboardShortcutGroups={
+                        Object {
+                                    "openEditor": Object {
+                                      "editId": Object {
+                                        "key": "e",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Id",
+                                          "id": "KeyMapping.openEditor.editId",
+                                        },
+                                      },
+                                      "editJosm": Object {
+                                        "key": "r",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in JOSM",
+                                          "id": "KeyMapping.openEditor.editJosm",
+                                        },
+                                      },
+                                      "editJosmLayer": Object {
+                                        "key": "t",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in new JOSM layer",
+                                          "id": "KeyMapping.openEditor.editJosmLayer",
+                                        },
+                                      },
+                                      "editLevel0": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Level0",
+                                          "id": "KeyMapping.openEditor.editLevel0",
+                                        },
+                                      },
+                                    },
+                                    "taskCompletion": Object {
+                                      "falsePositive": Object {
+                                        "key": "q",
+                                        "label": Object {
+                                          "defaultMessage": "Not an Issue",
+                                          "id": "KeyMapping.taskCompletion.falsePositive",
+                                        },
+                                      },
+                                      "skip": Object {
+                                        "key": "w",
+                                        "label": Object {
+                                          "defaultMessage": "Skip",
+                                          "id": "KeyMapping.taskCompletion.skip",
+                                        },
+                                      },
+                                    },
+                                    "taskEditing": Object {
+                                      "cancel": Object {
+                                        "key": "Escape",
+                                        "keyLabel": Object {
+                                          "defaultMessage": "ESC",
+                                          "id": "KeyMapping.taskEditing.escapeLabel",
+                                        },
+                                        "label": Object {
+                                          "defaultMessage": "Cancel Editing",
+                                          "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                    },
+                                    "taskReview": Object {
+                                      "nextTask": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Next Task",
+                                          "id": "KeyMapping.taskReview.nextTask",
+                                        },
+                                      },
+                                      "prevTask": Object {
+                                        "key": "h",
+                                        "label": Object {
+                                          "defaultMessage": "Previous Task",
+                                          "id": "KeyMapping.taskReview.prevTask",
+                                        },
+                                      },
+                                    },
+                                  }
+            }
+            mapBounds={
+                        Object {
+                                    "task": Object {
+                                      "bounds": Array [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                      ],
+                                    },
+                                  }
+            }
+            suppressIcon={true}
+            task={
+                        Object {
+                                    "id": 123,
+                                    "parent": Object {
+                                      "id": 321,
+                                    },
+                                    "status": 0,
+                                  }
+            }
+            user={
+                        Object {
+                                    "id": 357,
+                                    "isLoggedIn": true,
+                                    "settings": Object {
+                                      "defaultEditor": 1,
+                                    },
+                                  }
+            }
+/>,
           <TaskCancelEditingControl
             activateKeyboardShortcut={[Function]}
             activateKeyboardShortcutGroup={[Function]}
@@ -6435,6 +8063,137 @@ ShallowWrapper {
                 ],
               },
             },
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 0,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+            },
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "isMinimized": false,
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "suppressIcon": true,
             "task": Object {
               "id": 123,
               "parent": Object {
@@ -7146,6 +8905,141 @@ ShallowWrapper {
                             }
           }
 />,
+        <TaskSkipControl
+          activateKeyboardShortcut={[Function]}
+          activateKeyboardShortcutGroup={[Function]}
+          allowedProgressions={
+                    Set {
+                              1,
+                              2,
+                              3,
+                              4,
+                              5,
+                              6,
+                            }
+          }
+          cancelEditing={[Function]}
+          comment="Foo"
+          complete={[Function]}
+          deactivateKeyboardShortcut={[Function]}
+          deactivateKeyboardShortcutGroup={[Function]}
+          intl={
+                    Object {
+                              "formatMessage": [Function],
+                            }
+          }
+          isMinimized={false}
+          keyboardShortcutGroups={
+                    Object {
+                              "openEditor": Object {
+                                "editId": Object {
+                                  "key": "e",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Id",
+                                    "id": "KeyMapping.openEditor.editId",
+                                  },
+                                },
+                                "editJosm": Object {
+                                  "key": "r",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in JOSM",
+                                    "id": "KeyMapping.openEditor.editJosm",
+                                  },
+                                },
+                                "editJosmLayer": Object {
+                                  "key": "t",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in new JOSM layer",
+                                    "id": "KeyMapping.openEditor.editJosmLayer",
+                                  },
+                                },
+                                "editLevel0": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Level0",
+                                    "id": "KeyMapping.openEditor.editLevel0",
+                                  },
+                                },
+                              },
+                              "taskCompletion": Object {
+                                "falsePositive": Object {
+                                  "key": "q",
+                                  "label": Object {
+                                    "defaultMessage": "Not an Issue",
+                                    "id": "KeyMapping.taskCompletion.falsePositive",
+                                  },
+                                },
+                                "skip": Object {
+                                  "key": "w",
+                                  "label": Object {
+                                    "defaultMessage": "Skip",
+                                    "id": "KeyMapping.taskCompletion.skip",
+                                  },
+                                },
+                              },
+                              "taskEditing": Object {
+                                "cancel": Object {
+                                  "key": "Escape",
+                                  "keyLabel": Object {
+                                    "defaultMessage": "ESC",
+                                    "id": "KeyMapping.taskEditing.escapeLabel",
+                                  },
+                                  "label": Object {
+                                    "defaultMessage": "Cancel Editing",
+                                    "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                              },
+                              "taskReview": Object {
+                                "nextTask": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Next Task",
+                                    "id": "KeyMapping.taskReview.nextTask",
+                                  },
+                                },
+                                "prevTask": Object {
+                                  "key": "h",
+                                  "label": Object {
+                                    "defaultMessage": "Previous Task",
+                                    "id": "KeyMapping.taskReview.prevTask",
+                                  },
+                                },
+                              },
+                            }
+          }
+          mapBounds={
+                    Object {
+                              "task": Object {
+                                "bounds": Array [
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                ],
+                              },
+                            }
+          }
+          suppressIcon={true}
+          task={
+                    Object {
+                              "id": 123,
+                              "parent": Object {
+                                "id": 321,
+                              },
+                              "status": 0,
+                            }
+          }
+          user={
+                    Object {
+                              "id": 357,
+                              "isLoggedIn": true,
+                              "settings": Object {
+                                "defaultEditor": 1,
+                              },
+                            }
+          }
+/>,
         <TaskCancelEditingControl
           activateKeyboardShortcut={[Function]}
           activateKeyboardShortcutGroup={[Function]}
@@ -7652,6 +9546,137 @@ ShallowWrapper {
               ],
             },
           },
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          },
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "isMinimized": false,
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "suppressIcon": true,
           "task": Object {
             "id": 123,
             "parent": Object {
@@ -8209,6 +10234,141 @@ ShallowWrapper {
                                   }
             }
 />,
+          <TaskSkipControl
+            activateKeyboardShortcut={[Function]}
+            activateKeyboardShortcutGroup={[Function]}
+            allowedProgressions={
+                        Set {
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                  }
+            }
+            cancelEditing={[Function]}
+            comment="Foo"
+            complete={[Function]}
+            deactivateKeyboardShortcut={[Function]}
+            deactivateKeyboardShortcutGroup={[Function]}
+            intl={
+                        Object {
+                                    "formatMessage": [Function],
+                                  }
+            }
+            isMinimized={false}
+            keyboardShortcutGroups={
+                        Object {
+                                    "openEditor": Object {
+                                      "editId": Object {
+                                        "key": "e",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Id",
+                                          "id": "KeyMapping.openEditor.editId",
+                                        },
+                                      },
+                                      "editJosm": Object {
+                                        "key": "r",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in JOSM",
+                                          "id": "KeyMapping.openEditor.editJosm",
+                                        },
+                                      },
+                                      "editJosmLayer": Object {
+                                        "key": "t",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in new JOSM layer",
+                                          "id": "KeyMapping.openEditor.editJosmLayer",
+                                        },
+                                      },
+                                      "editLevel0": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Level0",
+                                          "id": "KeyMapping.openEditor.editLevel0",
+                                        },
+                                      },
+                                    },
+                                    "taskCompletion": Object {
+                                      "falsePositive": Object {
+                                        "key": "q",
+                                        "label": Object {
+                                          "defaultMessage": "Not an Issue",
+                                          "id": "KeyMapping.taskCompletion.falsePositive",
+                                        },
+                                      },
+                                      "skip": Object {
+                                        "key": "w",
+                                        "label": Object {
+                                          "defaultMessage": "Skip",
+                                          "id": "KeyMapping.taskCompletion.skip",
+                                        },
+                                      },
+                                    },
+                                    "taskEditing": Object {
+                                      "cancel": Object {
+                                        "key": "Escape",
+                                        "keyLabel": Object {
+                                          "defaultMessage": "ESC",
+                                          "id": "KeyMapping.taskEditing.escapeLabel",
+                                        },
+                                        "label": Object {
+                                          "defaultMessage": "Cancel Editing",
+                                          "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                    },
+                                    "taskReview": Object {
+                                      "nextTask": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Next Task",
+                                          "id": "KeyMapping.taskReview.nextTask",
+                                        },
+                                      },
+                                      "prevTask": Object {
+                                        "key": "h",
+                                        "label": Object {
+                                          "defaultMessage": "Previous Task",
+                                          "id": "KeyMapping.taskReview.prevTask",
+                                        },
+                                      },
+                                    },
+                                  }
+            }
+            mapBounds={
+                        Object {
+                                    "task": Object {
+                                      "bounds": Array [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                      ],
+                                    },
+                                  }
+            }
+            suppressIcon={true}
+            task={
+                        Object {
+                                    "id": 123,
+                                    "parent": Object {
+                                      "id": 321,
+                                    },
+                                    "status": 0,
+                                  }
+            }
+            user={
+                        Object {
+                                    "id": 357,
+                                    "isLoggedIn": true,
+                                    "settings": Object {
+                                      "defaultEditor": 1,
+                                    },
+                                  }
+            }
+/>,
           <TaskCancelEditingControl
             activateKeyboardShortcut={[Function]}
             activateKeyboardShortcutGroup={[Function]}
@@ -8715,6 +10875,2949 @@ ShallowWrapper {
                 ],
               },
             },
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 0,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+            },
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "isMinimized": false,
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "suppressIcon": true,
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 0,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+            },
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 0,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`shows skip control for appropriate status 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <TaskCompletionStep2
+    activateKeyboardShortcut={[Function]}
+    activateKeyboardShortcutGroup={[Function]}
+    allowedProgressions={
+        Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          }
+    }
+    cancelEditing={[Function]}
+    comment="Foo"
+    complete={[Function]}
+    deactivateKeyboardShortcut={[Function]}
+    deactivateKeyboardShortcutGroup={[Function]}
+    intl={
+        Object {
+            "formatMessage": [Function],
+          }
+    }
+    keyboardShortcutGroups={
+        Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          }
+    }
+    mapBounds={
+        Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          }
+    }
+    task={
+        Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          }
+    }
+    user={
+        Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          }
+    }
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <TaskFixedControl
+          activateKeyboardShortcut={[Function]}
+          activateKeyboardShortcutGroup={[Function]}
+          allowedProgressions={
+                    Set {
+                              1,
+                              2,
+                              3,
+                              4,
+                              5,
+                              6,
+                            }
+          }
+          cancelEditing={[Function]}
+          comment="Foo"
+          complete={[Function]}
+          deactivateKeyboardShortcut={[Function]}
+          deactivateKeyboardShortcutGroup={[Function]}
+          intl={
+                    Object {
+                              "formatMessage": [Function],
+                            }
+          }
+          keyboardShortcutGroups={
+                    Object {
+                              "openEditor": Object {
+                                "editId": Object {
+                                  "key": "e",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Id",
+                                    "id": "KeyMapping.openEditor.editId",
+                                  },
+                                },
+                                "editJosm": Object {
+                                  "key": "r",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in JOSM",
+                                    "id": "KeyMapping.openEditor.editJosm",
+                                  },
+                                },
+                                "editJosmLayer": Object {
+                                  "key": "t",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in new JOSM layer",
+                                    "id": "KeyMapping.openEditor.editJosmLayer",
+                                  },
+                                },
+                                "editLevel0": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Level0",
+                                    "id": "KeyMapping.openEditor.editLevel0",
+                                  },
+                                },
+                              },
+                              "taskCompletion": Object {
+                                "falsePositive": Object {
+                                  "key": "q",
+                                  "label": Object {
+                                    "defaultMessage": "Not an Issue",
+                                    "id": "KeyMapping.taskCompletion.falsePositive",
+                                  },
+                                },
+                                "skip": Object {
+                                  "key": "w",
+                                  "label": Object {
+                                    "defaultMessage": "Skip",
+                                    "id": "KeyMapping.taskCompletion.skip",
+                                  },
+                                },
+                              },
+                              "taskEditing": Object {
+                                "cancel": Object {
+                                  "key": "Escape",
+                                  "keyLabel": Object {
+                                    "defaultMessage": "ESC",
+                                    "id": "KeyMapping.taskEditing.escapeLabel",
+                                  },
+                                  "label": Object {
+                                    "defaultMessage": "Cancel Editing",
+                                    "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                              },
+                              "taskReview": Object {
+                                "nextTask": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Next Task",
+                                    "id": "KeyMapping.taskReview.nextTask",
+                                  },
+                                },
+                                "prevTask": Object {
+                                  "key": "h",
+                                  "label": Object {
+                                    "defaultMessage": "Previous Task",
+                                    "id": "KeyMapping.taskReview.prevTask",
+                                  },
+                                },
+                              },
+                            }
+          }
+          mapBounds={
+                    Object {
+                              "task": Object {
+                                "bounds": Array [
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                ],
+                              },
+                            }
+          }
+          task={
+                    Object {
+                              "id": 123,
+                              "parent": Object {
+                                "id": 321,
+                              },
+                              "status": 0,
+                            }
+          }
+          user={
+                    Object {
+                              "id": 357,
+                              "isLoggedIn": true,
+                              "settings": Object {
+                                "defaultEditor": 1,
+                              },
+                            }
+          }
+/>,
+        <TaskTooHardControl
+          activateKeyboardShortcut={[Function]}
+          activateKeyboardShortcutGroup={[Function]}
+          allowedProgressions={
+                    Set {
+                              1,
+                              2,
+                              3,
+                              4,
+                              5,
+                              6,
+                            }
+          }
+          cancelEditing={[Function]}
+          comment="Foo"
+          complete={[Function]}
+          deactivateKeyboardShortcut={[Function]}
+          deactivateKeyboardShortcutGroup={[Function]}
+          intl={
+                    Object {
+                              "formatMessage": [Function],
+                            }
+          }
+          keyboardShortcutGroups={
+                    Object {
+                              "openEditor": Object {
+                                "editId": Object {
+                                  "key": "e",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Id",
+                                    "id": "KeyMapping.openEditor.editId",
+                                  },
+                                },
+                                "editJosm": Object {
+                                  "key": "r",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in JOSM",
+                                    "id": "KeyMapping.openEditor.editJosm",
+                                  },
+                                },
+                                "editJosmLayer": Object {
+                                  "key": "t",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in new JOSM layer",
+                                    "id": "KeyMapping.openEditor.editJosmLayer",
+                                  },
+                                },
+                                "editLevel0": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Level0",
+                                    "id": "KeyMapping.openEditor.editLevel0",
+                                  },
+                                },
+                              },
+                              "taskCompletion": Object {
+                                "falsePositive": Object {
+                                  "key": "q",
+                                  "label": Object {
+                                    "defaultMessage": "Not an Issue",
+                                    "id": "KeyMapping.taskCompletion.falsePositive",
+                                  },
+                                },
+                                "skip": Object {
+                                  "key": "w",
+                                  "label": Object {
+                                    "defaultMessage": "Skip",
+                                    "id": "KeyMapping.taskCompletion.skip",
+                                  },
+                                },
+                              },
+                              "taskEditing": Object {
+                                "cancel": Object {
+                                  "key": "Escape",
+                                  "keyLabel": Object {
+                                    "defaultMessage": "ESC",
+                                    "id": "KeyMapping.taskEditing.escapeLabel",
+                                  },
+                                  "label": Object {
+                                    "defaultMessage": "Cancel Editing",
+                                    "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                              },
+                              "taskReview": Object {
+                                "nextTask": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Next Task",
+                                    "id": "KeyMapping.taskReview.nextTask",
+                                  },
+                                },
+                                "prevTask": Object {
+                                  "key": "h",
+                                  "label": Object {
+                                    "defaultMessage": "Previous Task",
+                                    "id": "KeyMapping.taskReview.prevTask",
+                                  },
+                                },
+                              },
+                            }
+          }
+          mapBounds={
+                    Object {
+                              "task": Object {
+                                "bounds": Array [
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                ],
+                              },
+                            }
+          }
+          task={
+                    Object {
+                              "id": 123,
+                              "parent": Object {
+                                "id": 321,
+                              },
+                              "status": 0,
+                            }
+          }
+          user={
+                    Object {
+                              "id": 357,
+                              "isLoggedIn": true,
+                              "settings": Object {
+                                "defaultEditor": 1,
+                              },
+                            }
+          }
+/>,
+        <TaskAlreadyFixedControl
+          activateKeyboardShortcut={[Function]}
+          activateKeyboardShortcutGroup={[Function]}
+          allowedProgressions={
+                    Set {
+                              1,
+                              2,
+                              3,
+                              4,
+                              5,
+                              6,
+                            }
+          }
+          cancelEditing={[Function]}
+          comment="Foo"
+          complete={[Function]}
+          deactivateKeyboardShortcut={[Function]}
+          deactivateKeyboardShortcutGroup={[Function]}
+          intl={
+                    Object {
+                              "formatMessage": [Function],
+                            }
+          }
+          keyboardShortcutGroups={
+                    Object {
+                              "openEditor": Object {
+                                "editId": Object {
+                                  "key": "e",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Id",
+                                    "id": "KeyMapping.openEditor.editId",
+                                  },
+                                },
+                                "editJosm": Object {
+                                  "key": "r",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in JOSM",
+                                    "id": "KeyMapping.openEditor.editJosm",
+                                  },
+                                },
+                                "editJosmLayer": Object {
+                                  "key": "t",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in new JOSM layer",
+                                    "id": "KeyMapping.openEditor.editJosmLayer",
+                                  },
+                                },
+                                "editLevel0": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Level0",
+                                    "id": "KeyMapping.openEditor.editLevel0",
+                                  },
+                                },
+                              },
+                              "taskCompletion": Object {
+                                "falsePositive": Object {
+                                  "key": "q",
+                                  "label": Object {
+                                    "defaultMessage": "Not an Issue",
+                                    "id": "KeyMapping.taskCompletion.falsePositive",
+                                  },
+                                },
+                                "skip": Object {
+                                  "key": "w",
+                                  "label": Object {
+                                    "defaultMessage": "Skip",
+                                    "id": "KeyMapping.taskCompletion.skip",
+                                  },
+                                },
+                              },
+                              "taskEditing": Object {
+                                "cancel": Object {
+                                  "key": "Escape",
+                                  "keyLabel": Object {
+                                    "defaultMessage": "ESC",
+                                    "id": "KeyMapping.taskEditing.escapeLabel",
+                                  },
+                                  "label": Object {
+                                    "defaultMessage": "Cancel Editing",
+                                    "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                              },
+                              "taskReview": Object {
+                                "nextTask": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Next Task",
+                                    "id": "KeyMapping.taskReview.nextTask",
+                                  },
+                                },
+                                "prevTask": Object {
+                                  "key": "h",
+                                  "label": Object {
+                                    "defaultMessage": "Previous Task",
+                                    "id": "KeyMapping.taskReview.prevTask",
+                                  },
+                                },
+                              },
+                            }
+          }
+          mapBounds={
+                    Object {
+                              "task": Object {
+                                "bounds": Array [
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                ],
+                              },
+                            }
+          }
+          task={
+                    Object {
+                              "id": 123,
+                              "parent": Object {
+                                "id": 321,
+                              },
+                              "status": 0,
+                            }
+          }
+          user={
+                    Object {
+                              "id": 357,
+                              "isLoggedIn": true,
+                              "settings": Object {
+                                "defaultEditor": 1,
+                              },
+                            }
+          }
+/>,
+        <TaskSkipControl
+          activateKeyboardShortcut={[Function]}
+          activateKeyboardShortcutGroup={[Function]}
+          allowedProgressions={
+                    Set {
+                              1,
+                              2,
+                              3,
+                              4,
+                              5,
+                              6,
+                            }
+          }
+          cancelEditing={[Function]}
+          comment="Foo"
+          complete={[Function]}
+          deactivateKeyboardShortcut={[Function]}
+          deactivateKeyboardShortcutGroup={[Function]}
+          intl={
+                    Object {
+                              "formatMessage": [Function],
+                            }
+          }
+          isMinimized={false}
+          keyboardShortcutGroups={
+                    Object {
+                              "openEditor": Object {
+                                "editId": Object {
+                                  "key": "e",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Id",
+                                    "id": "KeyMapping.openEditor.editId",
+                                  },
+                                },
+                                "editJosm": Object {
+                                  "key": "r",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in JOSM",
+                                    "id": "KeyMapping.openEditor.editJosm",
+                                  },
+                                },
+                                "editJosmLayer": Object {
+                                  "key": "t",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in new JOSM layer",
+                                    "id": "KeyMapping.openEditor.editJosmLayer",
+                                  },
+                                },
+                                "editLevel0": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Level0",
+                                    "id": "KeyMapping.openEditor.editLevel0",
+                                  },
+                                },
+                              },
+                              "taskCompletion": Object {
+                                "falsePositive": Object {
+                                  "key": "q",
+                                  "label": Object {
+                                    "defaultMessage": "Not an Issue",
+                                    "id": "KeyMapping.taskCompletion.falsePositive",
+                                  },
+                                },
+                                "skip": Object {
+                                  "key": "w",
+                                  "label": Object {
+                                    "defaultMessage": "Skip",
+                                    "id": "KeyMapping.taskCompletion.skip",
+                                  },
+                                },
+                              },
+                              "taskEditing": Object {
+                                "cancel": Object {
+                                  "key": "Escape",
+                                  "keyLabel": Object {
+                                    "defaultMessage": "ESC",
+                                    "id": "KeyMapping.taskEditing.escapeLabel",
+                                  },
+                                  "label": Object {
+                                    "defaultMessage": "Cancel Editing",
+                                    "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                              },
+                              "taskReview": Object {
+                                "nextTask": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Next Task",
+                                    "id": "KeyMapping.taskReview.nextTask",
+                                  },
+                                },
+                                "prevTask": Object {
+                                  "key": "h",
+                                  "label": Object {
+                                    "defaultMessage": "Previous Task",
+                                    "id": "KeyMapping.taskReview.prevTask",
+                                  },
+                                },
+                              },
+                            }
+          }
+          mapBounds={
+                    Object {
+                              "task": Object {
+                                "bounds": Array [
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                ],
+                              },
+                            }
+          }
+          suppressIcon={true}
+          task={
+                    Object {
+                              "id": 123,
+                              "parent": Object {
+                                "id": 321,
+                              },
+                              "status": 0,
+                            }
+          }
+          user={
+                    Object {
+                              "id": 357,
+                              "isLoggedIn": true,
+                              "settings": Object {
+                                "defaultEditor": 1,
+                              },
+                            }
+          }
+/>,
+        <TaskCancelEditingControl
+          activateKeyboardShortcut={[Function]}
+          activateKeyboardShortcutGroup={[Function]}
+          allowedProgressions={
+                    Set {
+                              1,
+                              2,
+                              3,
+                              4,
+                              5,
+                              6,
+                            }
+          }
+          cancelEditing={[Function]}
+          comment="Foo"
+          complete={[Function]}
+          deactivateKeyboardShortcut={[Function]}
+          deactivateKeyboardShortcutGroup={[Function]}
+          intl={
+                    Object {
+                              "formatMessage": [Function],
+                            }
+          }
+          keyboardShortcutGroups={
+                    Object {
+                              "openEditor": Object {
+                                "editId": Object {
+                                  "key": "e",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Id",
+                                    "id": "KeyMapping.openEditor.editId",
+                                  },
+                                },
+                                "editJosm": Object {
+                                  "key": "r",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in JOSM",
+                                    "id": "KeyMapping.openEditor.editJosm",
+                                  },
+                                },
+                                "editJosmLayer": Object {
+                                  "key": "t",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in new JOSM layer",
+                                    "id": "KeyMapping.openEditor.editJosmLayer",
+                                  },
+                                },
+                                "editLevel0": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Level0",
+                                    "id": "KeyMapping.openEditor.editLevel0",
+                                  },
+                                },
+                              },
+                              "taskCompletion": Object {
+                                "falsePositive": Object {
+                                  "key": "q",
+                                  "label": Object {
+                                    "defaultMessage": "Not an Issue",
+                                    "id": "KeyMapping.taskCompletion.falsePositive",
+                                  },
+                                },
+                                "skip": Object {
+                                  "key": "w",
+                                  "label": Object {
+                                    "defaultMessage": "Skip",
+                                    "id": "KeyMapping.taskCompletion.skip",
+                                  },
+                                },
+                              },
+                              "taskEditing": Object {
+                                "cancel": Object {
+                                  "key": "Escape",
+                                  "keyLabel": Object {
+                                    "defaultMessage": "ESC",
+                                    "id": "KeyMapping.taskEditing.escapeLabel",
+                                  },
+                                  "label": Object {
+                                    "defaultMessage": "Cancel Editing",
+                                    "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                              },
+                              "taskReview": Object {
+                                "nextTask": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Next Task",
+                                    "id": "KeyMapping.taskReview.nextTask",
+                                  },
+                                },
+                                "prevTask": Object {
+                                  "key": "h",
+                                  "label": Object {
+                                    "defaultMessage": "Previous Task",
+                                    "id": "KeyMapping.taskReview.prevTask",
+                                  },
+                                },
+                              },
+                            }
+          }
+          mapBounds={
+                    Object {
+                              "task": Object {
+                                "bounds": Array [
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                ],
+                              },
+                            }
+          }
+          task={
+                    Object {
+                              "id": 123,
+                              "parent": Object {
+                                "id": 321,
+                              },
+                              "status": 0,
+                            }
+          }
+          user={
+                    Object {
+                              "id": 357,
+                              "isLoggedIn": true,
+                              "settings": Object {
+                                "defaultEditor": 1,
+                              },
+                            }
+          }
+/>,
+      ],
+      "className": "active-task-controls__step2 active-task-controls__vertical-control-block",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          },
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          },
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          },
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          },
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "isMinimized": false,
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "suppressIcon": true,
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          },
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <TaskFixedControl
+            activateKeyboardShortcut={[Function]}
+            activateKeyboardShortcutGroup={[Function]}
+            allowedProgressions={
+                        Set {
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                  }
+            }
+            cancelEditing={[Function]}
+            comment="Foo"
+            complete={[Function]}
+            deactivateKeyboardShortcut={[Function]}
+            deactivateKeyboardShortcutGroup={[Function]}
+            intl={
+                        Object {
+                                    "formatMessage": [Function],
+                                  }
+            }
+            keyboardShortcutGroups={
+                        Object {
+                                    "openEditor": Object {
+                                      "editId": Object {
+                                        "key": "e",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Id",
+                                          "id": "KeyMapping.openEditor.editId",
+                                        },
+                                      },
+                                      "editJosm": Object {
+                                        "key": "r",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in JOSM",
+                                          "id": "KeyMapping.openEditor.editJosm",
+                                        },
+                                      },
+                                      "editJosmLayer": Object {
+                                        "key": "t",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in new JOSM layer",
+                                          "id": "KeyMapping.openEditor.editJosmLayer",
+                                        },
+                                      },
+                                      "editLevel0": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Level0",
+                                          "id": "KeyMapping.openEditor.editLevel0",
+                                        },
+                                      },
+                                    },
+                                    "taskCompletion": Object {
+                                      "falsePositive": Object {
+                                        "key": "q",
+                                        "label": Object {
+                                          "defaultMessage": "Not an Issue",
+                                          "id": "KeyMapping.taskCompletion.falsePositive",
+                                        },
+                                      },
+                                      "skip": Object {
+                                        "key": "w",
+                                        "label": Object {
+                                          "defaultMessage": "Skip",
+                                          "id": "KeyMapping.taskCompletion.skip",
+                                        },
+                                      },
+                                    },
+                                    "taskEditing": Object {
+                                      "cancel": Object {
+                                        "key": "Escape",
+                                        "keyLabel": Object {
+                                          "defaultMessage": "ESC",
+                                          "id": "KeyMapping.taskEditing.escapeLabel",
+                                        },
+                                        "label": Object {
+                                          "defaultMessage": "Cancel Editing",
+                                          "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                    },
+                                    "taskReview": Object {
+                                      "nextTask": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Next Task",
+                                          "id": "KeyMapping.taskReview.nextTask",
+                                        },
+                                      },
+                                      "prevTask": Object {
+                                        "key": "h",
+                                        "label": Object {
+                                          "defaultMessage": "Previous Task",
+                                          "id": "KeyMapping.taskReview.prevTask",
+                                        },
+                                      },
+                                    },
+                                  }
+            }
+            mapBounds={
+                        Object {
+                                    "task": Object {
+                                      "bounds": Array [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                      ],
+                                    },
+                                  }
+            }
+            task={
+                        Object {
+                                    "id": 123,
+                                    "parent": Object {
+                                      "id": 321,
+                                    },
+                                    "status": 0,
+                                  }
+            }
+            user={
+                        Object {
+                                    "id": 357,
+                                    "isLoggedIn": true,
+                                    "settings": Object {
+                                      "defaultEditor": 1,
+                                    },
+                                  }
+            }
+/>,
+          <TaskTooHardControl
+            activateKeyboardShortcut={[Function]}
+            activateKeyboardShortcutGroup={[Function]}
+            allowedProgressions={
+                        Set {
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                  }
+            }
+            cancelEditing={[Function]}
+            comment="Foo"
+            complete={[Function]}
+            deactivateKeyboardShortcut={[Function]}
+            deactivateKeyboardShortcutGroup={[Function]}
+            intl={
+                        Object {
+                                    "formatMessage": [Function],
+                                  }
+            }
+            keyboardShortcutGroups={
+                        Object {
+                                    "openEditor": Object {
+                                      "editId": Object {
+                                        "key": "e",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Id",
+                                          "id": "KeyMapping.openEditor.editId",
+                                        },
+                                      },
+                                      "editJosm": Object {
+                                        "key": "r",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in JOSM",
+                                          "id": "KeyMapping.openEditor.editJosm",
+                                        },
+                                      },
+                                      "editJosmLayer": Object {
+                                        "key": "t",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in new JOSM layer",
+                                          "id": "KeyMapping.openEditor.editJosmLayer",
+                                        },
+                                      },
+                                      "editLevel0": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Level0",
+                                          "id": "KeyMapping.openEditor.editLevel0",
+                                        },
+                                      },
+                                    },
+                                    "taskCompletion": Object {
+                                      "falsePositive": Object {
+                                        "key": "q",
+                                        "label": Object {
+                                          "defaultMessage": "Not an Issue",
+                                          "id": "KeyMapping.taskCompletion.falsePositive",
+                                        },
+                                      },
+                                      "skip": Object {
+                                        "key": "w",
+                                        "label": Object {
+                                          "defaultMessage": "Skip",
+                                          "id": "KeyMapping.taskCompletion.skip",
+                                        },
+                                      },
+                                    },
+                                    "taskEditing": Object {
+                                      "cancel": Object {
+                                        "key": "Escape",
+                                        "keyLabel": Object {
+                                          "defaultMessage": "ESC",
+                                          "id": "KeyMapping.taskEditing.escapeLabel",
+                                        },
+                                        "label": Object {
+                                          "defaultMessage": "Cancel Editing",
+                                          "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                    },
+                                    "taskReview": Object {
+                                      "nextTask": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Next Task",
+                                          "id": "KeyMapping.taskReview.nextTask",
+                                        },
+                                      },
+                                      "prevTask": Object {
+                                        "key": "h",
+                                        "label": Object {
+                                          "defaultMessage": "Previous Task",
+                                          "id": "KeyMapping.taskReview.prevTask",
+                                        },
+                                      },
+                                    },
+                                  }
+            }
+            mapBounds={
+                        Object {
+                                    "task": Object {
+                                      "bounds": Array [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                      ],
+                                    },
+                                  }
+            }
+            task={
+                        Object {
+                                    "id": 123,
+                                    "parent": Object {
+                                      "id": 321,
+                                    },
+                                    "status": 0,
+                                  }
+            }
+            user={
+                        Object {
+                                    "id": 357,
+                                    "isLoggedIn": true,
+                                    "settings": Object {
+                                      "defaultEditor": 1,
+                                    },
+                                  }
+            }
+/>,
+          <TaskAlreadyFixedControl
+            activateKeyboardShortcut={[Function]}
+            activateKeyboardShortcutGroup={[Function]}
+            allowedProgressions={
+                        Set {
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                  }
+            }
+            cancelEditing={[Function]}
+            comment="Foo"
+            complete={[Function]}
+            deactivateKeyboardShortcut={[Function]}
+            deactivateKeyboardShortcutGroup={[Function]}
+            intl={
+                        Object {
+                                    "formatMessage": [Function],
+                                  }
+            }
+            keyboardShortcutGroups={
+                        Object {
+                                    "openEditor": Object {
+                                      "editId": Object {
+                                        "key": "e",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Id",
+                                          "id": "KeyMapping.openEditor.editId",
+                                        },
+                                      },
+                                      "editJosm": Object {
+                                        "key": "r",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in JOSM",
+                                          "id": "KeyMapping.openEditor.editJosm",
+                                        },
+                                      },
+                                      "editJosmLayer": Object {
+                                        "key": "t",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in new JOSM layer",
+                                          "id": "KeyMapping.openEditor.editJosmLayer",
+                                        },
+                                      },
+                                      "editLevel0": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Level0",
+                                          "id": "KeyMapping.openEditor.editLevel0",
+                                        },
+                                      },
+                                    },
+                                    "taskCompletion": Object {
+                                      "falsePositive": Object {
+                                        "key": "q",
+                                        "label": Object {
+                                          "defaultMessage": "Not an Issue",
+                                          "id": "KeyMapping.taskCompletion.falsePositive",
+                                        },
+                                      },
+                                      "skip": Object {
+                                        "key": "w",
+                                        "label": Object {
+                                          "defaultMessage": "Skip",
+                                          "id": "KeyMapping.taskCompletion.skip",
+                                        },
+                                      },
+                                    },
+                                    "taskEditing": Object {
+                                      "cancel": Object {
+                                        "key": "Escape",
+                                        "keyLabel": Object {
+                                          "defaultMessage": "ESC",
+                                          "id": "KeyMapping.taskEditing.escapeLabel",
+                                        },
+                                        "label": Object {
+                                          "defaultMessage": "Cancel Editing",
+                                          "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                    },
+                                    "taskReview": Object {
+                                      "nextTask": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Next Task",
+                                          "id": "KeyMapping.taskReview.nextTask",
+                                        },
+                                      },
+                                      "prevTask": Object {
+                                        "key": "h",
+                                        "label": Object {
+                                          "defaultMessage": "Previous Task",
+                                          "id": "KeyMapping.taskReview.prevTask",
+                                        },
+                                      },
+                                    },
+                                  }
+            }
+            mapBounds={
+                        Object {
+                                    "task": Object {
+                                      "bounds": Array [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                      ],
+                                    },
+                                  }
+            }
+            task={
+                        Object {
+                                    "id": 123,
+                                    "parent": Object {
+                                      "id": 321,
+                                    },
+                                    "status": 0,
+                                  }
+            }
+            user={
+                        Object {
+                                    "id": 357,
+                                    "isLoggedIn": true,
+                                    "settings": Object {
+                                      "defaultEditor": 1,
+                                    },
+                                  }
+            }
+/>,
+          <TaskSkipControl
+            activateKeyboardShortcut={[Function]}
+            activateKeyboardShortcutGroup={[Function]}
+            allowedProgressions={
+                        Set {
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                  }
+            }
+            cancelEditing={[Function]}
+            comment="Foo"
+            complete={[Function]}
+            deactivateKeyboardShortcut={[Function]}
+            deactivateKeyboardShortcutGroup={[Function]}
+            intl={
+                        Object {
+                                    "formatMessage": [Function],
+                                  }
+            }
+            isMinimized={false}
+            keyboardShortcutGroups={
+                        Object {
+                                    "openEditor": Object {
+                                      "editId": Object {
+                                        "key": "e",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Id",
+                                          "id": "KeyMapping.openEditor.editId",
+                                        },
+                                      },
+                                      "editJosm": Object {
+                                        "key": "r",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in JOSM",
+                                          "id": "KeyMapping.openEditor.editJosm",
+                                        },
+                                      },
+                                      "editJosmLayer": Object {
+                                        "key": "t",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in new JOSM layer",
+                                          "id": "KeyMapping.openEditor.editJosmLayer",
+                                        },
+                                      },
+                                      "editLevel0": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Level0",
+                                          "id": "KeyMapping.openEditor.editLevel0",
+                                        },
+                                      },
+                                    },
+                                    "taskCompletion": Object {
+                                      "falsePositive": Object {
+                                        "key": "q",
+                                        "label": Object {
+                                          "defaultMessage": "Not an Issue",
+                                          "id": "KeyMapping.taskCompletion.falsePositive",
+                                        },
+                                      },
+                                      "skip": Object {
+                                        "key": "w",
+                                        "label": Object {
+                                          "defaultMessage": "Skip",
+                                          "id": "KeyMapping.taskCompletion.skip",
+                                        },
+                                      },
+                                    },
+                                    "taskEditing": Object {
+                                      "cancel": Object {
+                                        "key": "Escape",
+                                        "keyLabel": Object {
+                                          "defaultMessage": "ESC",
+                                          "id": "KeyMapping.taskEditing.escapeLabel",
+                                        },
+                                        "label": Object {
+                                          "defaultMessage": "Cancel Editing",
+                                          "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                    },
+                                    "taskReview": Object {
+                                      "nextTask": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Next Task",
+                                          "id": "KeyMapping.taskReview.nextTask",
+                                        },
+                                      },
+                                      "prevTask": Object {
+                                        "key": "h",
+                                        "label": Object {
+                                          "defaultMessage": "Previous Task",
+                                          "id": "KeyMapping.taskReview.prevTask",
+                                        },
+                                      },
+                                    },
+                                  }
+            }
+            mapBounds={
+                        Object {
+                                    "task": Object {
+                                      "bounds": Array [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                      ],
+                                    },
+                                  }
+            }
+            suppressIcon={true}
+            task={
+                        Object {
+                                    "id": 123,
+                                    "parent": Object {
+                                      "id": 321,
+                                    },
+                                    "status": 0,
+                                  }
+            }
+            user={
+                        Object {
+                                    "id": 357,
+                                    "isLoggedIn": true,
+                                    "settings": Object {
+                                      "defaultEditor": 1,
+                                    },
+                                  }
+            }
+/>,
+          <TaskCancelEditingControl
+            activateKeyboardShortcut={[Function]}
+            activateKeyboardShortcutGroup={[Function]}
+            allowedProgressions={
+                        Set {
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                  }
+            }
+            cancelEditing={[Function]}
+            comment="Foo"
+            complete={[Function]}
+            deactivateKeyboardShortcut={[Function]}
+            deactivateKeyboardShortcutGroup={[Function]}
+            intl={
+                        Object {
+                                    "formatMessage": [Function],
+                                  }
+            }
+            keyboardShortcutGroups={
+                        Object {
+                                    "openEditor": Object {
+                                      "editId": Object {
+                                        "key": "e",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Id",
+                                          "id": "KeyMapping.openEditor.editId",
+                                        },
+                                      },
+                                      "editJosm": Object {
+                                        "key": "r",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in JOSM",
+                                          "id": "KeyMapping.openEditor.editJosm",
+                                        },
+                                      },
+                                      "editJosmLayer": Object {
+                                        "key": "t",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in new JOSM layer",
+                                          "id": "KeyMapping.openEditor.editJosmLayer",
+                                        },
+                                      },
+                                      "editLevel0": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Level0",
+                                          "id": "KeyMapping.openEditor.editLevel0",
+                                        },
+                                      },
+                                    },
+                                    "taskCompletion": Object {
+                                      "falsePositive": Object {
+                                        "key": "q",
+                                        "label": Object {
+                                          "defaultMessage": "Not an Issue",
+                                          "id": "KeyMapping.taskCompletion.falsePositive",
+                                        },
+                                      },
+                                      "skip": Object {
+                                        "key": "w",
+                                        "label": Object {
+                                          "defaultMessage": "Skip",
+                                          "id": "KeyMapping.taskCompletion.skip",
+                                        },
+                                      },
+                                    },
+                                    "taskEditing": Object {
+                                      "cancel": Object {
+                                        "key": "Escape",
+                                        "keyLabel": Object {
+                                          "defaultMessage": "ESC",
+                                          "id": "KeyMapping.taskEditing.escapeLabel",
+                                        },
+                                        "label": Object {
+                                          "defaultMessage": "Cancel Editing",
+                                          "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                    },
+                                    "taskReview": Object {
+                                      "nextTask": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Next Task",
+                                          "id": "KeyMapping.taskReview.nextTask",
+                                        },
+                                      },
+                                      "prevTask": Object {
+                                        "key": "h",
+                                        "label": Object {
+                                          "defaultMessage": "Previous Task",
+                                          "id": "KeyMapping.taskReview.prevTask",
+                                        },
+                                      },
+                                    },
+                                  }
+            }
+            mapBounds={
+                        Object {
+                                    "task": Object {
+                                      "bounds": Array [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                      ],
+                                    },
+                                  }
+            }
+            task={
+                        Object {
+                                    "id": 123,
+                                    "parent": Object {
+                                      "id": 321,
+                                    },
+                                    "status": 0,
+                                  }
+            }
+            user={
+                        Object {
+                                    "id": 357,
+                                    "isLoggedIn": true,
+                                    "settings": Object {
+                                      "defaultEditor": 1,
+                                    },
+                                  }
+            }
+/>,
+        ],
+        "className": "active-task-controls__step2 active-task-controls__vertical-control-block",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+            },
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 0,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+            },
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 0,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+            },
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 0,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+            },
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "isMinimized": false,
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "suppressIcon": true,
             "task": Object {
               "id": 123,
               "parent": Object {
@@ -9426,6 +14529,141 @@ ShallowWrapper {
                             }
           }
 />,
+        <TaskSkipControl
+          activateKeyboardShortcut={[Function]}
+          activateKeyboardShortcutGroup={[Function]}
+          allowedProgressions={
+                    Set {
+                              1,
+                              2,
+                              3,
+                              4,
+                              5,
+                              6,
+                            }
+          }
+          cancelEditing={[Function]}
+          comment="Foo"
+          complete={[Function]}
+          deactivateKeyboardShortcut={[Function]}
+          deactivateKeyboardShortcutGroup={[Function]}
+          intl={
+                    Object {
+                              "formatMessage": [Function],
+                            }
+          }
+          isMinimized={false}
+          keyboardShortcutGroups={
+                    Object {
+                              "openEditor": Object {
+                                "editId": Object {
+                                  "key": "e",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Id",
+                                    "id": "KeyMapping.openEditor.editId",
+                                  },
+                                },
+                                "editJosm": Object {
+                                  "key": "r",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in JOSM",
+                                    "id": "KeyMapping.openEditor.editJosm",
+                                  },
+                                },
+                                "editJosmLayer": Object {
+                                  "key": "t",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in new JOSM layer",
+                                    "id": "KeyMapping.openEditor.editJosmLayer",
+                                  },
+                                },
+                                "editLevel0": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Edit in Level0",
+                                    "id": "KeyMapping.openEditor.editLevel0",
+                                  },
+                                },
+                              },
+                              "taskCompletion": Object {
+                                "falsePositive": Object {
+                                  "key": "q",
+                                  "label": Object {
+                                    "defaultMessage": "Not an Issue",
+                                    "id": "KeyMapping.taskCompletion.falsePositive",
+                                  },
+                                },
+                                "skip": Object {
+                                  "key": "w",
+                                  "label": Object {
+                                    "defaultMessage": "Skip",
+                                    "id": "KeyMapping.taskCompletion.skip",
+                                  },
+                                },
+                              },
+                              "taskEditing": Object {
+                                "cancel": Object {
+                                  "key": "Escape",
+                                  "keyLabel": Object {
+                                    "defaultMessage": "ESC",
+                                    "id": "KeyMapping.taskEditing.escapeLabel",
+                                  },
+                                  "label": Object {
+                                    "defaultMessage": "Cancel Editing",
+                                    "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                              },
+                              "taskReview": Object {
+                                "nextTask": Object {
+                                  "key": "l",
+                                  "label": Object {
+                                    "defaultMessage": "Next Task",
+                                    "id": "KeyMapping.taskReview.nextTask",
+                                  },
+                                },
+                                "prevTask": Object {
+                                  "key": "h",
+                                  "label": Object {
+                                    "defaultMessage": "Previous Task",
+                                    "id": "KeyMapping.taskReview.prevTask",
+                                  },
+                                },
+                              },
+                            }
+          }
+          mapBounds={
+                    Object {
+                              "task": Object {
+                                "bounds": Array [
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                ],
+                              },
+                            }
+          }
+          suppressIcon={true}
+          task={
+                    Object {
+                              "id": 123,
+                              "parent": Object {
+                                "id": 321,
+                              },
+                              "status": 0,
+                            }
+          }
+          user={
+                    Object {
+                              "id": 357,
+                              "isLoggedIn": true,
+                              "settings": Object {
+                                "defaultEditor": 1,
+                              },
+                            }
+          }
+/>,
         <TaskCancelEditingControl
           activateKeyboardShortcut={[Function]}
           activateKeyboardShortcutGroup={[Function]}
@@ -9932,6 +15170,137 @@ ShallowWrapper {
               ],
             },
           },
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          },
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "isMinimized": false,
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "suppressIcon": true,
           "task": Object {
             "id": 123,
             "parent": Object {
@@ -10489,6 +15858,141 @@ ShallowWrapper {
                                   }
             }
 />,
+          <TaskSkipControl
+            activateKeyboardShortcut={[Function]}
+            activateKeyboardShortcutGroup={[Function]}
+            allowedProgressions={
+                        Set {
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                  }
+            }
+            cancelEditing={[Function]}
+            comment="Foo"
+            complete={[Function]}
+            deactivateKeyboardShortcut={[Function]}
+            deactivateKeyboardShortcutGroup={[Function]}
+            intl={
+                        Object {
+                                    "formatMessage": [Function],
+                                  }
+            }
+            isMinimized={false}
+            keyboardShortcutGroups={
+                        Object {
+                                    "openEditor": Object {
+                                      "editId": Object {
+                                        "key": "e",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Id",
+                                          "id": "KeyMapping.openEditor.editId",
+                                        },
+                                      },
+                                      "editJosm": Object {
+                                        "key": "r",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in JOSM",
+                                          "id": "KeyMapping.openEditor.editJosm",
+                                        },
+                                      },
+                                      "editJosmLayer": Object {
+                                        "key": "t",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in new JOSM layer",
+                                          "id": "KeyMapping.openEditor.editJosmLayer",
+                                        },
+                                      },
+                                      "editLevel0": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Edit in Level0",
+                                          "id": "KeyMapping.openEditor.editLevel0",
+                                        },
+                                      },
+                                    },
+                                    "taskCompletion": Object {
+                                      "falsePositive": Object {
+                                        "key": "q",
+                                        "label": Object {
+                                          "defaultMessage": "Not an Issue",
+                                          "id": "KeyMapping.taskCompletion.falsePositive",
+                                        },
+                                      },
+                                      "skip": Object {
+                                        "key": "w",
+                                        "label": Object {
+                                          "defaultMessage": "Skip",
+                                          "id": "KeyMapping.taskCompletion.skip",
+                                        },
+                                      },
+                                    },
+                                    "taskEditing": Object {
+                                      "cancel": Object {
+                                        "key": "Escape",
+                                        "keyLabel": Object {
+                                          "defaultMessage": "ESC",
+                                          "id": "KeyMapping.taskEditing.escapeLabel",
+                                        },
+                                        "label": Object {
+                                          "defaultMessage": "Cancel Editing",
+                                          "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                    },
+                                    "taskReview": Object {
+                                      "nextTask": Object {
+                                        "key": "l",
+                                        "label": Object {
+                                          "defaultMessage": "Next Task",
+                                          "id": "KeyMapping.taskReview.nextTask",
+                                        },
+                                      },
+                                      "prevTask": Object {
+                                        "key": "h",
+                                        "label": Object {
+                                          "defaultMessage": "Previous Task",
+                                          "id": "KeyMapping.taskReview.prevTask",
+                                        },
+                                      },
+                                    },
+                                  }
+            }
+            mapBounds={
+                        Object {
+                                    "task": Object {
+                                      "bounds": Array [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                      ],
+                                    },
+                                  }
+            }
+            suppressIcon={true}
+            task={
+                        Object {
+                                    "id": 123,
+                                    "parent": Object {
+                                      "id": 321,
+                                    },
+                                    "status": 0,
+                                  }
+            }
+            user={
+                        Object {
+                                    "id": 357,
+                                    "isLoggedIn": true,
+                                    "settings": Object {
+                                      "defaultEditor": 1,
+                                    },
+                                  }
+            }
+/>,
           <TaskCancelEditingControl
             activateKeyboardShortcut={[Function]}
             activateKeyboardShortcutGroup={[Function]}
@@ -10995,6 +16499,137 @@ ShallowWrapper {
                 ],
               },
             },
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 0,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+            },
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "isMinimized": false,
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "suppressIcon": true,
             "task": Object {
               "id": 123,
               "parent": Object {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskSkipControl/TaskSkipControl.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskSkipControl/TaskSkipControl.js
@@ -45,9 +45,11 @@ export default class TaskSkipControl extends Component {
                                      "icon-only": this.props.isMinimized})}
               title={this.props.intl.formatMessage(messages.skipTooltip)}
               onClick={() => this.props.complete(TaskStatus.skipped)}>
-        <span className="control-icon">
-          <SvgSymbol viewBox='0 0 20 20' sym="skip-icon" />
-        </span>
+        {!this.props.suppressIcon &&
+         <span className="control-icon">
+           <SvgSymbol viewBox='0 0 20 20' sym="skip-icon" />
+         </span>
+        }
         <span className="control-label">
           <FormattedMessage {...messages.skipLabel} />
         </span>
@@ -59,6 +61,8 @@ export default class TaskSkipControl extends Component {
 TaskSkipControl.propTypes = {
   /** Set to true to render in a minimized form */
   isMinimized: PropTypes.bool,
+  /** Set to true to suppress display of control icon */
+  suppressIcon: PropTypes.bool,
   /** Invoked to mark the task as already-fixed */
   complete: PropTypes.func.isRequired,
   /** Available keyboard shortcuts */
@@ -71,4 +75,5 @@ TaskSkipControl.propTypes = {
 
 TaskSkipControl.defaultProps = {
   isMinimized: false,
+  suppressIcon: false,
 }

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskSkipControl/__snapshots__/TaskSkipControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskSkipControl/__snapshots__/TaskSkipControl.test.js.snap
@@ -93,6 +93,7 @@ ShallowWrapper {
             },
           }
     }
+    suppressIcon={false}
     task={
         Object {
             "id": 123,


### PR DESCRIPTION
Offer option to Skip the current task during task completion even after user has initiated an editing session. Previously, the user would have to first use the 'Go Back' control.