### PR TITLE
Allow inclusion of additional indexed layers

### DIFF
--- a/.env
+++ b/.env
@@ -62,6 +62,13 @@ REACT_APP_TAGINFO_SERVER_URL='https://taginfo.openstreetmap.org'
 # if a custom layer
 REACT_APP_DEFAULT_MAP_LAYER_ID='MAPNIK'
 
+# Additional layers to include from the OSM Editor Layer Index. This should be
+# a comma-separated list of layer ids, e.g.: 'tf-cycle, OpenTopoMap'
+# Note that this only applies to layers present in the index -- if you have
+# your own custom or 3rd-party layers outside of the index that you'd like to
+# use, you need to define them in the `src/extraLayers.json` file instead.
+REACT_APP_ADDITIONAL_INDEX_LAYERS='tf-cycle'
+
 # URL for Bing map layer tile server
 REACT_APP_BING_MAP_TILESERVER_URL='https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive",
     "build-intl": "yarn run combine-messages -i './src/**/*.js' -o './src/lang/en-US.json'",
-    "update-layers": "node update_layers.js",
+    "update-layers": "node scripts/update_layers.js",
     "start-js": "react-scripts start",
     "start": "npm-run-all -p update-layers watch-css start-js",
     "build": "npm run build-css && yarn run build-intl && yarn run update-layers && react-scripts build",

--- a/scripts/update_layers.js
+++ b/scripts/update_layers.js
@@ -8,6 +8,8 @@
  *
  * Requires curl and jq to both be installed.
  */
+require('dotenv').config()
+const _get = require('lodash/get')
 const shell = require('shelljs')
 shell.config.silent = true
 
@@ -29,6 +31,11 @@ if (shell.ls('./src').length === 0) {
   shell.exit(1)
 }
 
+// Additional layers (from the Layer Index) to include in addition to the
+// default layers.
+const additionalIndexLayers =
+  _get(process.env, 'REACT_APP_ADDITIONAL_INDEX_LAYERS', '').split(/,\s*/)
+
 // Download latest layer data and save to `src/imagery.json`
 shell.echo("Fetching latest layer data")
 if (shell.exec("curl -s https://osmlab.github.io/editor-layer-index/imagery.geojson -o ./src/imagery.json").code !== 0) {
@@ -38,11 +45,10 @@ if (shell.exec("curl -s https://osmlab.github.io/editor-layer-index/imagery.geoj
 
 // Extract properties from layers marked as default layers, that are not
 // overlays, and that have global coverage (geometry is null) and save them to
-// `src/defaultLayers.json`
-//
-// > Note, for backward compatibility we also include OpenCycleMap
+// `src/defaultLayers.json`. We also include any "additional" layers requested
 shell.echo("Extracting default layers")
-if (shell.exec("jq '[.features[].properties | select((.default == true and .overlay != true and .geometry == null) or .id == \"tf-cycle\")]' ./src/imagery.json > ./src/defaultLayers.json").code !== 0) {
+const jqLayerConditionals = additionalIndexLayers.map(layerId => ` or .id == "${layerId}"`).join(' ')
+if (shell.exec("jq '[.features[].properties | select((.default == true and .overlay != true and .geometry == null)" + jqLayerConditionals + ")]' ./src/imagery.json > ./src/defaultLayers.json").code !== 0) {
   shell.echo("Extracting default layers failed")
   shell.exit(1)
 }


### PR DESCRIPTION
* Add new `REACT_APP_ADDITIONAL_INDEX_LAYERS` .env config variable that can be used to specify comma-separated ids of additional map layers from the OSM Editor Layer Index that are to be included in the `defaultLayers.json` file by the `update_layers.js` script

* Move the `update_layers.js` script into a new `scripts/` directory