### PR TITLE
Ensure all task features displayed. Closes #451

### DIFF
--- a/src/components/EnhancedMap/EnhancedMap.js
+++ b/src/components/EnhancedMap/EnhancedMap.js
@@ -135,9 +135,13 @@ export default class EnhancedMap extends Map {
         this.currentFeatures.addTo(this.leafletElement)
       }
 
-      // If we're only supposed to fit the features once, don't do it
-      // if we already had features.
-      if (!this.props.fitFeaturesOnlyOnce || !hasExistingFeatures) {
+      // By default, we always fit the map bounds to the task features.
+      // However, if we're only supposed to fit the features as necessary, then
+      // we do it for initial task (no existing features) or if the new task
+      // features wouldn't all be displayed at the present zoom level.
+      if (!this.props.fitFeaturesOnlyAsNecessary ||
+          !hasExistingFeatures ||
+          !this.leafletElement.getBounds().contains(this.currentFeatures.getBounds())) {
         this.leafletElement.fitBounds(this.currentFeatures.getBounds().pad(0.5))
       }
     }

--- a/src/components/TaskPane/TaskMap/TaskMap.js
+++ b/src/components/TaskPane/TaskMap/TaskMap.js
@@ -99,7 +99,7 @@ export default class TaskMap extends Component {
                      minZoom={minZoom} maxZoom={maxZoom}
                      features={_get(this.props.task, 'geometries.features')}
                      justFitFeatures={!this.state.showTaskFeatures}
-                     fitFeaturesOnlyOnce
+                     fitFeaturesOnlyAsNecessary
                      animateFeatures
                      onBoundsChange={this.updateTaskBounds}
         >

--- a/src/components/TaskPane/TaskMap/__snapshots__/TaskMap.test.js.snap
+++ b/src/components/TaskPane/TaskMap/__snapshots__/TaskMap.test.js.snap
@@ -72,7 +72,7 @@ ShallowWrapper {
                             }
           }
           features={null}
-          fitFeaturesOnlyOnce={true}
+          fitFeaturesOnlyAsNecessary={true}
           justFitFeatures={false}
           maxZoom={0}
           minZoom={1}
@@ -182,7 +182,7 @@ ShallowWrapper {
 />,
           ],
           "features": null,
-          "fitFeaturesOnlyOnce": true,
+          "fitFeaturesOnlyAsNecessary": true,
           "justFitFeatures": false,
           "maxZoom": 0,
           "minZoom": 1,
@@ -286,7 +286,7 @@ ShallowWrapper {
                                   }
             }
             features={null}
-            fitFeaturesOnlyOnce={true}
+            fitFeaturesOnlyAsNecessary={true}
             justFitFeatures={false}
             maxZoom={0}
             minZoom={1}
@@ -396,7 +396,7 @@ ShallowWrapper {
 />,
             ],
             "features": null,
-            "fitFeaturesOnlyOnce": true,
+            "fitFeaturesOnlyAsNecessary": true,
             "justFitFeatures": false,
             "maxZoom": 0,
             "minZoom": 1,


### PR DESCRIPTION
When moving from task to task in a challenge, fit map to bounds of new task features if they wouldn't all be displayed on the map at the current zoom level.