### PR TITLE
Allow inclusion of additional indexed layers

### DIFF
--- a/.env
+++ b/.env
@@ -62,6 +62,13 @@ REACT_APP_TAGINFO_SERVER_URL='https://taginfo.openstreetmap.org'
 # if a custom layer
 REACT_APP_DEFAULT_MAP_LAYER_ID='MAPNIK'
 
+# Additional layers to include from the OSM Editor Layer Index. This should be
+# a comma-separated list of layer ids, e.g.: 'tf-cycle, OpenTopoMap'
+# Note that this only applies to layers present in the index -- if you have
+# your own custom or 3rd-party layers outside of the index that you'd like to
+# use, you need to define them in the `src/extraLayers.json` file instead.
+REACT_APP_ADDITIONAL_INDEX_LAYERS='tf-cycle'
+
 # URL for Bing map layer tile server
 REACT_APP_BING_MAP_TILESERVER_URL='https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 # Imagery
 src/imagery.json
 src/defaultLayers.json
-src/extraLayers.json
+src/customLayers.json
 
 # testing
 /coverage

--- a/README.md
+++ b/README.md
@@ -83,24 +83,31 @@ project is still required.
 3. `yarn run build` to create a minified front-end build in the `build/`
    directory.
 
-## Adding Custom Map Layers
+## Adding Additional and Custom Map Layers
 
 Default map layers are determined by pulling in data from the [OSM Editor Layer
-Index](https://github.com/osmlab/editor-layer-index) at build time, and
+Index](https://github.com/osmlab/editor-layer-index) at build time and
 extracting (non-overlay) layers marked as default layers with global coverage.
-For backward compatibility, the OpenCycleMap layer is also included. These are
-stored in the `src/defaultLayers.json` file. Modifying this file is not
-recommended as it will be overwritten automatically by the build process.
+These are stored in the `src/defaultLayers.json` file. Modifying this file is
+not recommended as it will be overwritten automatically by the build process.
 
-Extra, custom layers can be added to `src/extraLayers.json` following the
-same structure as the default layers.
+Layer ids of additional desired layers from the Layer Index can be specified in
+the `REACT_APP_ADDITIONAL_INDEX_LAYERS` .env config variable (see the .env file
+for documentation), and these will also be included in the `defaultLayers.json`
+file. The default .env file includes the OpenCycleMap layer this way.
+
+Custom and 3rd-party layers that aren't included in the Layer Index can be
+manually added to `src/customLayers.json` following the same structure as the
+default layers. The build process does not modify this file other than creating
+a stub if it doesn't exist.
 
 ### Setting API Keys for Map Layers
 
-API keys for any layers -- default or extra -- can be set through the
+API keys for any layers -- default or custom -- can be set through the
 `REACT_APP_MAP_LAYER_API_KEYS` .env file configuration variable (see the .env
-file for documentation). For custom/extra layers, an API key can also simply be
-included in the specified layer url if that is simpler.
+file for documentation). For custom layers, an API key can also simply be
+included in the specified layer url in `src/customLayers.json` if that is
+simpler.
 
 # Development Notes
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive",
     "build-intl": "yarn run combine-messages -i './src/**/*.js' -o './src/lang/en-US.json'",
-    "update-layers": "node update_layers.js",
+    "update-layers": "node scripts/update_layers.js",
     "start-js": "react-scripts start",
     "start": "npm-run-all -p update-layers watch-css start-js",
     "build": "npm run build-css && yarn run build-intl && yarn run update-layers && react-scripts build",

--- a/src/services/VisibleLayer/LayerSources.js
+++ b/src/services/VisibleLayer/LayerSources.js
@@ -8,7 +8,7 @@ import _sortBy from 'lodash/sortBy'
 import { ChallengeBasemap, basemapLayerSources }
        from '../Challenge/ChallengeBasemap/ChallengeBasemap'
 import defaultLayers from '../../defaultLayers.json'
-import extraLayers from '../../extraLayers.json'
+import customLayers from '../../customLayers.json'
 
 export const layerSourceShape = PropTypes.shape({
   /** Unique id for layer */
@@ -52,7 +52,7 @@ export const MAPBOX_SATELLITE_STREETS = 'MapboxSatellite'
  * Editor Layer Index](https://github.com/osmlab/editor-layer-index) and
  * add/override based on local .env file settings.
  */
-export const LayerSources = _sortBy(defaultLayers.concat(extraLayers), 'name')
+export const LayerSources = _sortBy(defaultLayers.concat(customLayers), 'name')
 
 // Load any API keys from .env file
 let layerAPIKeys = {}


### PR DESCRIPTION
* Add new `REACT_APP_ADDITIONAL_INDEX_LAYERS` .env config variable that can be used to specify comma-separated ids of additional map layers from the OSM Editor Layer Index that are to be included in the `defaultLayers.json` file by the `update_layers.js` script

* Move the `update_layers.js` script into a new `scripts/` directory

* Rename `src/extraLayers.json` to `src/customLayers.json`

* Update README section on map layers