### PR TITLE
Remove specific layer defaults from map components

### DIFF
--- a/src/components/AboutPane/AboutPane.js
+++ b/src/components/AboutPane/AboutPane.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import { MAPBOX_STREETS } from '../../services/VisibleLayer/LayerSources'
 import MapPane from '../EnhancedMap/MapPane/MapPane'
 import LocatorMap from '../LocatorMap/LocatorMap'
 import AboutModal from './AboutModal/AboutModal'
@@ -15,7 +14,7 @@ export default class AboutPane extends Component {
     return (
       <div className="about-pane">
         <MapPane>
-          <LocatorMap layerSourceId={MAPBOX_STREETS} className="about" {...this.props} />
+          <LocatorMap className="about" {...this.props} />
         </MapPane>
 
         <AboutModal {...this.props} />

--- a/src/components/AdminPane/Manage/ViewChallenge/ViewChallengeTasks.js
+++ b/src/components/AdminPane/Manage/ViewChallenge/ViewChallengeTasks.js
@@ -17,9 +17,6 @@ import { TaskPriority,
          messagesByPriority,
          taskPriorityLabels }
        from '../../../../services/Task/TaskPriority/TaskPriority'
-import { MAPBOX_LIGHT,
-         layerSourceWithId }
-       from '../../../../services/VisibleLayer/LayerSources'
 import AsManager from '../../../../interactions/User/AsManager'
 import WithBoundedTasks
        from '../../HOCs/WithBoundedTasks/WithBoundedTasks'
@@ -197,7 +194,6 @@ export class ViewChallengeTasks extends Component {
                             statusColors={statusColors}
                             filterOptions={filterOptions}
                             monochromaticClusters
-                            defaultLayer={layerSourceWithId(MAPBOX_LIGHT)}
                             {...this.props} />
         </MapPane>
 

--- a/src/components/ChallengePane/ChallengePane.js
+++ b/src/components/ChallengePane/ChallengePane.js
@@ -3,7 +3,6 @@ import classNames from 'classnames'
 import MediaQuery from 'react-responsive'
 import _isEqual from 'lodash/isEqual'
 import _get from 'lodash/get'
-import { MAPBOX_STREETS } from '../../services/VisibleLayer/LayerSources'
 import ChallengeFilterSubnav from './ChallengeFilterSubnav/ChallengeFilterSubnav'
 import MapPane from '../EnhancedMap/MapPane/MapPane'
 import Sidebar from '../Sidebar/Sidebar'
@@ -94,8 +93,7 @@ export class ChallengePane extends Component {
           </MediaQuery>
 
           <MapPane>
-            <Map layerSourceId={MAPBOX_STREETS}
-                 challenge={this.props.browsedChallenge}
+            <Map challenge={this.props.browsedChallenge}
                  onTaskClick={this.props.startChallengeWithTask}
                  {...this.props} />
           </MapPane>

--- a/src/components/ChallengePane/__snapshots__/ChallengePane.test.js.snap
+++ b/src/components/ChallengePane/__snapshots__/ChallengePane.test.js.snap
@@ -114,7 +114,6 @@ ShallowWrapper {
                                                   "formatMessage": [Function],
                                                 }
                               }
-                              layerSourceId="Mapbox"
                               onTaskClick={undefined}
                               saveChallenge={[Function]}
                               startChallenge={[Function]}
@@ -220,7 +219,6 @@ ShallowWrapper {
                                                         "formatMessage": [Function],
                                                       }
                             }
-                            layerSourceId="Mapbox"
                             onTaskClick={undefined}
                             saveChallenge={[Function]}
                             startChallenge={[Function]}
@@ -410,7 +408,6 @@ ShallowWrapper {
                                                 "formatMessage": [Function],
                                               }
                 }
-                layerSourceId="Mapbox"
                 onTaskClick={undefined}
                 saveChallenge={[Function]}
                 startChallenge={[Function]}
@@ -433,7 +430,6 @@ ShallowWrapper {
                 "intl": Object {
                   "formatMessage": [Function],
                 },
-                "layerSourceId": "Mapbox",
                 "onTaskClick": undefined,
                 "saveChallenge": [Function],
                 "startChallenge": [Function],
@@ -543,7 +539,6 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                                     }
-                                    layerSourceId="Mapbox"
                                     onTaskClick={undefined}
                                     saveChallenge={[Function]}
                                     startChallenge={[Function]}
@@ -649,7 +644,6 @@ ShallowWrapper {
                                                                 "formatMessage": [Function],
                                                               }
                                 }
-                                layerSourceId="Mapbox"
                                 onTaskClick={undefined}
                                 saveChallenge={[Function]}
                                 startChallenge={[Function]}
@@ -839,7 +833,6 @@ ShallowWrapper {
                                                       "formatMessage": [Function],
                                                     }
                   }
-                  layerSourceId="Mapbox"
                   onTaskClick={undefined}
                   saveChallenge={[Function]}
                   startChallenge={[Function]}
@@ -862,7 +855,6 @@ ShallowWrapper {
                   "intl": Object {
                     "formatMessage": [Function],
                   },
-                  "layerSourceId": "Mapbox",
                   "onTaskClick": undefined,
                   "saveChallenge": [Function],
                   "startChallenge": [Function],
@@ -1038,7 +1030,6 @@ ShallowWrapper {
                                                   "formatMessage": [Function],
                                                 }
                               }
-                              layerSourceId="Mapbox"
                               onTaskClick={undefined}
                               saveChallenge={[Function]}
                               startChallenge={[Function]}
@@ -1166,7 +1157,6 @@ ShallowWrapper {
                                                         "formatMessage": [Function],
                                                       }
                             }
-                            layerSourceId="Mapbox"
                             onTaskClick={undefined}
                             saveChallenge={[Function]}
                             startChallenge={[Function]}
@@ -1391,7 +1381,6 @@ ShallowWrapper {
                                                 "formatMessage": [Function],
                                               }
                 }
-                layerSourceId="Mapbox"
                 onTaskClick={undefined}
                 saveChallenge={[Function]}
                 startChallenge={[Function]}
@@ -1419,7 +1408,6 @@ ShallowWrapper {
                 "intl": Object {
                   "formatMessage": [Function],
                 },
-                "layerSourceId": "Mapbox",
                 "onTaskClick": undefined,
                 "saveChallenge": [Function],
                 "startChallenge": [Function],
@@ -1553,7 +1541,6 @@ ShallowWrapper {
                                                             "formatMessage": [Function],
                                                           }
                                     }
-                                    layerSourceId="Mapbox"
                                     onTaskClick={undefined}
                                     saveChallenge={[Function]}
                                     startChallenge={[Function]}
@@ -1681,7 +1668,6 @@ ShallowWrapper {
                                                                 "formatMessage": [Function],
                                                               }
                                 }
-                                layerSourceId="Mapbox"
                                 onTaskClick={undefined}
                                 saveChallenge={[Function]}
                                 startChallenge={[Function]}
@@ -1906,7 +1892,6 @@ ShallowWrapper {
                                                       "formatMessage": [Function],
                                                     }
                   }
-                  layerSourceId="Mapbox"
                   onTaskClick={undefined}
                   saveChallenge={[Function]}
                   startChallenge={[Function]}
@@ -1934,7 +1919,6 @@ ShallowWrapper {
                   "intl": Object {
                     "formatMessage": [Function],
                   },
-                  "layerSourceId": "Mapbox",
                   "onTaskClick": undefined,
                   "saveChallenge": [Function],
                   "startChallenge": [Function],

--- a/src/components/InsetMap/InsetMap.js
+++ b/src/components/InsetMap/InsetMap.js
@@ -3,18 +3,15 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { Map, Marker } from 'react-leaflet'
 import SourcedTileLayer from '../EnhancedMap/SourcedTileLayer/SourcedTileLayer'
-import { MAPBOX_LIGHT,
-         layerSourceWithId,
+import { layerSourceWithId,
          defaultLayerSource } from '../../services/VisibleLayer/LayerSources'
 import './InsetMap.css'
 
 export default class InsetMap extends Component {
   render() {
-    // Use requested layer source, otherwise Mapbox Light if it's available,
-    // otherwise the default source.
+    // Use requested layer source, otherwise the default source
     const layerSource =
-      layerSourceWithId(this.props.layerSourceId || MAPBOX_LIGHT) ||
-      defaultLayerSource()
+      layerSourceWithId(this.props.layerSourceId) || defaultLayerSource()
 
     return (
       <div className={classNames("inset-map", this.props.className)}>


### PR DESCRIPTION
Now that the default layer is controlled via .env configuration variable, individual map components should not be setting their own specific default layers.