### PR TITLE
Support identified layers in default basemaps

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
@@ -4,6 +4,8 @@ import _isObject from 'lodash/isObject'
 import _isNumber from 'lodash/isNumber'
 import _isString from 'lodash/isString'
 import _isEmpty from 'lodash/isEmpty'
+import _isUndefined from 'lodash/isUndefined'
+import _isFinite from 'lodash/isFinite'
 import _omit from 'lodash/omit'
 import _each from 'lodash/each'
 import _filter from 'lodash/filter'
@@ -262,6 +264,19 @@ export class EditChallenge extends Component {
       }
     }
 
+    // Copy basemap layer id to defaultBasemap so the proper layer will be
+    // selected in the form even if it isn't represented by one one of the
+    // ChallengeBasemap constants
+    if (_isUndefined(this.state.formData.defaultBasemap)) {
+      if (!_isEmpty(challengeData.defaultBasemapId)) {
+        challengeData.defaultBasemap = challengeData.defaultBasemapId
+      }
+      else if (_isFinite(challengeData.defaultBasemap)) {
+        // Use string for form
+        challengeData.defaultBasemap = challengeData.defaultBasemap.toString()
+      }
+    }
+
     if (!this.state.formData.highPriorityRules) {
       challengeData.highPriorityRules =
         preparePriorityRuleGroupForForm(challengeData.highPriorityRule)
@@ -322,6 +337,8 @@ export class EditChallenge extends Component {
     if (challengeData.isNew() && challengeData.includeCheckinHashtag) {
       challengeData.appendHashtagToCheckinComment()
     }
+
+    challengeData.normalizeDefaultBasemap()
 
     challengeData.highPriorityRule =
       preparePriorityRuleGroupForSaving(challengeData.highPriorityRules.ruleGroup)

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step4Schema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step4Schema.js
@@ -6,8 +6,8 @@ import { ZOOM_LEVELS,
 import { ChallengeBasemap,
          challengeOwnerBasemapLayerLabels }
        from '../../../../../services/Challenge/ChallengeBasemap/ChallengeBasemap'
+import { LayerSources } from '../../../../../services/VisibleLayer/LayerSources'
 import _get from 'lodash/get'
-import _values from 'lodash/values'
 import _without from 'lodash/without'
 import _map from 'lodash/map'
 import _isString from 'lodash/isString'
@@ -30,6 +30,12 @@ import messages from './Messages'
  */
 export const jsSchema = intl => {
   const localizedBasemapLabels = challengeOwnerBasemapLayerLabels(intl)
+
+  const defaultBasemapChoices = [
+    { id: ChallengeBasemap.none.toString(), name: localizedBasemapLabels.none }
+  ].concat(_map(LayerSources, source => ({id: source.id, name: source.name}))).concat([
+    { id: ChallengeBasemap.custom.toString(), name: localizedBasemapLabels.custom }
+  ])
 
   return {
     "$schema": "http://json-schema.org/draft-06/schema#",
@@ -72,9 +78,9 @@ export const jsSchema = intl => {
       defaultBasemap: {
         title: intl.formatMessage(messages.defaultBasemapLabel),
         description: intl.formatMessage(messages.defaultBasemapDescription),
-        type: "number",
-        enum: _values(ChallengeBasemap),
-        enumNames: _map(ChallengeBasemap, (value, key) => localizedBasemapLabels[key]),
+        type: "string",
+        enum: _map(defaultBasemapChoices, 'id'),
+        enumNames: _map(defaultBasemapChoices, 'name'),
         default: ChallengeBasemap.none,
       },
     },
@@ -84,14 +90,14 @@ export const jsSchema = intl => {
           {
             properties: {
               defaultBasemap: {
-                enum: _without(_values(ChallengeBasemap), ChallengeBasemap.custom),
+                enum: _without(_map(defaultBasemapChoices, 'id'), ChallengeBasemap.custom.toString()),
               }
             }
           },
           {
             properties: {
               defaultBasemap: {
-                enum: [ChallengeBasemap.custom],
+                enum: [ChallengeBasemap.custom.toString()],
               },
               customBasemap: {
                 title: intl.formatMessage(messages.customBasemapLabel),

--- a/src/components/UserProfile/UserSettings/UserSettingsSchema.js
+++ b/src/components/UserProfile/UserSettings/UserSettingsSchema.js
@@ -9,6 +9,7 @@ import { Editor,
 import { ChallengeBasemap,
          basemapLayerLabels }
        from '../../../services/Challenge/ChallengeBasemap/ChallengeBasemap'
+import { LayerSources } from '../../../services/VisibleLayer/LayerSources'
 import messages from './Messages'
 
 /**
@@ -26,6 +27,12 @@ export const jsSchema = intl => {
   const localizedLocaleLabels = localeLabels(intl)
   const localizedEditorLabels = editorLabels(intl)
   const localizedBasemapLabels = basemapLayerLabels(intl)
+
+  const defaultBasemapChoices = [
+    { id: ChallengeBasemap.none.toString(), name: localizedBasemapLabels.none }
+  ].concat(_map(LayerSources, source => ({id: source.id, name: source.name}))).concat([
+    { id: ChallengeBasemap.custom.toString(), name: localizedBasemapLabels.custom }
+  ])
 
   return {
     "$schema": "http://json-schema.org/draft-06/schema#",
@@ -50,9 +57,9 @@ export const jsSchema = intl => {
       defaultBasemap: {
         title: intl.formatMessage(messages.defaultBasemapLabel),
         description: intl.formatMessage(messages.defaultBasemapDescription),
-        type: "number",
-        enum: _values(ChallengeBasemap),
-        enumNames: _map(ChallengeBasemap, (value, key) => localizedBasemapLabels[key]),
+        type: "string",
+        enum: _map(defaultBasemapChoices, 'id'),
+        enumNames: _map(defaultBasemapChoices, 'name'),
         default: ChallengeBasemap.none,
       },
       leaderboardOptOut: {
@@ -68,14 +75,14 @@ export const jsSchema = intl => {
           {
             properties: {
               defaultBasemap: {
-                enum: _without(_values(ChallengeBasemap), ChallengeBasemap.custom),
+                enum: _without(_map(defaultBasemapChoices, 'id'), ChallengeBasemap.custom.toString()),
               }
             }
           },
           {
             properties: {
               defaultBasemap: {
-                enum: [ChallengeBasemap.custom],
+                enum: [ChallengeBasemap.custom.toString()],
               },
               customBasemap: {
                 title: intl.formatMessage(messages.customBasemapLabel),

--- a/src/interactions/Challenge/AsEditableChallenge.js
+++ b/src/interactions/Challenge/AsEditableChallenge.js
@@ -1,6 +1,9 @@
 import _isFinite from 'lodash/isFinite'
 import _get from 'lodash/get'
 import _isEmpty from 'lodash/isEmpty'
+import _isString from 'lodash/isString'
+import { ChallengeBasemap }
+       from '../../services/Challenge/ChallengeBasemap/ChallengeBasemap'
 
 const maprouletteHashtag = '#maproulette'
 
@@ -54,6 +57,31 @@ export class AsEditableChallenge {
       this.checkinComment = _isEmpty(this.checkinComment) ?
                                      maprouletteHashtag :
                                      `${this.checkinComment} ${maprouletteHashtag}`
+    }
+  }
+
+  /**
+   * The edit-challenge form can set defaultBasemap to one of the numeric
+   * constants, but can also set it to the string identifier of a layer not
+   * otherwise represented by a constant.
+   *
+   * This normalizes the defaultBasemap value to a valid constant from
+   * ChallengeBasemap, and also sets the defaultBasemapId to a string
+   * identifier if appropriate.
+   *
+   */
+  normalizeDefaultBasemap() {
+    if (_isFinite(Number(this.defaultBasemap))) {
+      this.defaultBasemapId = ''
+      this.defaultBasemap = Number(this.defaultBasemap)
+    }
+    else if (_isString(this.defaultBasemap) && this.defaultBasemap.length > 0) {
+      this.defaultBasemapId = this.defaultBasemap
+      this.defaultBasemap = ChallengeBasemap.identified
+    }
+    else {
+      this.defaultBasemapId = ''
+      this.defaultBasemap = ChallengeBasemap.none
     }
   }
 }

--- a/src/interactions/Challenge/AsMappableChallenge.js
+++ b/src/interactions/Challenge/AsMappableChallenge.js
@@ -16,6 +16,7 @@ export class AsMappableChallenge {
     }
 
     return basemapLayerSource(this.defaultBasemap,
+                              this.defaultBasemapId,
                               this.customBasemap,
                               `challenge_${this.id}`)
   }

--- a/src/interactions/User/AsEditableUser.js
+++ b/src/interactions/User/AsEditableUser.js
@@ -1,0 +1,40 @@
+import _isFinite from 'lodash/isFinite'
+import _isString from 'lodash/isString'
+import { ChallengeBasemap }
+       from '../../services/Challenge/ChallengeBasemap/ChallengeBasemap'
+
+/**
+ * AsEditableUser adds functionality to a User related to editing.
+ */
+export class AsEditableUser {
+  constructor(user) {
+    Object.assign(this, user)
+  }
+
+  /**
+   * The user-settings form can set defaultBasemap to one of the numeric
+   * constants, but can also set it to the string identifier of a layer not
+   * otherwise represented by a constant.
+   *
+   * This normalizes the defaultBasemap value to a valid constant from
+   * ChallengeBasemap, and also sets the defaultBasemapId to a string
+   * identifier if appropriate.
+   *
+   */
+  normalizeDefaultBasemap() {
+    if (_isFinite(Number(this.defaultBasemap))) {
+      this.defaultBasemapId = ''
+      this.defaultBasemap = Number(this.defaultBasemap)
+    }
+    else if (_isString(this.defaultBasemap) && this.defaultBasemap.length > 0) {
+      this.defaultBasemapId = this.defaultBasemap
+      this.defaultBasemap = ChallengeBasemap.identified
+    }
+    else {
+      this.defaultBasemapId = ''
+      this.defaultBasemap = ChallengeBasemap.none
+    }
+  }
+}
+
+export default user => new AsEditableUser(user)

--- a/src/interactions/User/AsMappingUser.js
+++ b/src/interactions/User/AsMappingUser.js
@@ -17,6 +17,7 @@ export class AsMappingUser {
     }
 
     return basemapLayerSource(this.settings.defaultBasemap,
+                              this.settings.defaultBasemapId,
                               this.settings.customBasemap,
                               `user_${this.id}`)
   }

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -508,8 +508,8 @@ export const saveChallenge = function(originalChallengeData, storeResponse=true)
     return removeChallengeKeywords(challengeData.id, challengeData.removedTags).then(() => {
       challengeData = _pick(challengeData, // fields in alphabetical order
         ['blurb', 'challengeType', 'checkinComment', 'checkinSource', 'customBasemap',
-        'defaultBasemap', 'defaultPriority', 'defaultZoom', 'description',
-        'difficulty', 'enabled', 'featured', 'highPriorityRule', 'id',
+        'defaultBasemap', 'defaultBasemapId', 'defaultPriority', 'defaultZoom',
+        'description', 'difficulty', 'enabled', 'featured', 'highPriorityRule', 'id',
         'instruction', 'localGeoJSON', 'lowPriorityRule', 'maxZoom',
         'mediumPriorityRule', 'minZoom', 'name', 'overpassQL', 'parent',
         'remoteGeoJson', 'status', 'tags', 'updateTasks'])

--- a/src/services/Challenge/ChallengeBasemap/ChallengeBasemap.js
+++ b/src/services/Challenge/ChallengeBasemap/ChallengeBasemap.js
@@ -14,6 +14,7 @@ export const CHALLENGE_BASEMAP_OPEN_STREET_MAP = 0
 export const CHALLENGE_BASEMAP_OPEN_CYCLE_MAP = 1
 export const CHALLENGE_BASEMAP_BING = 2
 export const CHALLENGE_BASEMAP_CUSTOM = 3
+export const CHALLENGE_BASEMAP_IDENTIFIED = 4
 
 export const ChallengeBasemap = Object.freeze({
   none: CHALLENGE_BASEMAP_NONE,
@@ -21,6 +22,7 @@ export const ChallengeBasemap = Object.freeze({
   openCycleMap: CHALLENGE_BASEMAP_OPEN_CYCLE_MAP,
   bing: CHALLENGE_BASEMAP_BING,
   custom: CHALLENGE_BASEMAP_CUSTOM,
+  identified: CHALLENGE_BASEMAP_IDENTIFIED,
 })
 
 /** Map basemap constants to layer source constants */

--- a/src/services/VisibleLayer/LayerSources.js
+++ b/src/services/VisibleLayer/LayerSources.js
@@ -3,7 +3,6 @@ import QueryString from 'query-string'
 import _isEmpty from 'lodash/isEmpty'
 import _find from 'lodash/find'
 import _get from 'lodash/get'
-import _isFinite from 'lodash/isFinite'
 import _sortBy from 'lodash/sortBy'
 import { ChallengeBasemap, basemapLayerSources }
        from '../Challenge/ChallengeBasemap/ChallengeBasemap'
@@ -134,17 +133,22 @@ export const createDynamicLayerSource = function(layerId, url) {
 }
 
 /**
- * Returns a layer source for the given basemapSetting, including generating a
- * dynamic layer source with the given customBasemap and layerId if appropriate.
+ * Returns a layer source for the given defaultBasemap, defaultBasemapId, and
+ * customBasemap settings, including generating a dynamic layer source with the
+ * given customBasemap and customLayerId if appropriate.
  */
-export const basemapLayerSource = function(basemapSetting, customBasemap, layerId) {
-  if (_isFinite(basemapSetting) && basemapSetting !== ChallengeBasemap.none) {
-    if (basemapSetting !== ChallengeBasemap.custom) {
-      return layerSourceWithId(basemapLayerSources()[basemapSetting])
-    }
-    else if (!_isEmpty(customBasemap)) {
-      return createDynamicLayerSource(layerId, customBasemap)
-    }
+export const basemapLayerSource = function(defaultBasemap, defaultBasemapId, customBasemap, customLayerId) {
+  if (defaultBasemap === ChallengeBasemap.none) {
+    return null
+  }
+  else if (defaultBasemap === ChallengeBasemap.identified) {
+    return layerSourceWithId(defaultBasemapId)
+  }
+  else if (defaultBasemap !== ChallengeBasemap.custom) {
+    return layerSourceWithId(basemapLayerSources()[defaultBasemap])
+  }
+  else if (!_isEmpty(customBasemap)) {
+    return createDynamicLayerSource(customLayerId, customBasemap)
   }
 
   return null

--- a/src/services/VisibleLayer/LayerSources.test.js
+++ b/src/services/VisibleLayer/LayerSources.test.js
@@ -44,18 +44,23 @@ describe("createDynamicLayerSource", () => {
 })
 
 describe("basemapLayerSource", () => {
-  test("Returns an existing layer if basemap setting matches", () => {
-    const layer = basemapLayerSource(ChallengeBasemap.openStreetMap, null, layerId)
+  test("Returns a constant layer if defaultBasemap setting matches", () => {
+    const layer = basemapLayerSource(ChallengeBasemap.openStreetMap, null, null, layerId)
     expect(layer.id).toEqual(OPEN_STREET_MAP)
   })
 
+  test("Returns an identified layer if defaultBasemap setting matches", () => {
+    const layer = basemapLayerSource(ChallengeBasemap.identified, 'DigitalGlobe-Premium', null, layerId)
+    expect(layer.id).toEqual('DigitalGlobe-Premium')
+  })
+
   test("Returns null if basemap set to none", () => {
-    const layer = basemapLayerSource(ChallengeBasemap.none, null, layerId)
+    const layer = basemapLayerSource(ChallengeBasemap.none, null, null, layerId)
     expect(layer).toBeNull()
   })
 
   test("Returns custom layer if set to custom and url provided", () => {
-    const layer = basemapLayerSource(ChallengeBasemap.custom, layerUrl, layerId)
+    const layer = basemapLayerSource(ChallengeBasemap.custom, null, layerUrl, layerId)
 
     expect(layer.id).toEqual(layerId)
     expect(layer.url).toEqual(layerUrl)
@@ -63,7 +68,7 @@ describe("basemapLayerSource", () => {
   })
 
   test("Returns null for custom layer if no url provided", () => {
-    const layer = basemapLayerSource(ChallengeBasemap.custom, null, layerId)
+    const layer = basemapLayerSource(ChallengeBasemap.custom, null, null, layerId)
 
     expect(layer).toBeNull()
   })


### PR DESCRIPTION
Add support for choosing additional layers from OSM Editor Layer Index as default basemaps for challenges and users.

> Note that this depends on maproulette/maproulette2#453 on the backend