### PR TITLE
Add keyboard shortcut for fit bounds to task

### DIFF
--- a/src/components/HOCs/WithKeyboardShortcuts/WithKeyboardShortcuts.js
+++ b/src/components/HOCs/WithKeyboardShortcuts/WithKeyboardShortcuts.js
@@ -36,6 +36,12 @@ const mapDispatchToProps = dispatch => {
       document.removeEventListener("keydown", handler)
       dispatch(removeKeyboardShortcut(groupName, shortcutName))
     },
+    addExternalKeyboardShortcut: (groupName, shortcut) => {
+      dispatch(addKeyboardShortcut(groupName, shortcut))
+    },
+    removeExternalKeyboardShortcut: (groupName, shortcutName) => {
+      dispatch(removeKeyboardShortcut(groupName, shortcutName))
+    },
     textInputActive: textInputActive,
     quickKeyHandler: (key, handler) => (event => {
       if (textInputActive(event)) {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskAlreadyFixedControl/__snapshots__/TaskAlreadyFixedControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskAlreadyFixedControl/__snapshots__/TaskAlreadyFixedControl.test.js.snap
@@ -94,6 +94,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCancelEditingControl/__snapshots__/TaskCancelEditingControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCancelEditingControl/__snapshots__/TaskCancelEditingControl.test.js.snap
@@ -94,6 +94,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep1/__snapshots__/TaskCompletionStep1.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep1/__snapshots__/TaskCompletionStep1.test.js.snap
@@ -98,6 +98,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -306,6 +313,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -512,6 +526,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -731,6 +752,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -899,6 +927,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -1055,6 +1090,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -1209,6 +1251,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -1371,6 +1420,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -1523,6 +1579,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -1673,6 +1736,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -1838,6 +1908,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -1994,6 +2071,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -2148,6 +2232,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -2310,6 +2401,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -2462,6 +2560,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -2612,6 +2717,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -2784,6 +2896,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -2952,6 +3071,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -3108,6 +3234,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -3262,6 +3395,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -3424,6 +3564,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -3576,6 +3723,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -3726,6 +3880,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -3891,6 +4052,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -4047,6 +4215,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -4201,6 +4376,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -4363,6 +4545,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -4515,6 +4704,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -4665,6 +4861,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -4837,6 +5040,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -5005,6 +5215,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -5161,6 +5378,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -5315,6 +5539,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -5477,6 +5708,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -5629,6 +5867,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -5779,6 +6024,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -5944,6 +6196,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -6100,6 +6359,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -6254,6 +6520,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -6416,6 +6689,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -6568,6 +6848,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -6718,6 +7005,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep2/__snapshots__/TaskCompletionStep2.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep2/__snapshots__/TaskCompletionStep2.test.js.snap
@@ -99,6 +99,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -261,6 +268,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -414,6 +428,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -572,6 +593,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -725,6 +753,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -887,6 +922,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -1049,6 +1091,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -1202,6 +1251,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -1360,6 +1416,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -1513,6 +1576,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -1675,6 +1745,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -1837,6 +1914,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -1990,6 +2074,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -2148,6 +2239,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -2301,6 +2399,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -2463,6 +2568,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -2625,6 +2737,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -2778,6 +2897,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -2936,6 +3062,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -3089,6 +3222,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -3260,6 +3400,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -3427,6 +3574,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -3581,6 +3735,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -3733,6 +3894,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -3890,6 +4058,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -4043,6 +4218,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -4203,154 +4385,11 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
-            },
-            "taskReview": Object {
-              "nextTask": Object {
-                "key": "l",
+              "fitBounds": Object {
+                "key": "0",
                 "label": Object {
-                  "defaultMessage": "Next Task",
-                  "id": "KeyMapping.taskReview.nextTask",
-                },
-              },
-              "prevTask": Object {
-                "key": "h",
-                "label": Object {
-                  "defaultMessage": "Previous Task",
-                  "id": "KeyMapping.taskReview.prevTask",
-                },
-              },
-            },
-          },
-          "mapBounds": Object {
-            "task": Object {
-              "bounds": Array [
-                0,
-                0,
-                0,
-                0,
-              ],
-            },
-          },
-          "task": Object {
-            "id": 123,
-            "parent": Object {
-              "id": 321,
-            },
-            "status": 0,
-          },
-          "user": Object {
-            "id": 357,
-            "isLoggedIn": true,
-            "settings": Object {
-              "defaultEditor": 1,
-            },
-          },
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "class",
-        "props": Object {
-          "activateKeyboardShortcut": [Function],
-          "activateKeyboardShortcutGroup": [Function],
-          "allowedProgressions": Set {
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-          },
-          "cancelEditing": [Function],
-          "comment": "Foo",
-          "complete": [Function],
-          "deactivateKeyboardShortcut": [Function],
-          "deactivateKeyboardShortcutGroup": [Function],
-          "intl": Object {
-            "formatMessage": [Function],
-          },
-          "keyboardShortcutGroups": Object {
-            "openEditor": Object {
-              "editId": Object {
-                "key": "e",
-                "label": Object {
-                  "defaultMessage": "Edit in Id",
-                  "id": "KeyMapping.openEditor.editId",
-                },
-              },
-              "editJosm": Object {
-                "key": "r",
-                "label": Object {
-                  "defaultMessage": "Edit in JOSM",
-                  "id": "KeyMapping.openEditor.editJosm",
-                },
-              },
-              "editJosmLayer": Object {
-                "key": "t",
-                "label": Object {
-                  "defaultMessage": "Edit in new JOSM layer",
-                  "id": "KeyMapping.openEditor.editJosmLayer",
-                },
-              },
-              "editLevel0": Object {
-                "key": "l",
-                "label": Object {
-                  "defaultMessage": "Edit in Level0",
-                  "id": "KeyMapping.openEditor.editLevel0",
-                },
-              },
-            },
-            "taskCompletion": Object {
-              "alreadyFixed": Object {
-                "key": "x",
-                "label": Object {
-                  "defaultMessage": "Already fixed",
-                  "id": "KeyMapping.taskCompletion.alreadyFixed",
-                },
-              },
-              "falsePositive": Object {
-                "key": "q",
-                "label": Object {
-                  "defaultMessage": "Not an Issue",
-                  "id": "KeyMapping.taskCompletion.falsePositive",
-                },
-              },
-              "fixed": Object {
-                "key": "f",
-                "label": Object {
-                  "defaultMessage": "I fixed it!",
-                  "id": "KeyMapping.taskCompletion.fixed",
-                },
-              },
-              "skip": Object {
-                "key": "w",
-                "label": Object {
-                  "defaultMessage": "Skip",
-                  "id": "KeyMapping.taskCompletion.skip",
-                },
-              },
-              "tooHard": Object {
-                "key": "d",
-                "label": Object {
-                  "defaultMessage": "Too difficult / Couldn't see",
-                  "id": "KeyMapping.taskCompletion.tooHard",
-                },
-              },
-            },
-            "taskEditing": Object {
-              "cancel": Object {
-                "key": "Escape",
-                "keyLabel": Object {
-                  "defaultMessage": "ESC",
-                  "id": "KeyMapping.taskEditing.escapeLabel",
-                },
-                "label": Object {
-                  "defaultMessage": "Cancel Editing",
-                  "id": "KeyMapping.taskEditing.cancel",
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -4501,6 +4540,170 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          },
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "alreadyFixed": Object {
+                "key": "x",
+                "label": Object {
+                  "defaultMessage": "Already fixed",
+                  "id": "KeyMapping.taskCompletion.alreadyFixed",
+                },
+              },
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "fixed": Object {
+                "key": "f",
+                "label": Object {
+                  "defaultMessage": "I fixed it!",
+                  "id": "KeyMapping.taskCompletion.fixed",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+              "tooHard": Object {
+                "key": "d",
+                "label": Object {
+                  "defaultMessage": "Too difficult / Couldn't see",
+                  "id": "KeyMapping.taskCompletion.tooHard",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -4654,6 +4857,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -4803,6 +5013,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -4966,6 +5183,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -5120,6 +5344,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -5272,6 +5503,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -5429,6 +5667,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -5582,6 +5827,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -5742,154 +5994,11 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
-              },
-              "taskReview": Object {
-                "nextTask": Object {
-                  "key": "l",
+                "fitBounds": Object {
+                  "key": "0",
                   "label": Object {
-                    "defaultMessage": "Next Task",
-                    "id": "KeyMapping.taskReview.nextTask",
-                  },
-                },
-                "prevTask": Object {
-                  "key": "h",
-                  "label": Object {
-                    "defaultMessage": "Previous Task",
-                    "id": "KeyMapping.taskReview.prevTask",
-                  },
-                },
-              },
-            },
-            "mapBounds": Object {
-              "task": Object {
-                "bounds": Array [
-                  0,
-                  0,
-                  0,
-                  0,
-                ],
-              },
-            },
-            "task": Object {
-              "id": 123,
-              "parent": Object {
-                "id": 321,
-              },
-              "status": 0,
-            },
-            "user": Object {
-              "id": 357,
-              "isLoggedIn": true,
-              "settings": Object {
-                "defaultEditor": 1,
-              },
-            },
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "activateKeyboardShortcut": [Function],
-            "activateKeyboardShortcutGroup": [Function],
-            "allowedProgressions": Set {
-              1,
-              2,
-              3,
-              4,
-              5,
-              6,
-            },
-            "cancelEditing": [Function],
-            "comment": "Foo",
-            "complete": [Function],
-            "deactivateKeyboardShortcut": [Function],
-            "deactivateKeyboardShortcutGroup": [Function],
-            "intl": Object {
-              "formatMessage": [Function],
-            },
-            "keyboardShortcutGroups": Object {
-              "openEditor": Object {
-                "editId": Object {
-                  "key": "e",
-                  "label": Object {
-                    "defaultMessage": "Edit in Id",
-                    "id": "KeyMapping.openEditor.editId",
-                  },
-                },
-                "editJosm": Object {
-                  "key": "r",
-                  "label": Object {
-                    "defaultMessage": "Edit in JOSM",
-                    "id": "KeyMapping.openEditor.editJosm",
-                  },
-                },
-                "editJosmLayer": Object {
-                  "key": "t",
-                  "label": Object {
-                    "defaultMessage": "Edit in new JOSM layer",
-                    "id": "KeyMapping.openEditor.editJosmLayer",
-                  },
-                },
-                "editLevel0": Object {
-                  "key": "l",
-                  "label": Object {
-                    "defaultMessage": "Edit in Level0",
-                    "id": "KeyMapping.openEditor.editLevel0",
-                  },
-                },
-              },
-              "taskCompletion": Object {
-                "alreadyFixed": Object {
-                  "key": "x",
-                  "label": Object {
-                    "defaultMessage": "Already fixed",
-                    "id": "KeyMapping.taskCompletion.alreadyFixed",
-                  },
-                },
-                "falsePositive": Object {
-                  "key": "q",
-                  "label": Object {
-                    "defaultMessage": "Not an Issue",
-                    "id": "KeyMapping.taskCompletion.falsePositive",
-                  },
-                },
-                "fixed": Object {
-                  "key": "f",
-                  "label": Object {
-                    "defaultMessage": "I fixed it!",
-                    "id": "KeyMapping.taskCompletion.fixed",
-                  },
-                },
-                "skip": Object {
-                  "key": "w",
-                  "label": Object {
-                    "defaultMessage": "Skip",
-                    "id": "KeyMapping.taskCompletion.skip",
-                  },
-                },
-                "tooHard": Object {
-                  "key": "d",
-                  "label": Object {
-                    "defaultMessage": "Too difficult / Couldn't see",
-                    "id": "KeyMapping.taskCompletion.tooHard",
-                  },
-                },
-              },
-              "taskEditing": Object {
-                "cancel": Object {
-                  "key": "Escape",
-                  "keyLabel": Object {
-                    "defaultMessage": "ESC",
-                    "id": "KeyMapping.taskEditing.escapeLabel",
-                  },
-                  "label": Object {
-                    "defaultMessage": "Cancel Editing",
-                    "id": "KeyMapping.taskEditing.cancel",
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -6040,6 +6149,170 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 0,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+            },
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "alreadyFixed": Object {
+                  "key": "x",
+                  "label": Object {
+                    "defaultMessage": "Already fixed",
+                    "id": "KeyMapping.taskCompletion.alreadyFixed",
+                  },
+                },
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "fixed": Object {
+                  "key": "f",
+                  "label": Object {
+                    "defaultMessage": "I fixed it!",
+                    "id": "KeyMapping.taskCompletion.fixed",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+                "tooHard": Object {
+                  "key": "d",
+                  "label": Object {
+                    "defaultMessage": "Too difficult / Couldn't see",
+                    "id": "KeyMapping.taskCompletion.tooHard",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -6193,6 +6466,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -6342,6 +6622,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -6513,6 +6800,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -6680,6 +6974,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -6834,6 +7135,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -6986,6 +7294,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -7143,6 +7458,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -7296,6 +7618,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -7456,154 +7785,11 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
-            },
-            "taskReview": Object {
-              "nextTask": Object {
-                "key": "l",
+              "fitBounds": Object {
+                "key": "0",
                 "label": Object {
-                  "defaultMessage": "Next Task",
-                  "id": "KeyMapping.taskReview.nextTask",
-                },
-              },
-              "prevTask": Object {
-                "key": "h",
-                "label": Object {
-                  "defaultMessage": "Previous Task",
-                  "id": "KeyMapping.taskReview.prevTask",
-                },
-              },
-            },
-          },
-          "mapBounds": Object {
-            "task": Object {
-              "bounds": Array [
-                0,
-                0,
-                0,
-                0,
-              ],
-            },
-          },
-          "task": Object {
-            "id": 123,
-            "parent": Object {
-              "id": 321,
-            },
-            "status": 0,
-          },
-          "user": Object {
-            "id": 357,
-            "isLoggedIn": true,
-            "settings": Object {
-              "defaultEditor": 1,
-            },
-          },
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "class",
-        "props": Object {
-          "activateKeyboardShortcut": [Function],
-          "activateKeyboardShortcutGroup": [Function],
-          "allowedProgressions": Set {
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-          },
-          "cancelEditing": [Function],
-          "comment": "Foo",
-          "complete": [Function],
-          "deactivateKeyboardShortcut": [Function],
-          "deactivateKeyboardShortcutGroup": [Function],
-          "intl": Object {
-            "formatMessage": [Function],
-          },
-          "keyboardShortcutGroups": Object {
-            "openEditor": Object {
-              "editId": Object {
-                "key": "e",
-                "label": Object {
-                  "defaultMessage": "Edit in Id",
-                  "id": "KeyMapping.openEditor.editId",
-                },
-              },
-              "editJosm": Object {
-                "key": "r",
-                "label": Object {
-                  "defaultMessage": "Edit in JOSM",
-                  "id": "KeyMapping.openEditor.editJosm",
-                },
-              },
-              "editJosmLayer": Object {
-                "key": "t",
-                "label": Object {
-                  "defaultMessage": "Edit in new JOSM layer",
-                  "id": "KeyMapping.openEditor.editJosmLayer",
-                },
-              },
-              "editLevel0": Object {
-                "key": "l",
-                "label": Object {
-                  "defaultMessage": "Edit in Level0",
-                  "id": "KeyMapping.openEditor.editLevel0",
-                },
-              },
-            },
-            "taskCompletion": Object {
-              "alreadyFixed": Object {
-                "key": "x",
-                "label": Object {
-                  "defaultMessage": "Already fixed",
-                  "id": "KeyMapping.taskCompletion.alreadyFixed",
-                },
-              },
-              "falsePositive": Object {
-                "key": "q",
-                "label": Object {
-                  "defaultMessage": "Not an Issue",
-                  "id": "KeyMapping.taskCompletion.falsePositive",
-                },
-              },
-              "fixed": Object {
-                "key": "f",
-                "label": Object {
-                  "defaultMessage": "I fixed it!",
-                  "id": "KeyMapping.taskCompletion.fixed",
-                },
-              },
-              "skip": Object {
-                "key": "w",
-                "label": Object {
-                  "defaultMessage": "Skip",
-                  "id": "KeyMapping.taskCompletion.skip",
-                },
-              },
-              "tooHard": Object {
-                "key": "d",
-                "label": Object {
-                  "defaultMessage": "Too difficult / Couldn't see",
-                  "id": "KeyMapping.taskCompletion.tooHard",
-                },
-              },
-            },
-            "taskEditing": Object {
-              "cancel": Object {
-                "key": "Escape",
-                "keyLabel": Object {
-                  "defaultMessage": "ESC",
-                  "id": "KeyMapping.taskEditing.escapeLabel",
-                },
-                "label": Object {
-                  "defaultMessage": "Cancel Editing",
-                  "id": "KeyMapping.taskEditing.cancel",
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -7754,6 +7940,170 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          },
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "alreadyFixed": Object {
+                "key": "x",
+                "label": Object {
+                  "defaultMessage": "Already fixed",
+                  "id": "KeyMapping.taskCompletion.alreadyFixed",
+                },
+              },
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "fixed": Object {
+                "key": "f",
+                "label": Object {
+                  "defaultMessage": "I fixed it!",
+                  "id": "KeyMapping.taskCompletion.fixed",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+              "tooHard": Object {
+                "key": "d",
+                "label": Object {
+                  "defaultMessage": "Too difficult / Couldn't see",
+                  "id": "KeyMapping.taskCompletion.tooHard",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -7907,6 +8257,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -8056,6 +8413,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -8219,6 +8583,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -8373,6 +8744,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -8525,6 +8903,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -8682,6 +9067,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -8835,6 +9227,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -8995,154 +9394,11 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
-              },
-              "taskReview": Object {
-                "nextTask": Object {
-                  "key": "l",
+                "fitBounds": Object {
+                  "key": "0",
                   "label": Object {
-                    "defaultMessage": "Next Task",
-                    "id": "KeyMapping.taskReview.nextTask",
-                  },
-                },
-                "prevTask": Object {
-                  "key": "h",
-                  "label": Object {
-                    "defaultMessage": "Previous Task",
-                    "id": "KeyMapping.taskReview.prevTask",
-                  },
-                },
-              },
-            },
-            "mapBounds": Object {
-              "task": Object {
-                "bounds": Array [
-                  0,
-                  0,
-                  0,
-                  0,
-                ],
-              },
-            },
-            "task": Object {
-              "id": 123,
-              "parent": Object {
-                "id": 321,
-              },
-              "status": 0,
-            },
-            "user": Object {
-              "id": 357,
-              "isLoggedIn": true,
-              "settings": Object {
-                "defaultEditor": 1,
-              },
-            },
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "activateKeyboardShortcut": [Function],
-            "activateKeyboardShortcutGroup": [Function],
-            "allowedProgressions": Set {
-              1,
-              2,
-              3,
-              4,
-              5,
-              6,
-            },
-            "cancelEditing": [Function],
-            "comment": "Foo",
-            "complete": [Function],
-            "deactivateKeyboardShortcut": [Function],
-            "deactivateKeyboardShortcutGroup": [Function],
-            "intl": Object {
-              "formatMessage": [Function],
-            },
-            "keyboardShortcutGroups": Object {
-              "openEditor": Object {
-                "editId": Object {
-                  "key": "e",
-                  "label": Object {
-                    "defaultMessage": "Edit in Id",
-                    "id": "KeyMapping.openEditor.editId",
-                  },
-                },
-                "editJosm": Object {
-                  "key": "r",
-                  "label": Object {
-                    "defaultMessage": "Edit in JOSM",
-                    "id": "KeyMapping.openEditor.editJosm",
-                  },
-                },
-                "editJosmLayer": Object {
-                  "key": "t",
-                  "label": Object {
-                    "defaultMessage": "Edit in new JOSM layer",
-                    "id": "KeyMapping.openEditor.editJosmLayer",
-                  },
-                },
-                "editLevel0": Object {
-                  "key": "l",
-                  "label": Object {
-                    "defaultMessage": "Edit in Level0",
-                    "id": "KeyMapping.openEditor.editLevel0",
-                  },
-                },
-              },
-              "taskCompletion": Object {
-                "alreadyFixed": Object {
-                  "key": "x",
-                  "label": Object {
-                    "defaultMessage": "Already fixed",
-                    "id": "KeyMapping.taskCompletion.alreadyFixed",
-                  },
-                },
-                "falsePositive": Object {
-                  "key": "q",
-                  "label": Object {
-                    "defaultMessage": "Not an Issue",
-                    "id": "KeyMapping.taskCompletion.falsePositive",
-                  },
-                },
-                "fixed": Object {
-                  "key": "f",
-                  "label": Object {
-                    "defaultMessage": "I fixed it!",
-                    "id": "KeyMapping.taskCompletion.fixed",
-                  },
-                },
-                "skip": Object {
-                  "key": "w",
-                  "label": Object {
-                    "defaultMessage": "Skip",
-                    "id": "KeyMapping.taskCompletion.skip",
-                  },
-                },
-                "tooHard": Object {
-                  "key": "d",
-                  "label": Object {
-                    "defaultMessage": "Too difficult / Couldn't see",
-                    "id": "KeyMapping.taskCompletion.tooHard",
-                  },
-                },
-              },
-              "taskEditing": Object {
-                "cancel": Object {
-                  "key": "Escape",
-                  "keyLabel": Object {
-                    "defaultMessage": "ESC",
-                    "id": "KeyMapping.taskEditing.escapeLabel",
-                  },
-                  "label": Object {
-                    "defaultMessage": "Cancel Editing",
-                    "id": "KeyMapping.taskEditing.cancel",
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -9293,6 +9549,170 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 0,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+            },
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "alreadyFixed": Object {
+                  "key": "x",
+                  "label": Object {
+                    "defaultMessage": "Already fixed",
+                    "id": "KeyMapping.taskCompletion.alreadyFixed",
+                  },
+                },
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "fixed": Object {
+                  "key": "f",
+                  "label": Object {
+                    "defaultMessage": "I fixed it!",
+                    "id": "KeyMapping.taskCompletion.fixed",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+                "tooHard": Object {
+                  "key": "d",
+                  "label": Object {
+                    "defaultMessage": "Too difficult / Couldn't see",
+                    "id": "KeyMapping.taskCompletion.tooHard",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -9446,6 +9866,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -9595,6 +10022,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -9766,6 +10200,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -9933,6 +10374,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -10087,6 +10535,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -10239,6 +10694,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -10396,6 +10858,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -10549,6 +11018,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -10709,154 +11185,11 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
-            },
-            "taskReview": Object {
-              "nextTask": Object {
-                "key": "l",
+              "fitBounds": Object {
+                "key": "0",
                 "label": Object {
-                  "defaultMessage": "Next Task",
-                  "id": "KeyMapping.taskReview.nextTask",
-                },
-              },
-              "prevTask": Object {
-                "key": "h",
-                "label": Object {
-                  "defaultMessage": "Previous Task",
-                  "id": "KeyMapping.taskReview.prevTask",
-                },
-              },
-            },
-          },
-          "mapBounds": Object {
-            "task": Object {
-              "bounds": Array [
-                0,
-                0,
-                0,
-                0,
-              ],
-            },
-          },
-          "task": Object {
-            "id": 123,
-            "parent": Object {
-              "id": 321,
-            },
-            "status": 0,
-          },
-          "user": Object {
-            "id": 357,
-            "isLoggedIn": true,
-            "settings": Object {
-              "defaultEditor": 1,
-            },
-          },
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "class",
-        "props": Object {
-          "activateKeyboardShortcut": [Function],
-          "activateKeyboardShortcutGroup": [Function],
-          "allowedProgressions": Set {
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-          },
-          "cancelEditing": [Function],
-          "comment": "Foo",
-          "complete": [Function],
-          "deactivateKeyboardShortcut": [Function],
-          "deactivateKeyboardShortcutGroup": [Function],
-          "intl": Object {
-            "formatMessage": [Function],
-          },
-          "keyboardShortcutGroups": Object {
-            "openEditor": Object {
-              "editId": Object {
-                "key": "e",
-                "label": Object {
-                  "defaultMessage": "Edit in Id",
-                  "id": "KeyMapping.openEditor.editId",
-                },
-              },
-              "editJosm": Object {
-                "key": "r",
-                "label": Object {
-                  "defaultMessage": "Edit in JOSM",
-                  "id": "KeyMapping.openEditor.editJosm",
-                },
-              },
-              "editJosmLayer": Object {
-                "key": "t",
-                "label": Object {
-                  "defaultMessage": "Edit in new JOSM layer",
-                  "id": "KeyMapping.openEditor.editJosmLayer",
-                },
-              },
-              "editLevel0": Object {
-                "key": "l",
-                "label": Object {
-                  "defaultMessage": "Edit in Level0",
-                  "id": "KeyMapping.openEditor.editLevel0",
-                },
-              },
-            },
-            "taskCompletion": Object {
-              "alreadyFixed": Object {
-                "key": "x",
-                "label": Object {
-                  "defaultMessage": "Already fixed",
-                  "id": "KeyMapping.taskCompletion.alreadyFixed",
-                },
-              },
-              "falsePositive": Object {
-                "key": "q",
-                "label": Object {
-                  "defaultMessage": "Not an Issue",
-                  "id": "KeyMapping.taskCompletion.falsePositive",
-                },
-              },
-              "fixed": Object {
-                "key": "f",
-                "label": Object {
-                  "defaultMessage": "I fixed it!",
-                  "id": "KeyMapping.taskCompletion.fixed",
-                },
-              },
-              "skip": Object {
-                "key": "w",
-                "label": Object {
-                  "defaultMessage": "Skip",
-                  "id": "KeyMapping.taskCompletion.skip",
-                },
-              },
-              "tooHard": Object {
-                "key": "d",
-                "label": Object {
-                  "defaultMessage": "Too difficult / Couldn't see",
-                  "id": "KeyMapping.taskCompletion.tooHard",
-                },
-              },
-            },
-            "taskEditing": Object {
-              "cancel": Object {
-                "key": "Escape",
-                "keyLabel": Object {
-                  "defaultMessage": "ESC",
-                  "id": "KeyMapping.taskEditing.escapeLabel",
-                },
-                "label": Object {
-                  "defaultMessage": "Cancel Editing",
-                  "id": "KeyMapping.taskEditing.cancel",
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -11007,6 +11340,170 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          },
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "alreadyFixed": Object {
+                "key": "x",
+                "label": Object {
+                  "defaultMessage": "Already fixed",
+                  "id": "KeyMapping.taskCompletion.alreadyFixed",
+                },
+              },
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "fixed": Object {
+                "key": "f",
+                "label": Object {
+                  "defaultMessage": "I fixed it!",
+                  "id": "KeyMapping.taskCompletion.fixed",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+              "tooHard": Object {
+                "key": "d",
+                "label": Object {
+                  "defaultMessage": "Too difficult / Couldn't see",
+                  "id": "KeyMapping.taskCompletion.tooHard",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -11160,6 +11657,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -11309,6 +11813,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -11472,6 +11983,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -11626,6 +12144,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -11778,6 +12303,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -11935,6 +12467,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -12088,6 +12627,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -12248,154 +12794,11 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
-              },
-              "taskReview": Object {
-                "nextTask": Object {
-                  "key": "l",
+                "fitBounds": Object {
+                  "key": "0",
                   "label": Object {
-                    "defaultMessage": "Next Task",
-                    "id": "KeyMapping.taskReview.nextTask",
-                  },
-                },
-                "prevTask": Object {
-                  "key": "h",
-                  "label": Object {
-                    "defaultMessage": "Previous Task",
-                    "id": "KeyMapping.taskReview.prevTask",
-                  },
-                },
-              },
-            },
-            "mapBounds": Object {
-              "task": Object {
-                "bounds": Array [
-                  0,
-                  0,
-                  0,
-                  0,
-                ],
-              },
-            },
-            "task": Object {
-              "id": 123,
-              "parent": Object {
-                "id": 321,
-              },
-              "status": 0,
-            },
-            "user": Object {
-              "id": 357,
-              "isLoggedIn": true,
-              "settings": Object {
-                "defaultEditor": 1,
-              },
-            },
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "activateKeyboardShortcut": [Function],
-            "activateKeyboardShortcutGroup": [Function],
-            "allowedProgressions": Set {
-              1,
-              2,
-              3,
-              4,
-              5,
-              6,
-            },
-            "cancelEditing": [Function],
-            "comment": "Foo",
-            "complete": [Function],
-            "deactivateKeyboardShortcut": [Function],
-            "deactivateKeyboardShortcutGroup": [Function],
-            "intl": Object {
-              "formatMessage": [Function],
-            },
-            "keyboardShortcutGroups": Object {
-              "openEditor": Object {
-                "editId": Object {
-                  "key": "e",
-                  "label": Object {
-                    "defaultMessage": "Edit in Id",
-                    "id": "KeyMapping.openEditor.editId",
-                  },
-                },
-                "editJosm": Object {
-                  "key": "r",
-                  "label": Object {
-                    "defaultMessage": "Edit in JOSM",
-                    "id": "KeyMapping.openEditor.editJosm",
-                  },
-                },
-                "editJosmLayer": Object {
-                  "key": "t",
-                  "label": Object {
-                    "defaultMessage": "Edit in new JOSM layer",
-                    "id": "KeyMapping.openEditor.editJosmLayer",
-                  },
-                },
-                "editLevel0": Object {
-                  "key": "l",
-                  "label": Object {
-                    "defaultMessage": "Edit in Level0",
-                    "id": "KeyMapping.openEditor.editLevel0",
-                  },
-                },
-              },
-              "taskCompletion": Object {
-                "alreadyFixed": Object {
-                  "key": "x",
-                  "label": Object {
-                    "defaultMessage": "Already fixed",
-                    "id": "KeyMapping.taskCompletion.alreadyFixed",
-                  },
-                },
-                "falsePositive": Object {
-                  "key": "q",
-                  "label": Object {
-                    "defaultMessage": "Not an Issue",
-                    "id": "KeyMapping.taskCompletion.falsePositive",
-                  },
-                },
-                "fixed": Object {
-                  "key": "f",
-                  "label": Object {
-                    "defaultMessage": "I fixed it!",
-                    "id": "KeyMapping.taskCompletion.fixed",
-                  },
-                },
-                "skip": Object {
-                  "key": "w",
-                  "label": Object {
-                    "defaultMessage": "Skip",
-                    "id": "KeyMapping.taskCompletion.skip",
-                  },
-                },
-                "tooHard": Object {
-                  "key": "d",
-                  "label": Object {
-                    "defaultMessage": "Too difficult / Couldn't see",
-                    "id": "KeyMapping.taskCompletion.tooHard",
-                  },
-                },
-              },
-              "taskEditing": Object {
-                "cancel": Object {
-                  "key": "Escape",
-                  "keyLabel": Object {
-                    "defaultMessage": "ESC",
-                    "id": "KeyMapping.taskEditing.escapeLabel",
-                  },
-                  "label": Object {
-                    "defaultMessage": "Cancel Editing",
-                    "id": "KeyMapping.taskEditing.cancel",
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -12546,6 +12949,170 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 0,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+            },
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "alreadyFixed": Object {
+                  "key": "x",
+                  "label": Object {
+                    "defaultMessage": "Already fixed",
+                    "id": "KeyMapping.taskCompletion.alreadyFixed",
+                  },
+                },
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "fixed": Object {
+                  "key": "f",
+                  "label": Object {
+                    "defaultMessage": "I fixed it!",
+                    "id": "KeyMapping.taskCompletion.fixed",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+                "tooHard": Object {
+                  "key": "d",
+                  "label": Object {
+                    "defaultMessage": "Too difficult / Couldn't see",
+                    "id": "KeyMapping.taskCompletion.tooHard",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -12699,6 +13266,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -12848,6 +13422,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -13019,6 +13600,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -13186,6 +13774,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -13340,6 +13935,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -13492,6 +14094,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -13649,6 +14258,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -13802,6 +14418,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -13962,154 +14585,11 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
-            },
-            "taskReview": Object {
-              "nextTask": Object {
-                "key": "l",
+              "fitBounds": Object {
+                "key": "0",
                 "label": Object {
-                  "defaultMessage": "Next Task",
-                  "id": "KeyMapping.taskReview.nextTask",
-                },
-              },
-              "prevTask": Object {
-                "key": "h",
-                "label": Object {
-                  "defaultMessage": "Previous Task",
-                  "id": "KeyMapping.taskReview.prevTask",
-                },
-              },
-            },
-          },
-          "mapBounds": Object {
-            "task": Object {
-              "bounds": Array [
-                0,
-                0,
-                0,
-                0,
-              ],
-            },
-          },
-          "task": Object {
-            "id": 123,
-            "parent": Object {
-              "id": 321,
-            },
-            "status": 0,
-          },
-          "user": Object {
-            "id": 357,
-            "isLoggedIn": true,
-            "settings": Object {
-              "defaultEditor": 1,
-            },
-          },
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "class",
-        "props": Object {
-          "activateKeyboardShortcut": [Function],
-          "activateKeyboardShortcutGroup": [Function],
-          "allowedProgressions": Set {
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-          },
-          "cancelEditing": [Function],
-          "comment": "Foo",
-          "complete": [Function],
-          "deactivateKeyboardShortcut": [Function],
-          "deactivateKeyboardShortcutGroup": [Function],
-          "intl": Object {
-            "formatMessage": [Function],
-          },
-          "keyboardShortcutGroups": Object {
-            "openEditor": Object {
-              "editId": Object {
-                "key": "e",
-                "label": Object {
-                  "defaultMessage": "Edit in Id",
-                  "id": "KeyMapping.openEditor.editId",
-                },
-              },
-              "editJosm": Object {
-                "key": "r",
-                "label": Object {
-                  "defaultMessage": "Edit in JOSM",
-                  "id": "KeyMapping.openEditor.editJosm",
-                },
-              },
-              "editJosmLayer": Object {
-                "key": "t",
-                "label": Object {
-                  "defaultMessage": "Edit in new JOSM layer",
-                  "id": "KeyMapping.openEditor.editJosmLayer",
-                },
-              },
-              "editLevel0": Object {
-                "key": "l",
-                "label": Object {
-                  "defaultMessage": "Edit in Level0",
-                  "id": "KeyMapping.openEditor.editLevel0",
-                },
-              },
-            },
-            "taskCompletion": Object {
-              "alreadyFixed": Object {
-                "key": "x",
-                "label": Object {
-                  "defaultMessage": "Already fixed",
-                  "id": "KeyMapping.taskCompletion.alreadyFixed",
-                },
-              },
-              "falsePositive": Object {
-                "key": "q",
-                "label": Object {
-                  "defaultMessage": "Not an Issue",
-                  "id": "KeyMapping.taskCompletion.falsePositive",
-                },
-              },
-              "fixed": Object {
-                "key": "f",
-                "label": Object {
-                  "defaultMessage": "I fixed it!",
-                  "id": "KeyMapping.taskCompletion.fixed",
-                },
-              },
-              "skip": Object {
-                "key": "w",
-                "label": Object {
-                  "defaultMessage": "Skip",
-                  "id": "KeyMapping.taskCompletion.skip",
-                },
-              },
-              "tooHard": Object {
-                "key": "d",
-                "label": Object {
-                  "defaultMessage": "Too difficult / Couldn't see",
-                  "id": "KeyMapping.taskCompletion.tooHard",
-                },
-              },
-            },
-            "taskEditing": Object {
-              "cancel": Object {
-                "key": "Escape",
-                "keyLabel": Object {
-                  "defaultMessage": "ESC",
-                  "id": "KeyMapping.taskEditing.escapeLabel",
-                },
-                "label": Object {
-                  "defaultMessage": "Cancel Editing",
-                  "id": "KeyMapping.taskEditing.cancel",
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -14260,6 +14740,170 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          },
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "alreadyFixed": Object {
+                "key": "x",
+                "label": Object {
+                  "defaultMessage": "Already fixed",
+                  "id": "KeyMapping.taskCompletion.alreadyFixed",
+                },
+              },
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "fixed": Object {
+                "key": "f",
+                "label": Object {
+                  "defaultMessage": "I fixed it!",
+                  "id": "KeyMapping.taskCompletion.fixed",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+              "tooHard": Object {
+                "key": "d",
+                "label": Object {
+                  "defaultMessage": "Too difficult / Couldn't see",
+                  "id": "KeyMapping.taskCompletion.tooHard",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -14413,6 +15057,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -14562,6 +15213,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -14725,6 +15383,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -14879,6 +15544,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -15031,6 +15703,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -15188,6 +15867,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -15341,6 +16027,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -15501,154 +16194,11 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
-              },
-              "taskReview": Object {
-                "nextTask": Object {
-                  "key": "l",
+                "fitBounds": Object {
+                  "key": "0",
                   "label": Object {
-                    "defaultMessage": "Next Task",
-                    "id": "KeyMapping.taskReview.nextTask",
-                  },
-                },
-                "prevTask": Object {
-                  "key": "h",
-                  "label": Object {
-                    "defaultMessage": "Previous Task",
-                    "id": "KeyMapping.taskReview.prevTask",
-                  },
-                },
-              },
-            },
-            "mapBounds": Object {
-              "task": Object {
-                "bounds": Array [
-                  0,
-                  0,
-                  0,
-                  0,
-                ],
-              },
-            },
-            "task": Object {
-              "id": 123,
-              "parent": Object {
-                "id": 321,
-              },
-              "status": 0,
-            },
-            "user": Object {
-              "id": 357,
-              "isLoggedIn": true,
-              "settings": Object {
-                "defaultEditor": 1,
-              },
-            },
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "activateKeyboardShortcut": [Function],
-            "activateKeyboardShortcutGroup": [Function],
-            "allowedProgressions": Set {
-              1,
-              2,
-              3,
-              4,
-              5,
-              6,
-            },
-            "cancelEditing": [Function],
-            "comment": "Foo",
-            "complete": [Function],
-            "deactivateKeyboardShortcut": [Function],
-            "deactivateKeyboardShortcutGroup": [Function],
-            "intl": Object {
-              "formatMessage": [Function],
-            },
-            "keyboardShortcutGroups": Object {
-              "openEditor": Object {
-                "editId": Object {
-                  "key": "e",
-                  "label": Object {
-                    "defaultMessage": "Edit in Id",
-                    "id": "KeyMapping.openEditor.editId",
-                  },
-                },
-                "editJosm": Object {
-                  "key": "r",
-                  "label": Object {
-                    "defaultMessage": "Edit in JOSM",
-                    "id": "KeyMapping.openEditor.editJosm",
-                  },
-                },
-                "editJosmLayer": Object {
-                  "key": "t",
-                  "label": Object {
-                    "defaultMessage": "Edit in new JOSM layer",
-                    "id": "KeyMapping.openEditor.editJosmLayer",
-                  },
-                },
-                "editLevel0": Object {
-                  "key": "l",
-                  "label": Object {
-                    "defaultMessage": "Edit in Level0",
-                    "id": "KeyMapping.openEditor.editLevel0",
-                  },
-                },
-              },
-              "taskCompletion": Object {
-                "alreadyFixed": Object {
-                  "key": "x",
-                  "label": Object {
-                    "defaultMessage": "Already fixed",
-                    "id": "KeyMapping.taskCompletion.alreadyFixed",
-                  },
-                },
-                "falsePositive": Object {
-                  "key": "q",
-                  "label": Object {
-                    "defaultMessage": "Not an Issue",
-                    "id": "KeyMapping.taskCompletion.falsePositive",
-                  },
-                },
-                "fixed": Object {
-                  "key": "f",
-                  "label": Object {
-                    "defaultMessage": "I fixed it!",
-                    "id": "KeyMapping.taskCompletion.fixed",
-                  },
-                },
-                "skip": Object {
-                  "key": "w",
-                  "label": Object {
-                    "defaultMessage": "Skip",
-                    "id": "KeyMapping.taskCompletion.skip",
-                  },
-                },
-                "tooHard": Object {
-                  "key": "d",
-                  "label": Object {
-                    "defaultMessage": "Too difficult / Couldn't see",
-                    "id": "KeyMapping.taskCompletion.tooHard",
-                  },
-                },
-              },
-              "taskEditing": Object {
-                "cancel": Object {
-                  "key": "Escape",
-                  "keyLabel": Object {
-                    "defaultMessage": "ESC",
-                    "id": "KeyMapping.taskEditing.escapeLabel",
-                  },
-                  "label": Object {
-                    "defaultMessage": "Cancel Editing",
-                    "id": "KeyMapping.taskEditing.cancel",
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -15799,6 +16349,170 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 0,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+            },
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "alreadyFixed": Object {
+                  "key": "x",
+                  "label": Object {
+                    "defaultMessage": "Already fixed",
+                    "id": "KeyMapping.taskCompletion.alreadyFixed",
+                  },
+                },
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "fixed": Object {
+                  "key": "f",
+                  "label": Object {
+                    "defaultMessage": "I fixed it!",
+                    "id": "KeyMapping.taskCompletion.fixed",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+                "tooHard": Object {
+                  "key": "d",
+                  "label": Object {
+                    "defaultMessage": "Too difficult / Couldn't see",
+                    "id": "KeyMapping.taskCompletion.tooHard",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -15952,6 +16666,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -16101,6 +16822,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -16272,6 +17000,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -16439,6 +17174,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -16593,6 +17335,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -16745,6 +17494,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -16902,6 +17658,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -17055,6 +17818,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -17215,154 +17985,11 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
-            },
-            "taskReview": Object {
-              "nextTask": Object {
-                "key": "l",
+              "fitBounds": Object {
+                "key": "0",
                 "label": Object {
-                  "defaultMessage": "Next Task",
-                  "id": "KeyMapping.taskReview.nextTask",
-                },
-              },
-              "prevTask": Object {
-                "key": "h",
-                "label": Object {
-                  "defaultMessage": "Previous Task",
-                  "id": "KeyMapping.taskReview.prevTask",
-                },
-              },
-            },
-          },
-          "mapBounds": Object {
-            "task": Object {
-              "bounds": Array [
-                0,
-                0,
-                0,
-                0,
-              ],
-            },
-          },
-          "task": Object {
-            "id": 123,
-            "parent": Object {
-              "id": 321,
-            },
-            "status": 0,
-          },
-          "user": Object {
-            "id": 357,
-            "isLoggedIn": true,
-            "settings": Object {
-              "defaultEditor": 1,
-            },
-          },
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "class",
-        "props": Object {
-          "activateKeyboardShortcut": [Function],
-          "activateKeyboardShortcutGroup": [Function],
-          "allowedProgressions": Set {
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-          },
-          "cancelEditing": [Function],
-          "comment": "Foo",
-          "complete": [Function],
-          "deactivateKeyboardShortcut": [Function],
-          "deactivateKeyboardShortcutGroup": [Function],
-          "intl": Object {
-            "formatMessage": [Function],
-          },
-          "keyboardShortcutGroups": Object {
-            "openEditor": Object {
-              "editId": Object {
-                "key": "e",
-                "label": Object {
-                  "defaultMessage": "Edit in Id",
-                  "id": "KeyMapping.openEditor.editId",
-                },
-              },
-              "editJosm": Object {
-                "key": "r",
-                "label": Object {
-                  "defaultMessage": "Edit in JOSM",
-                  "id": "KeyMapping.openEditor.editJosm",
-                },
-              },
-              "editJosmLayer": Object {
-                "key": "t",
-                "label": Object {
-                  "defaultMessage": "Edit in new JOSM layer",
-                  "id": "KeyMapping.openEditor.editJosmLayer",
-                },
-              },
-              "editLevel0": Object {
-                "key": "l",
-                "label": Object {
-                  "defaultMessage": "Edit in Level0",
-                  "id": "KeyMapping.openEditor.editLevel0",
-                },
-              },
-            },
-            "taskCompletion": Object {
-              "alreadyFixed": Object {
-                "key": "x",
-                "label": Object {
-                  "defaultMessage": "Already fixed",
-                  "id": "KeyMapping.taskCompletion.alreadyFixed",
-                },
-              },
-              "falsePositive": Object {
-                "key": "q",
-                "label": Object {
-                  "defaultMessage": "Not an Issue",
-                  "id": "KeyMapping.taskCompletion.falsePositive",
-                },
-              },
-              "fixed": Object {
-                "key": "f",
-                "label": Object {
-                  "defaultMessage": "I fixed it!",
-                  "id": "KeyMapping.taskCompletion.fixed",
-                },
-              },
-              "skip": Object {
-                "key": "w",
-                "label": Object {
-                  "defaultMessage": "Skip",
-                  "id": "KeyMapping.taskCompletion.skip",
-                },
-              },
-              "tooHard": Object {
-                "key": "d",
-                "label": Object {
-                  "defaultMessage": "Too difficult / Couldn't see",
-                  "id": "KeyMapping.taskCompletion.tooHard",
-                },
-              },
-            },
-            "taskEditing": Object {
-              "cancel": Object {
-                "key": "Escape",
-                "keyLabel": Object {
-                  "defaultMessage": "ESC",
-                  "id": "KeyMapping.taskEditing.escapeLabel",
-                },
-                "label": Object {
-                  "defaultMessage": "Cancel Editing",
-                  "id": "KeyMapping.taskEditing.cancel",
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -17513,6 +18140,170 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
+            },
+            "taskReview": Object {
+              "nextTask": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Next Task",
+                  "id": "KeyMapping.taskReview.nextTask",
+                },
+              },
+              "prevTask": Object {
+                "key": "h",
+                "label": Object {
+                  "defaultMessage": "Previous Task",
+                  "id": "KeyMapping.taskReview.prevTask",
+                },
+              },
+            },
+          },
+          "mapBounds": Object {
+            "task": Object {
+              "bounds": Array [
+                0,
+                0,
+                0,
+                0,
+              ],
+            },
+          },
+          "task": Object {
+            "id": 123,
+            "parent": Object {
+              "id": 321,
+            },
+            "status": 0,
+          },
+          "user": Object {
+            "id": 357,
+            "isLoggedIn": true,
+            "settings": Object {
+              "defaultEditor": 1,
+            },
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "activateKeyboardShortcut": [Function],
+          "activateKeyboardShortcutGroup": [Function],
+          "allowedProgressions": Set {
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+          },
+          "cancelEditing": [Function],
+          "comment": "Foo",
+          "complete": [Function],
+          "deactivateKeyboardShortcut": [Function],
+          "deactivateKeyboardShortcutGroup": [Function],
+          "intl": Object {
+            "formatMessage": [Function],
+          },
+          "keyboardShortcutGroups": Object {
+            "openEditor": Object {
+              "editId": Object {
+                "key": "e",
+                "label": Object {
+                  "defaultMessage": "Edit in Id",
+                  "id": "KeyMapping.openEditor.editId",
+                },
+              },
+              "editJosm": Object {
+                "key": "r",
+                "label": Object {
+                  "defaultMessage": "Edit in JOSM",
+                  "id": "KeyMapping.openEditor.editJosm",
+                },
+              },
+              "editJosmLayer": Object {
+                "key": "t",
+                "label": Object {
+                  "defaultMessage": "Edit in new JOSM layer",
+                  "id": "KeyMapping.openEditor.editJosmLayer",
+                },
+              },
+              "editLevel0": Object {
+                "key": "l",
+                "label": Object {
+                  "defaultMessage": "Edit in Level0",
+                  "id": "KeyMapping.openEditor.editLevel0",
+                },
+              },
+            },
+            "taskCompletion": Object {
+              "alreadyFixed": Object {
+                "key": "x",
+                "label": Object {
+                  "defaultMessage": "Already fixed",
+                  "id": "KeyMapping.taskCompletion.alreadyFixed",
+                },
+              },
+              "falsePositive": Object {
+                "key": "q",
+                "label": Object {
+                  "defaultMessage": "Not an Issue",
+                  "id": "KeyMapping.taskCompletion.falsePositive",
+                },
+              },
+              "fixed": Object {
+                "key": "f",
+                "label": Object {
+                  "defaultMessage": "I fixed it!",
+                  "id": "KeyMapping.taskCompletion.fixed",
+                },
+              },
+              "skip": Object {
+                "key": "w",
+                "label": Object {
+                  "defaultMessage": "Skip",
+                  "id": "KeyMapping.taskCompletion.skip",
+                },
+              },
+              "tooHard": Object {
+                "key": "d",
+                "label": Object {
+                  "defaultMessage": "Too difficult / Couldn't see",
+                  "id": "KeyMapping.taskCompletion.tooHard",
+                },
+              },
+            },
+            "taskEditing": Object {
+              "cancel": Object {
+                "key": "Escape",
+                "keyLabel": Object {
+                  "defaultMessage": "ESC",
+                  "id": "KeyMapping.taskEditing.escapeLabel",
+                },
+                "label": Object {
+                  "defaultMessage": "Cancel Editing",
+                  "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -17666,6 +18457,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -17815,6 +18613,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -17978,6 +18783,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -18132,6 +18944,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -18284,6 +19103,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -18441,6 +19267,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -18594,6 +19427,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -18754,154 +19594,11 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
-              },
-              "taskReview": Object {
-                "nextTask": Object {
-                  "key": "l",
+                "fitBounds": Object {
+                  "key": "0",
                   "label": Object {
-                    "defaultMessage": "Next Task",
-                    "id": "KeyMapping.taskReview.nextTask",
-                  },
-                },
-                "prevTask": Object {
-                  "key": "h",
-                  "label": Object {
-                    "defaultMessage": "Previous Task",
-                    "id": "KeyMapping.taskReview.prevTask",
-                  },
-                },
-              },
-            },
-            "mapBounds": Object {
-              "task": Object {
-                "bounds": Array [
-                  0,
-                  0,
-                  0,
-                  0,
-                ],
-              },
-            },
-            "task": Object {
-              "id": 123,
-              "parent": Object {
-                "id": 321,
-              },
-              "status": 0,
-            },
-            "user": Object {
-              "id": 357,
-              "isLoggedIn": true,
-              "settings": Object {
-                "defaultEditor": 1,
-              },
-            },
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "activateKeyboardShortcut": [Function],
-            "activateKeyboardShortcutGroup": [Function],
-            "allowedProgressions": Set {
-              1,
-              2,
-              3,
-              4,
-              5,
-              6,
-            },
-            "cancelEditing": [Function],
-            "comment": "Foo",
-            "complete": [Function],
-            "deactivateKeyboardShortcut": [Function],
-            "deactivateKeyboardShortcutGroup": [Function],
-            "intl": Object {
-              "formatMessage": [Function],
-            },
-            "keyboardShortcutGroups": Object {
-              "openEditor": Object {
-                "editId": Object {
-                  "key": "e",
-                  "label": Object {
-                    "defaultMessage": "Edit in Id",
-                    "id": "KeyMapping.openEditor.editId",
-                  },
-                },
-                "editJosm": Object {
-                  "key": "r",
-                  "label": Object {
-                    "defaultMessage": "Edit in JOSM",
-                    "id": "KeyMapping.openEditor.editJosm",
-                  },
-                },
-                "editJosmLayer": Object {
-                  "key": "t",
-                  "label": Object {
-                    "defaultMessage": "Edit in new JOSM layer",
-                    "id": "KeyMapping.openEditor.editJosmLayer",
-                  },
-                },
-                "editLevel0": Object {
-                  "key": "l",
-                  "label": Object {
-                    "defaultMessage": "Edit in Level0",
-                    "id": "KeyMapping.openEditor.editLevel0",
-                  },
-                },
-              },
-              "taskCompletion": Object {
-                "alreadyFixed": Object {
-                  "key": "x",
-                  "label": Object {
-                    "defaultMessage": "Already fixed",
-                    "id": "KeyMapping.taskCompletion.alreadyFixed",
-                  },
-                },
-                "falsePositive": Object {
-                  "key": "q",
-                  "label": Object {
-                    "defaultMessage": "Not an Issue",
-                    "id": "KeyMapping.taskCompletion.falsePositive",
-                  },
-                },
-                "fixed": Object {
-                  "key": "f",
-                  "label": Object {
-                    "defaultMessage": "I fixed it!",
-                    "id": "KeyMapping.taskCompletion.fixed",
-                  },
-                },
-                "skip": Object {
-                  "key": "w",
-                  "label": Object {
-                    "defaultMessage": "Skip",
-                    "id": "KeyMapping.taskCompletion.skip",
-                  },
-                },
-                "tooHard": Object {
-                  "key": "d",
-                  "label": Object {
-                    "defaultMessage": "Too difficult / Couldn't see",
-                    "id": "KeyMapping.taskCompletion.tooHard",
-                  },
-                },
-              },
-              "taskEditing": Object {
-                "cancel": Object {
-                  "key": "Escape",
-                  "keyLabel": Object {
-                    "defaultMessage": "ESC",
-                    "id": "KeyMapping.taskEditing.escapeLabel",
-                  },
-                  "label": Object {
-                    "defaultMessage": "Cancel Editing",
-                    "id": "KeyMapping.taskEditing.cancel",
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -19052,6 +19749,170 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
+              },
+              "taskReview": Object {
+                "nextTask": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Next Task",
+                    "id": "KeyMapping.taskReview.nextTask",
+                  },
+                },
+                "prevTask": Object {
+                  "key": "h",
+                  "label": Object {
+                    "defaultMessage": "Previous Task",
+                    "id": "KeyMapping.taskReview.prevTask",
+                  },
+                },
+              },
+            },
+            "mapBounds": Object {
+              "task": Object {
+                "bounds": Array [
+                  0,
+                  0,
+                  0,
+                  0,
+                ],
+              },
+            },
+            "task": Object {
+              "id": 123,
+              "parent": Object {
+                "id": 321,
+              },
+              "status": 0,
+            },
+            "user": Object {
+              "id": 357,
+              "isLoggedIn": true,
+              "settings": Object {
+                "defaultEditor": 1,
+              },
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "activateKeyboardShortcut": [Function],
+            "activateKeyboardShortcutGroup": [Function],
+            "allowedProgressions": Set {
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+            },
+            "cancelEditing": [Function],
+            "comment": "Foo",
+            "complete": [Function],
+            "deactivateKeyboardShortcut": [Function],
+            "deactivateKeyboardShortcutGroup": [Function],
+            "intl": Object {
+              "formatMessage": [Function],
+            },
+            "keyboardShortcutGroups": Object {
+              "openEditor": Object {
+                "editId": Object {
+                  "key": "e",
+                  "label": Object {
+                    "defaultMessage": "Edit in Id",
+                    "id": "KeyMapping.openEditor.editId",
+                  },
+                },
+                "editJosm": Object {
+                  "key": "r",
+                  "label": Object {
+                    "defaultMessage": "Edit in JOSM",
+                    "id": "KeyMapping.openEditor.editJosm",
+                  },
+                },
+                "editJosmLayer": Object {
+                  "key": "t",
+                  "label": Object {
+                    "defaultMessage": "Edit in new JOSM layer",
+                    "id": "KeyMapping.openEditor.editJosmLayer",
+                  },
+                },
+                "editLevel0": Object {
+                  "key": "l",
+                  "label": Object {
+                    "defaultMessage": "Edit in Level0",
+                    "id": "KeyMapping.openEditor.editLevel0",
+                  },
+                },
+              },
+              "taskCompletion": Object {
+                "alreadyFixed": Object {
+                  "key": "x",
+                  "label": Object {
+                    "defaultMessage": "Already fixed",
+                    "id": "KeyMapping.taskCompletion.alreadyFixed",
+                  },
+                },
+                "falsePositive": Object {
+                  "key": "q",
+                  "label": Object {
+                    "defaultMessage": "Not an Issue",
+                    "id": "KeyMapping.taskCompletion.falsePositive",
+                  },
+                },
+                "fixed": Object {
+                  "key": "f",
+                  "label": Object {
+                    "defaultMessage": "I fixed it!",
+                    "id": "KeyMapping.taskCompletion.fixed",
+                  },
+                },
+                "skip": Object {
+                  "key": "w",
+                  "label": Object {
+                    "defaultMessage": "Skip",
+                    "id": "KeyMapping.taskCompletion.skip",
+                  },
+                },
+                "tooHard": Object {
+                  "key": "d",
+                  "label": Object {
+                    "defaultMessage": "Too difficult / Couldn't see",
+                    "id": "KeyMapping.taskCompletion.tooHard",
+                  },
+                },
+              },
+              "taskEditing": Object {
+                "cancel": Object {
+                  "key": "Escape",
+                  "keyLabel": Object {
+                    "defaultMessage": "ESC",
+                    "id": "KeyMapping.taskEditing.escapeLabel",
+                  },
+                  "label": Object {
+                    "defaultMessage": "Cancel Editing",
+                    "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -19205,6 +20066,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -19354,6 +20222,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskEditControl/__snapshots__/TaskEditControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskEditControl/__snapshots__/TaskEditControl.test.js.snap
@@ -93,6 +93,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -541,6 +548,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -865,6 +879,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFalsePositiveControl/__snapshots__/TaskFalsePositiveControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFalsePositiveControl/__snapshots__/TaskFalsePositiveControl.test.js.snap
@@ -95,6 +95,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFixedControl/__snapshots__/TaskFixedControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFixedControl/__snapshots__/TaskFixedControl.test.js.snap
@@ -94,6 +94,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskSkipControl/__snapshots__/TaskSkipControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskSkipControl/__snapshots__/TaskSkipControl.test.js.snap
@@ -95,6 +95,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskTooHardControl/__snapshots__/TaskTooHardControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskTooHardControl/__snapshots__/TaskTooHardControl.test.js.snap
@@ -94,6 +94,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/__snapshots__/ActiveTaskControls.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/__snapshots__/ActiveTaskControls.test.js.snap
@@ -98,6 +98,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -289,6 +296,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -454,6 +468,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -616,6 +637,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -770,6 +798,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -919,6 +954,13 @@ ShallowWrapper {
                                             "label": Object {
                                               "defaultMessage": "Cancel Editing",
                                               "id": "KeyMapping.taskEditing.cancel",
+                                            },
+                                          },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
                                             },
                                           },
                                         },
@@ -1071,6 +1113,13 @@ ShallowWrapper {
                                               "id": "KeyMapping.taskEditing.cancel",
                                             },
                                           },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
+                                            },
+                                          },
                                         },
                                         "taskReview": Object {
                                           "nextTask": Object {
@@ -1221,6 +1270,13 @@ ShallowWrapper {
                                               "id": "KeyMapping.taskEditing.cancel",
                                             },
                                           },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
+                                            },
+                                          },
                                         },
                                         "taskReview": Object {
                                           "nextTask": Object {
@@ -1369,6 +1425,13 @@ ShallowWrapper {
                                             "label": Object {
                                               "defaultMessage": "Cancel Editing",
                                               "id": "KeyMapping.taskEditing.cancel",
+                                            },
+                                          },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
                                             },
                                           },
                                         },
@@ -1530,6 +1593,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -1686,6 +1756,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -1847,6 +1924,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -1995,6 +2079,13 @@ ShallowWrapper {
                                               "label": Object {
                                                 "defaultMessage": "Cancel Editing",
                                                 "id": "KeyMapping.taskEditing.cancel",
+                                              },
+                                            },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
                                               },
                                             },
                                           },
@@ -2147,6 +2238,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -2297,6 +2395,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -2441,6 +2546,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -2590,152 +2702,11 @@ ShallowWrapper {
                       "id": "KeyMapping.taskEditing.cancel",
                     },
                   },
-                },
-                "taskReview": Object {
-                  "nextTask": Object {
-                    "key": "l",
+                  "fitBounds": Object {
+                    "key": "0",
                     "label": Object {
-                      "defaultMessage": "Next Task",
-                      "id": "KeyMapping.taskReview.nextTask",
-                    },
-                  },
-                  "prevTask": Object {
-                    "key": "h",
-                    "label": Object {
-                      "defaultMessage": "Previous Task",
-                      "id": "KeyMapping.taskReview.prevTask",
-                    },
-                  },
-                },
-              },
-              "mapBounds": Object {
-                "task": Object {
-                  "bounds": Array [
-                    0,
-                    0,
-                    0,
-                    0,
-                  ],
-                },
-              },
-              "nextTask": [Function],
-              "saveTask": [Function],
-              "setTaskBeingCompleted": [Function],
-              "setTaskLoadBy": [Function],
-              "task": Object {
-                "id": 123,
-                "parent": Object {
-                  "id": 321,
-                },
-                "status": 0,
-              },
-              "taskLoadBy": "random",
-              "unsaveTask": [Function],
-              "user": Object {
-                "id": 357,
-                "isLoggedIn": true,
-                "settings": Object {
-                  "defaultEditor": 1,
-                },
-              },
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "activateKeyboardShortcutGroup": [Function],
-              "challengeId": 321,
-              "closeEditor": [Function],
-              "completeTask": [Function],
-              "deactivateKeyboardShortcutGroup": [Function],
-              "editTask": [Function],
-              "editor": Object {},
-              "intl": Object {
-                "formatMessage": [Function],
-              },
-              "keyboardShortcutGroups": Object {
-                "openEditor": Object {
-                  "editId": Object {
-                    "key": "e",
-                    "label": Object {
-                      "defaultMessage": "Edit in Id",
-                      "id": "KeyMapping.openEditor.editId",
-                    },
-                  },
-                  "editJosm": Object {
-                    "key": "r",
-                    "label": Object {
-                      "defaultMessage": "Edit in JOSM",
-                      "id": "KeyMapping.openEditor.editJosm",
-                    },
-                  },
-                  "editJosmLayer": Object {
-                    "key": "t",
-                    "label": Object {
-                      "defaultMessage": "Edit in new JOSM layer",
-                      "id": "KeyMapping.openEditor.editJosmLayer",
-                    },
-                  },
-                  "editLevel0": Object {
-                    "key": "l",
-                    "label": Object {
-                      "defaultMessage": "Edit in Level0",
-                      "id": "KeyMapping.openEditor.editLevel0",
-                    },
-                  },
-                },
-                "taskCompletion": Object {
-                  "alreadyFixed": Object {
-                    "key": "x",
-                    "label": Object {
-                      "defaultMessage": "Already fixed",
-                      "id": "KeyMapping.taskCompletion.alreadyFixed",
-                    },
-                  },
-                  "falsePositive": Object {
-                    "key": "q",
-                    "label": Object {
-                      "defaultMessage": "Not an Issue",
-                      "id": "KeyMapping.taskCompletion.falsePositive",
-                    },
-                  },
-                  "fixed": Object {
-                    "key": "f",
-                    "label": Object {
-                      "defaultMessage": "I fixed it!",
-                      "id": "KeyMapping.taskCompletion.fixed",
-                    },
-                  },
-                  "skip": Object {
-                    "key": "w",
-                    "label": Object {
-                      "defaultMessage": "Skip",
-                      "id": "KeyMapping.taskCompletion.skip",
-                    },
-                  },
-                  "tooHard": Object {
-                    "key": "d",
-                    "label": Object {
-                      "defaultMessage": "Too difficult / Couldn't see",
-                      "id": "KeyMapping.taskCompletion.tooHard",
-                    },
-                  },
-                },
-                "taskEditing": Object {
-                  "cancel": Object {
-                    "key": "Escape",
-                    "keyLabel": Object {
-                      "defaultMessage": "ESC",
-                      "id": "KeyMapping.taskEditing.escapeLabel",
-                    },
-                    "label": Object {
-                      "defaultMessage": "Cancel Editing",
-                      "id": "KeyMapping.taskEditing.cancel",
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
                     },
                   },
                 },
@@ -2886,6 +2857,13 @@ ShallowWrapper {
                       "id": "KeyMapping.taskEditing.cancel",
                     },
                   },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
+                    },
+                  },
                 },
                 "taskReview": Object {
                   "nextTask": Object {
@@ -3032,6 +3010,168 @@ ShallowWrapper {
                     "label": Object {
                       "defaultMessage": "Cancel Editing",
                       "id": "KeyMapping.taskEditing.cancel",
+                    },
+                  },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
+                    },
+                  },
+                },
+                "taskReview": Object {
+                  "nextTask": Object {
+                    "key": "l",
+                    "label": Object {
+                      "defaultMessage": "Next Task",
+                      "id": "KeyMapping.taskReview.nextTask",
+                    },
+                  },
+                  "prevTask": Object {
+                    "key": "h",
+                    "label": Object {
+                      "defaultMessage": "Previous Task",
+                      "id": "KeyMapping.taskReview.prevTask",
+                    },
+                  },
+                },
+              },
+              "mapBounds": Object {
+                "task": Object {
+                  "bounds": Array [
+                    0,
+                    0,
+                    0,
+                    0,
+                  ],
+                },
+              },
+              "nextTask": [Function],
+              "saveTask": [Function],
+              "setTaskBeingCompleted": [Function],
+              "setTaskLoadBy": [Function],
+              "task": Object {
+                "id": 123,
+                "parent": Object {
+                  "id": 321,
+                },
+                "status": 0,
+              },
+              "taskLoadBy": "random",
+              "unsaveTask": [Function],
+              "user": Object {
+                "id": 357,
+                "isLoggedIn": true,
+                "settings": Object {
+                  "defaultEditor": 1,
+                },
+              },
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "activateKeyboardShortcutGroup": [Function],
+              "challengeId": 321,
+              "closeEditor": [Function],
+              "completeTask": [Function],
+              "deactivateKeyboardShortcutGroup": [Function],
+              "editTask": [Function],
+              "editor": Object {},
+              "intl": Object {
+                "formatMessage": [Function],
+              },
+              "keyboardShortcutGroups": Object {
+                "openEditor": Object {
+                  "editId": Object {
+                    "key": "e",
+                    "label": Object {
+                      "defaultMessage": "Edit in Id",
+                      "id": "KeyMapping.openEditor.editId",
+                    },
+                  },
+                  "editJosm": Object {
+                    "key": "r",
+                    "label": Object {
+                      "defaultMessage": "Edit in JOSM",
+                      "id": "KeyMapping.openEditor.editJosm",
+                    },
+                  },
+                  "editJosmLayer": Object {
+                    "key": "t",
+                    "label": Object {
+                      "defaultMessage": "Edit in new JOSM layer",
+                      "id": "KeyMapping.openEditor.editJosmLayer",
+                    },
+                  },
+                  "editLevel0": Object {
+                    "key": "l",
+                    "label": Object {
+                      "defaultMessage": "Edit in Level0",
+                      "id": "KeyMapping.openEditor.editLevel0",
+                    },
+                  },
+                },
+                "taskCompletion": Object {
+                  "alreadyFixed": Object {
+                    "key": "x",
+                    "label": Object {
+                      "defaultMessage": "Already fixed",
+                      "id": "KeyMapping.taskCompletion.alreadyFixed",
+                    },
+                  },
+                  "falsePositive": Object {
+                    "key": "q",
+                    "label": Object {
+                      "defaultMessage": "Not an Issue",
+                      "id": "KeyMapping.taskCompletion.falsePositive",
+                    },
+                  },
+                  "fixed": Object {
+                    "key": "f",
+                    "label": Object {
+                      "defaultMessage": "I fixed it!",
+                      "id": "KeyMapping.taskCompletion.fixed",
+                    },
+                  },
+                  "skip": Object {
+                    "key": "w",
+                    "label": Object {
+                      "defaultMessage": "Skip",
+                      "id": "KeyMapping.taskCompletion.skip",
+                    },
+                  },
+                  "tooHard": Object {
+                    "key": "d",
+                    "label": Object {
+                      "defaultMessage": "Too difficult / Couldn't see",
+                      "id": "KeyMapping.taskCompletion.tooHard",
+                    },
+                  },
+                },
+                "taskEditing": Object {
+                  "cancel": Object {
+                    "key": "Escape",
+                    "keyLabel": Object {
+                      "defaultMessage": "ESC",
+                      "id": "KeyMapping.taskEditing.escapeLabel",
+                    },
+                    "label": Object {
+                      "defaultMessage": "Cancel Editing",
+                      "id": "KeyMapping.taskEditing.cancel",
+                    },
+                  },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
                     },
                   },
                 },
@@ -3196,6 +3336,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -3358,6 +3505,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -3512,6 +3666,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -3661,6 +3822,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -3813,6 +3981,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -3963,6 +4138,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -4111,6 +4293,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -4272,6 +4461,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -4428,6 +4624,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -4589,6 +4792,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -4737,6 +4947,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -4889,6 +5106,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -5039,6 +5263,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -5183,6 +5414,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -5332,152 +5570,11 @@ ShallowWrapper {
                         "id": "KeyMapping.taskEditing.cancel",
                       },
                     },
-                  },
-                  "taskReview": Object {
-                    "nextTask": Object {
-                      "key": "l",
+                    "fitBounds": Object {
+                      "key": "0",
                       "label": Object {
-                        "defaultMessage": "Next Task",
-                        "id": "KeyMapping.taskReview.nextTask",
-                      },
-                    },
-                    "prevTask": Object {
-                      "key": "h",
-                      "label": Object {
-                        "defaultMessage": "Previous Task",
-                        "id": "KeyMapping.taskReview.prevTask",
-                      },
-                    },
-                  },
-                },
-                "mapBounds": Object {
-                  "task": Object {
-                    "bounds": Array [
-                      0,
-                      0,
-                      0,
-                      0,
-                    ],
-                  },
-                },
-                "nextTask": [Function],
-                "saveTask": [Function],
-                "setTaskBeingCompleted": [Function],
-                "setTaskLoadBy": [Function],
-                "task": Object {
-                  "id": 123,
-                  "parent": Object {
-                    "id": 321,
-                  },
-                  "status": 0,
-                },
-                "taskLoadBy": "random",
-                "unsaveTask": [Function],
-                "user": Object {
-                  "id": 357,
-                  "isLoggedIn": true,
-                  "settings": Object {
-                    "defaultEditor": 1,
-                  },
-                },
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "activateKeyboardShortcutGroup": [Function],
-                "challengeId": 321,
-                "closeEditor": [Function],
-                "completeTask": [Function],
-                "deactivateKeyboardShortcutGroup": [Function],
-                "editTask": [Function],
-                "editor": Object {},
-                "intl": Object {
-                  "formatMessage": [Function],
-                },
-                "keyboardShortcutGroups": Object {
-                  "openEditor": Object {
-                    "editId": Object {
-                      "key": "e",
-                      "label": Object {
-                        "defaultMessage": "Edit in Id",
-                        "id": "KeyMapping.openEditor.editId",
-                      },
-                    },
-                    "editJosm": Object {
-                      "key": "r",
-                      "label": Object {
-                        "defaultMessage": "Edit in JOSM",
-                        "id": "KeyMapping.openEditor.editJosm",
-                      },
-                    },
-                    "editJosmLayer": Object {
-                      "key": "t",
-                      "label": Object {
-                        "defaultMessage": "Edit in new JOSM layer",
-                        "id": "KeyMapping.openEditor.editJosmLayer",
-                      },
-                    },
-                    "editLevel0": Object {
-                      "key": "l",
-                      "label": Object {
-                        "defaultMessage": "Edit in Level0",
-                        "id": "KeyMapping.openEditor.editLevel0",
-                      },
-                    },
-                  },
-                  "taskCompletion": Object {
-                    "alreadyFixed": Object {
-                      "key": "x",
-                      "label": Object {
-                        "defaultMessage": "Already fixed",
-                        "id": "KeyMapping.taskCompletion.alreadyFixed",
-                      },
-                    },
-                    "falsePositive": Object {
-                      "key": "q",
-                      "label": Object {
-                        "defaultMessage": "Not an Issue",
-                        "id": "KeyMapping.taskCompletion.falsePositive",
-                      },
-                    },
-                    "fixed": Object {
-                      "key": "f",
-                      "label": Object {
-                        "defaultMessage": "I fixed it!",
-                        "id": "KeyMapping.taskCompletion.fixed",
-                      },
-                    },
-                    "skip": Object {
-                      "key": "w",
-                      "label": Object {
-                        "defaultMessage": "Skip",
-                        "id": "KeyMapping.taskCompletion.skip",
-                      },
-                    },
-                    "tooHard": Object {
-                      "key": "d",
-                      "label": Object {
-                        "defaultMessage": "Too difficult / Couldn't see",
-                        "id": "KeyMapping.taskCompletion.tooHard",
-                      },
-                    },
-                  },
-                  "taskEditing": Object {
-                    "cancel": Object {
-                      "key": "Escape",
-                      "keyLabel": Object {
-                        "defaultMessage": "ESC",
-                        "id": "KeyMapping.taskEditing.escapeLabel",
-                      },
-                      "label": Object {
-                        "defaultMessage": "Cancel Editing",
-                        "id": "KeyMapping.taskEditing.cancel",
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
                       },
                     },
                   },
@@ -5628,6 +5725,13 @@ ShallowWrapper {
                         "id": "KeyMapping.taskEditing.cancel",
                       },
                     },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
+                      },
+                    },
                   },
                   "taskReview": Object {
                     "nextTask": Object {
@@ -5774,6 +5878,168 @@ ShallowWrapper {
                       "label": Object {
                         "defaultMessage": "Cancel Editing",
                         "id": "KeyMapping.taskEditing.cancel",
+                      },
+                    },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
+                      },
+                    },
+                  },
+                  "taskReview": Object {
+                    "nextTask": Object {
+                      "key": "l",
+                      "label": Object {
+                        "defaultMessage": "Next Task",
+                        "id": "KeyMapping.taskReview.nextTask",
+                      },
+                    },
+                    "prevTask": Object {
+                      "key": "h",
+                      "label": Object {
+                        "defaultMessage": "Previous Task",
+                        "id": "KeyMapping.taskReview.prevTask",
+                      },
+                    },
+                  },
+                },
+                "mapBounds": Object {
+                  "task": Object {
+                    "bounds": Array [
+                      0,
+                      0,
+                      0,
+                      0,
+                    ],
+                  },
+                },
+                "nextTask": [Function],
+                "saveTask": [Function],
+                "setTaskBeingCompleted": [Function],
+                "setTaskLoadBy": [Function],
+                "task": Object {
+                  "id": 123,
+                  "parent": Object {
+                    "id": 321,
+                  },
+                  "status": 0,
+                },
+                "taskLoadBy": "random",
+                "unsaveTask": [Function],
+                "user": Object {
+                  "id": 357,
+                  "isLoggedIn": true,
+                  "settings": Object {
+                    "defaultEditor": 1,
+                  },
+                },
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "activateKeyboardShortcutGroup": [Function],
+                "challengeId": 321,
+                "closeEditor": [Function],
+                "completeTask": [Function],
+                "deactivateKeyboardShortcutGroup": [Function],
+                "editTask": [Function],
+                "editor": Object {},
+                "intl": Object {
+                  "formatMessage": [Function],
+                },
+                "keyboardShortcutGroups": Object {
+                  "openEditor": Object {
+                    "editId": Object {
+                      "key": "e",
+                      "label": Object {
+                        "defaultMessage": "Edit in Id",
+                        "id": "KeyMapping.openEditor.editId",
+                      },
+                    },
+                    "editJosm": Object {
+                      "key": "r",
+                      "label": Object {
+                        "defaultMessage": "Edit in JOSM",
+                        "id": "KeyMapping.openEditor.editJosm",
+                      },
+                    },
+                    "editJosmLayer": Object {
+                      "key": "t",
+                      "label": Object {
+                        "defaultMessage": "Edit in new JOSM layer",
+                        "id": "KeyMapping.openEditor.editJosmLayer",
+                      },
+                    },
+                    "editLevel0": Object {
+                      "key": "l",
+                      "label": Object {
+                        "defaultMessage": "Edit in Level0",
+                        "id": "KeyMapping.openEditor.editLevel0",
+                      },
+                    },
+                  },
+                  "taskCompletion": Object {
+                    "alreadyFixed": Object {
+                      "key": "x",
+                      "label": Object {
+                        "defaultMessage": "Already fixed",
+                        "id": "KeyMapping.taskCompletion.alreadyFixed",
+                      },
+                    },
+                    "falsePositive": Object {
+                      "key": "q",
+                      "label": Object {
+                        "defaultMessage": "Not an Issue",
+                        "id": "KeyMapping.taskCompletion.falsePositive",
+                      },
+                    },
+                    "fixed": Object {
+                      "key": "f",
+                      "label": Object {
+                        "defaultMessage": "I fixed it!",
+                        "id": "KeyMapping.taskCompletion.fixed",
+                      },
+                    },
+                    "skip": Object {
+                      "key": "w",
+                      "label": Object {
+                        "defaultMessage": "Skip",
+                        "id": "KeyMapping.taskCompletion.skip",
+                      },
+                    },
+                    "tooHard": Object {
+                      "key": "d",
+                      "label": Object {
+                        "defaultMessage": "Too difficult / Couldn't see",
+                        "id": "KeyMapping.taskCompletion.tooHard",
+                      },
+                    },
+                  },
+                  "taskEditing": Object {
+                    "cancel": Object {
+                      "key": "Escape",
+                      "keyLabel": Object {
+                        "defaultMessage": "ESC",
+                        "id": "KeyMapping.taskEditing.escapeLabel",
+                      },
+                      "label": Object {
+                        "defaultMessage": "Cancel Editing",
+                        "id": "KeyMapping.taskEditing.cancel",
+                      },
+                    },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
                       },
                     },
                   },
@@ -5944,6 +6210,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -6109,6 +6382,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -6260,6 +6540,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -6414,6 +6701,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -6564,6 +6858,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -6717,6 +7018,13 @@ ShallowWrapper {
                                               "id": "KeyMapping.taskEditing.cancel",
                                             },
                                           },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
+                                            },
+                                          },
                                         },
                                         "taskReview": Object {
                                           "nextTask": Object {
@@ -6865,6 +7173,13 @@ ShallowWrapper {
                                             "label": Object {
                                               "defaultMessage": "Cancel Editing",
                                               "id": "KeyMapping.taskEditing.cancel",
+                                            },
+                                          },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
                                             },
                                           },
                                         },
@@ -7017,6 +7332,13 @@ ShallowWrapper {
                                               "id": "KeyMapping.taskEditing.cancel",
                                             },
                                           },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
+                                            },
+                                          },
                                         },
                                         "taskReview": Object {
                                           "nextTask": Object {
@@ -7165,6 +7487,13 @@ ShallowWrapper {
                                             "label": Object {
                                               "defaultMessage": "Cancel Editing",
                                               "id": "KeyMapping.taskEditing.cancel",
+                                            },
+                                          },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
                                             },
                                           },
                                         },
@@ -7326,6 +7655,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -7477,6 +7813,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -7625,6 +7968,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -7784,6 +8134,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -7932,6 +8289,13 @@ ShallowWrapper {
                                               "label": Object {
                                                 "defaultMessage": "Cancel Editing",
                                                 "id": "KeyMapping.taskEditing.cancel",
+                                              },
+                                            },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
                                               },
                                             },
                                           },
@@ -8084,6 +8448,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -8234,6 +8605,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -8378,6 +8756,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -8527,152 +8912,11 @@ ShallowWrapper {
                       "id": "KeyMapping.taskEditing.cancel",
                     },
                   },
-                },
-                "taskReview": Object {
-                  "nextTask": Object {
-                    "key": "l",
+                  "fitBounds": Object {
+                    "key": "0",
                     "label": Object {
-                      "defaultMessage": "Next Task",
-                      "id": "KeyMapping.taskReview.nextTask",
-                    },
-                  },
-                  "prevTask": Object {
-                    "key": "h",
-                    "label": Object {
-                      "defaultMessage": "Previous Task",
-                      "id": "KeyMapping.taskReview.prevTask",
-                    },
-                  },
-                },
-              },
-              "mapBounds": Object {
-                "task": Object {
-                  "bounds": Array [
-                    0,
-                    0,
-                    0,
-                    0,
-                  ],
-                },
-              },
-              "nextTask": [Function],
-              "saveTask": [Function],
-              "setTaskBeingCompleted": [Function],
-              "setTaskLoadBy": [Function],
-              "task": Object {
-                "id": 123,
-                "parent": Object {
-                  "id": 321,
-                },
-                "status": 1,
-              },
-              "taskLoadBy": "random",
-              "unsaveTask": [Function],
-              "user": Object {
-                "id": 357,
-                "isLoggedIn": true,
-                "settings": Object {
-                  "defaultEditor": 1,
-                },
-              },
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "activateKeyboardShortcutGroup": [Function],
-              "challengeId": 321,
-              "closeEditor": [Function],
-              "completeTask": [Function],
-              "deactivateKeyboardShortcutGroup": [Function],
-              "editTask": [Function],
-              "editor": Object {},
-              "intl": Object {
-                "formatMessage": [Function],
-              },
-              "keyboardShortcutGroups": Object {
-                "openEditor": Object {
-                  "editId": Object {
-                    "key": "e",
-                    "label": Object {
-                      "defaultMessage": "Edit in Id",
-                      "id": "KeyMapping.openEditor.editId",
-                    },
-                  },
-                  "editJosm": Object {
-                    "key": "r",
-                    "label": Object {
-                      "defaultMessage": "Edit in JOSM",
-                      "id": "KeyMapping.openEditor.editJosm",
-                    },
-                  },
-                  "editJosmLayer": Object {
-                    "key": "t",
-                    "label": Object {
-                      "defaultMessage": "Edit in new JOSM layer",
-                      "id": "KeyMapping.openEditor.editJosmLayer",
-                    },
-                  },
-                  "editLevel0": Object {
-                    "key": "l",
-                    "label": Object {
-                      "defaultMessage": "Edit in Level0",
-                      "id": "KeyMapping.openEditor.editLevel0",
-                    },
-                  },
-                },
-                "taskCompletion": Object {
-                  "alreadyFixed": Object {
-                    "key": "x",
-                    "label": Object {
-                      "defaultMessage": "Already fixed",
-                      "id": "KeyMapping.taskCompletion.alreadyFixed",
-                    },
-                  },
-                  "falsePositive": Object {
-                    "key": "q",
-                    "label": Object {
-                      "defaultMessage": "Not an Issue",
-                      "id": "KeyMapping.taskCompletion.falsePositive",
-                    },
-                  },
-                  "fixed": Object {
-                    "key": "f",
-                    "label": Object {
-                      "defaultMessage": "I fixed it!",
-                      "id": "KeyMapping.taskCompletion.fixed",
-                    },
-                  },
-                  "skip": Object {
-                    "key": "w",
-                    "label": Object {
-                      "defaultMessage": "Skip",
-                      "id": "KeyMapping.taskCompletion.skip",
-                    },
-                  },
-                  "tooHard": Object {
-                    "key": "d",
-                    "label": Object {
-                      "defaultMessage": "Too difficult / Couldn't see",
-                      "id": "KeyMapping.taskCompletion.tooHard",
-                    },
-                  },
-                },
-                "taskEditing": Object {
-                  "cancel": Object {
-                    "key": "Escape",
-                    "keyLabel": Object {
-                      "defaultMessage": "ESC",
-                      "id": "KeyMapping.taskEditing.escapeLabel",
-                    },
-                    "label": Object {
-                      "defaultMessage": "Cancel Editing",
-                      "id": "KeyMapping.taskEditing.cancel",
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
                     },
                   },
                 },
@@ -8823,6 +9067,13 @@ ShallowWrapper {
                       "id": "KeyMapping.taskEditing.cancel",
                     },
                   },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
+                    },
+                  },
                 },
                 "taskReview": Object {
                   "nextTask": Object {
@@ -8969,6 +9220,168 @@ ShallowWrapper {
                     "label": Object {
                       "defaultMessage": "Cancel Editing",
                       "id": "KeyMapping.taskEditing.cancel",
+                    },
+                  },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
+                    },
+                  },
+                },
+                "taskReview": Object {
+                  "nextTask": Object {
+                    "key": "l",
+                    "label": Object {
+                      "defaultMessage": "Next Task",
+                      "id": "KeyMapping.taskReview.nextTask",
+                    },
+                  },
+                  "prevTask": Object {
+                    "key": "h",
+                    "label": Object {
+                      "defaultMessage": "Previous Task",
+                      "id": "KeyMapping.taskReview.prevTask",
+                    },
+                  },
+                },
+              },
+              "mapBounds": Object {
+                "task": Object {
+                  "bounds": Array [
+                    0,
+                    0,
+                    0,
+                    0,
+                  ],
+                },
+              },
+              "nextTask": [Function],
+              "saveTask": [Function],
+              "setTaskBeingCompleted": [Function],
+              "setTaskLoadBy": [Function],
+              "task": Object {
+                "id": 123,
+                "parent": Object {
+                  "id": 321,
+                },
+                "status": 1,
+              },
+              "taskLoadBy": "random",
+              "unsaveTask": [Function],
+              "user": Object {
+                "id": 357,
+                "isLoggedIn": true,
+                "settings": Object {
+                  "defaultEditor": 1,
+                },
+              },
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "activateKeyboardShortcutGroup": [Function],
+              "challengeId": 321,
+              "closeEditor": [Function],
+              "completeTask": [Function],
+              "deactivateKeyboardShortcutGroup": [Function],
+              "editTask": [Function],
+              "editor": Object {},
+              "intl": Object {
+                "formatMessage": [Function],
+              },
+              "keyboardShortcutGroups": Object {
+                "openEditor": Object {
+                  "editId": Object {
+                    "key": "e",
+                    "label": Object {
+                      "defaultMessage": "Edit in Id",
+                      "id": "KeyMapping.openEditor.editId",
+                    },
+                  },
+                  "editJosm": Object {
+                    "key": "r",
+                    "label": Object {
+                      "defaultMessage": "Edit in JOSM",
+                      "id": "KeyMapping.openEditor.editJosm",
+                    },
+                  },
+                  "editJosmLayer": Object {
+                    "key": "t",
+                    "label": Object {
+                      "defaultMessage": "Edit in new JOSM layer",
+                      "id": "KeyMapping.openEditor.editJosmLayer",
+                    },
+                  },
+                  "editLevel0": Object {
+                    "key": "l",
+                    "label": Object {
+                      "defaultMessage": "Edit in Level0",
+                      "id": "KeyMapping.openEditor.editLevel0",
+                    },
+                  },
+                },
+                "taskCompletion": Object {
+                  "alreadyFixed": Object {
+                    "key": "x",
+                    "label": Object {
+                      "defaultMessage": "Already fixed",
+                      "id": "KeyMapping.taskCompletion.alreadyFixed",
+                    },
+                  },
+                  "falsePositive": Object {
+                    "key": "q",
+                    "label": Object {
+                      "defaultMessage": "Not an Issue",
+                      "id": "KeyMapping.taskCompletion.falsePositive",
+                    },
+                  },
+                  "fixed": Object {
+                    "key": "f",
+                    "label": Object {
+                      "defaultMessage": "I fixed it!",
+                      "id": "KeyMapping.taskCompletion.fixed",
+                    },
+                  },
+                  "skip": Object {
+                    "key": "w",
+                    "label": Object {
+                      "defaultMessage": "Skip",
+                      "id": "KeyMapping.taskCompletion.skip",
+                    },
+                  },
+                  "tooHard": Object {
+                    "key": "d",
+                    "label": Object {
+                      "defaultMessage": "Too difficult / Couldn't see",
+                      "id": "KeyMapping.taskCompletion.tooHard",
+                    },
+                  },
+                },
+                "taskEditing": Object {
+                  "cancel": Object {
+                    "key": "Escape",
+                    "keyLabel": Object {
+                      "defaultMessage": "ESC",
+                      "id": "KeyMapping.taskEditing.escapeLabel",
+                    },
+                    "label": Object {
+                      "defaultMessage": "Cancel Editing",
+                      "id": "KeyMapping.taskEditing.cancel",
+                    },
+                  },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
                     },
                   },
                 },
@@ -9133,6 +9546,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -9284,6 +9704,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -9438,6 +9865,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -9588,6 +10022,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -9741,6 +10182,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -9889,6 +10337,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -10041,6 +10496,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -10189,6 +10651,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -10350,6 +10819,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -10501,6 +10977,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -10649,6 +11132,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -10808,6 +11298,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -10956,6 +11453,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -11108,6 +11612,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -11258,6 +11769,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -11402,6 +11920,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -11551,152 +12076,11 @@ ShallowWrapper {
                         "id": "KeyMapping.taskEditing.cancel",
                       },
                     },
-                  },
-                  "taskReview": Object {
-                    "nextTask": Object {
-                      "key": "l",
+                    "fitBounds": Object {
+                      "key": "0",
                       "label": Object {
-                        "defaultMessage": "Next Task",
-                        "id": "KeyMapping.taskReview.nextTask",
-                      },
-                    },
-                    "prevTask": Object {
-                      "key": "h",
-                      "label": Object {
-                        "defaultMessage": "Previous Task",
-                        "id": "KeyMapping.taskReview.prevTask",
-                      },
-                    },
-                  },
-                },
-                "mapBounds": Object {
-                  "task": Object {
-                    "bounds": Array [
-                      0,
-                      0,
-                      0,
-                      0,
-                    ],
-                  },
-                },
-                "nextTask": [Function],
-                "saveTask": [Function],
-                "setTaskBeingCompleted": [Function],
-                "setTaskLoadBy": [Function],
-                "task": Object {
-                  "id": 123,
-                  "parent": Object {
-                    "id": 321,
-                  },
-                  "status": 1,
-                },
-                "taskLoadBy": "random",
-                "unsaveTask": [Function],
-                "user": Object {
-                  "id": 357,
-                  "isLoggedIn": true,
-                  "settings": Object {
-                    "defaultEditor": 1,
-                  },
-                },
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "activateKeyboardShortcutGroup": [Function],
-                "challengeId": 321,
-                "closeEditor": [Function],
-                "completeTask": [Function],
-                "deactivateKeyboardShortcutGroup": [Function],
-                "editTask": [Function],
-                "editor": Object {},
-                "intl": Object {
-                  "formatMessage": [Function],
-                },
-                "keyboardShortcutGroups": Object {
-                  "openEditor": Object {
-                    "editId": Object {
-                      "key": "e",
-                      "label": Object {
-                        "defaultMessage": "Edit in Id",
-                        "id": "KeyMapping.openEditor.editId",
-                      },
-                    },
-                    "editJosm": Object {
-                      "key": "r",
-                      "label": Object {
-                        "defaultMessage": "Edit in JOSM",
-                        "id": "KeyMapping.openEditor.editJosm",
-                      },
-                    },
-                    "editJosmLayer": Object {
-                      "key": "t",
-                      "label": Object {
-                        "defaultMessage": "Edit in new JOSM layer",
-                        "id": "KeyMapping.openEditor.editJosmLayer",
-                      },
-                    },
-                    "editLevel0": Object {
-                      "key": "l",
-                      "label": Object {
-                        "defaultMessage": "Edit in Level0",
-                        "id": "KeyMapping.openEditor.editLevel0",
-                      },
-                    },
-                  },
-                  "taskCompletion": Object {
-                    "alreadyFixed": Object {
-                      "key": "x",
-                      "label": Object {
-                        "defaultMessage": "Already fixed",
-                        "id": "KeyMapping.taskCompletion.alreadyFixed",
-                      },
-                    },
-                    "falsePositive": Object {
-                      "key": "q",
-                      "label": Object {
-                        "defaultMessage": "Not an Issue",
-                        "id": "KeyMapping.taskCompletion.falsePositive",
-                      },
-                    },
-                    "fixed": Object {
-                      "key": "f",
-                      "label": Object {
-                        "defaultMessage": "I fixed it!",
-                        "id": "KeyMapping.taskCompletion.fixed",
-                      },
-                    },
-                    "skip": Object {
-                      "key": "w",
-                      "label": Object {
-                        "defaultMessage": "Skip",
-                        "id": "KeyMapping.taskCompletion.skip",
-                      },
-                    },
-                    "tooHard": Object {
-                      "key": "d",
-                      "label": Object {
-                        "defaultMessage": "Too difficult / Couldn't see",
-                        "id": "KeyMapping.taskCompletion.tooHard",
-                      },
-                    },
-                  },
-                  "taskEditing": Object {
-                    "cancel": Object {
-                      "key": "Escape",
-                      "keyLabel": Object {
-                        "defaultMessage": "ESC",
-                        "id": "KeyMapping.taskEditing.escapeLabel",
-                      },
-                      "label": Object {
-                        "defaultMessage": "Cancel Editing",
-                        "id": "KeyMapping.taskEditing.cancel",
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
                       },
                     },
                   },
@@ -11847,6 +12231,13 @@ ShallowWrapper {
                         "id": "KeyMapping.taskEditing.cancel",
                       },
                     },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
+                      },
+                    },
                   },
                   "taskReview": Object {
                     "nextTask": Object {
@@ -11993,6 +12384,168 @@ ShallowWrapper {
                       "label": Object {
                         "defaultMessage": "Cancel Editing",
                         "id": "KeyMapping.taskEditing.cancel",
+                      },
+                    },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
+                      },
+                    },
+                  },
+                  "taskReview": Object {
+                    "nextTask": Object {
+                      "key": "l",
+                      "label": Object {
+                        "defaultMessage": "Next Task",
+                        "id": "KeyMapping.taskReview.nextTask",
+                      },
+                    },
+                    "prevTask": Object {
+                      "key": "h",
+                      "label": Object {
+                        "defaultMessage": "Previous Task",
+                        "id": "KeyMapping.taskReview.prevTask",
+                      },
+                    },
+                  },
+                },
+                "mapBounds": Object {
+                  "task": Object {
+                    "bounds": Array [
+                      0,
+                      0,
+                      0,
+                      0,
+                    ],
+                  },
+                },
+                "nextTask": [Function],
+                "saveTask": [Function],
+                "setTaskBeingCompleted": [Function],
+                "setTaskLoadBy": [Function],
+                "task": Object {
+                  "id": 123,
+                  "parent": Object {
+                    "id": 321,
+                  },
+                  "status": 1,
+                },
+                "taskLoadBy": "random",
+                "unsaveTask": [Function],
+                "user": Object {
+                  "id": 357,
+                  "isLoggedIn": true,
+                  "settings": Object {
+                    "defaultEditor": 1,
+                  },
+                },
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "activateKeyboardShortcutGroup": [Function],
+                "challengeId": 321,
+                "closeEditor": [Function],
+                "completeTask": [Function],
+                "deactivateKeyboardShortcutGroup": [Function],
+                "editTask": [Function],
+                "editor": Object {},
+                "intl": Object {
+                  "formatMessage": [Function],
+                },
+                "keyboardShortcutGroups": Object {
+                  "openEditor": Object {
+                    "editId": Object {
+                      "key": "e",
+                      "label": Object {
+                        "defaultMessage": "Edit in Id",
+                        "id": "KeyMapping.openEditor.editId",
+                      },
+                    },
+                    "editJosm": Object {
+                      "key": "r",
+                      "label": Object {
+                        "defaultMessage": "Edit in JOSM",
+                        "id": "KeyMapping.openEditor.editJosm",
+                      },
+                    },
+                    "editJosmLayer": Object {
+                      "key": "t",
+                      "label": Object {
+                        "defaultMessage": "Edit in new JOSM layer",
+                        "id": "KeyMapping.openEditor.editJosmLayer",
+                      },
+                    },
+                    "editLevel0": Object {
+                      "key": "l",
+                      "label": Object {
+                        "defaultMessage": "Edit in Level0",
+                        "id": "KeyMapping.openEditor.editLevel0",
+                      },
+                    },
+                  },
+                  "taskCompletion": Object {
+                    "alreadyFixed": Object {
+                      "key": "x",
+                      "label": Object {
+                        "defaultMessage": "Already fixed",
+                        "id": "KeyMapping.taskCompletion.alreadyFixed",
+                      },
+                    },
+                    "falsePositive": Object {
+                      "key": "q",
+                      "label": Object {
+                        "defaultMessage": "Not an Issue",
+                        "id": "KeyMapping.taskCompletion.falsePositive",
+                      },
+                    },
+                    "fixed": Object {
+                      "key": "f",
+                      "label": Object {
+                        "defaultMessage": "I fixed it!",
+                        "id": "KeyMapping.taskCompletion.fixed",
+                      },
+                    },
+                    "skip": Object {
+                      "key": "w",
+                      "label": Object {
+                        "defaultMessage": "Skip",
+                        "id": "KeyMapping.taskCompletion.skip",
+                      },
+                    },
+                    "tooHard": Object {
+                      "key": "d",
+                      "label": Object {
+                        "defaultMessage": "Too difficult / Couldn't see",
+                        "id": "KeyMapping.taskCompletion.tooHard",
+                      },
+                    },
+                  },
+                  "taskEditing": Object {
+                    "cancel": Object {
+                      "key": "Escape",
+                      "keyLabel": Object {
+                        "defaultMessage": "ESC",
+                        "id": "KeyMapping.taskEditing.escapeLabel",
+                      },
+                      "label": Object {
+                        "defaultMessage": "Cancel Editing",
+                        "id": "KeyMapping.taskEditing.cancel",
+                      },
+                    },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
                       },
                     },
                   },
@@ -12168,6 +12721,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -12336,6 +12896,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -12508,6 +13075,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -12662,6 +13236,13 @@ ShallowWrapper {
                                   "label": Object {
                                     "defaultMessage": "Cancel Editing",
                                     "id": "KeyMapping.taskEditing.cancel",
+                                  },
+                                },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
                                   },
                                 },
                               },
@@ -12820,6 +13401,13 @@ ShallowWrapper {
                                               "id": "KeyMapping.taskEditing.cancel",
                                             },
                                           },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
+                                            },
+                                          },
                                         },
                                         "taskReview": Object {
                                           "nextTask": Object {
@@ -12973,6 +13561,13 @@ ShallowWrapper {
                                             "label": Object {
                                               "defaultMessage": "Cancel Editing",
                                               "id": "KeyMapping.taskEditing.cancel",
+                                            },
+                                          },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
                                             },
                                           },
                                         },
@@ -13130,6 +13725,13 @@ ShallowWrapper {
                                               "id": "KeyMapping.taskEditing.cancel",
                                             },
                                           },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
+                                            },
+                                          },
                                         },
                                         "taskReview": Object {
                                           "nextTask": Object {
@@ -13283,6 +13885,13 @@ ShallowWrapper {
                                             "label": Object {
                                               "defaultMessage": "Cancel Editing",
                                               "id": "KeyMapping.taskEditing.cancel",
+                                            },
+                                          },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
                                             },
                                           },
                                         },
@@ -13445,6 +14054,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -13611,6 +14227,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -13772,6 +14395,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -13925,6 +14555,13 @@ ShallowWrapper {
                                               "label": Object {
                                                 "defaultMessage": "Cancel Editing",
                                                 "id": "KeyMapping.taskEditing.cancel",
+                                              },
+                                            },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
                                               },
                                             },
                                           },
@@ -14082,6 +14719,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -14237,6 +14881,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -14384,6 +15035,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -14536,155 +15194,11 @@ ShallowWrapper {
                       "id": "KeyMapping.taskEditing.cancel",
                     },
                   },
-                },
-                "taskReview": Object {
-                  "nextTask": Object {
-                    "key": "l",
+                  "fitBounds": Object {
+                    "key": "0",
                     "label": Object {
-                      "defaultMessage": "Next Task",
-                      "id": "KeyMapping.taskReview.nextTask",
-                    },
-                  },
-                  "prevTask": Object {
-                    "key": "h",
-                    "label": Object {
-                      "defaultMessage": "Previous Task",
-                      "id": "KeyMapping.taskReview.prevTask",
-                    },
-                  },
-                },
-              },
-              "mapBounds": Object {
-                "task": Object {
-                  "bounds": Array [
-                    0,
-                    0,
-                    0,
-                    0,
-                  ],
-                },
-              },
-              "nextTask": [Function],
-              "saveTask": [Function],
-              "setTaskBeingCompleted": [Function],
-              "setTaskLoadBy": [Function],
-              "task": Object {
-                "id": 123,
-                "parent": Object {
-                  "id": 321,
-                },
-                "status": 0,
-              },
-              "taskLoadBy": "random",
-              "unsaveTask": [Function],
-              "user": Object {
-                "id": 357,
-                "isLoggedIn": true,
-                "settings": Object {
-                  "defaultEditor": 1,
-                },
-              },
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "activateKeyboardShortcutGroup": [Function],
-              "challengeId": 321,
-              "closeEditor": [Function],
-              "completeTask": [Function],
-              "deactivateKeyboardShortcutGroup": [Function],
-              "editTask": [Function],
-              "editor": Object {
-                "success": true,
-                "taskId": 123,
-              },
-              "intl": Object {
-                "formatMessage": [Function],
-              },
-              "keyboardShortcutGroups": Object {
-                "openEditor": Object {
-                  "editId": Object {
-                    "key": "e",
-                    "label": Object {
-                      "defaultMessage": "Edit in Id",
-                      "id": "KeyMapping.openEditor.editId",
-                    },
-                  },
-                  "editJosm": Object {
-                    "key": "r",
-                    "label": Object {
-                      "defaultMessage": "Edit in JOSM",
-                      "id": "KeyMapping.openEditor.editJosm",
-                    },
-                  },
-                  "editJosmLayer": Object {
-                    "key": "t",
-                    "label": Object {
-                      "defaultMessage": "Edit in new JOSM layer",
-                      "id": "KeyMapping.openEditor.editJosmLayer",
-                    },
-                  },
-                  "editLevel0": Object {
-                    "key": "l",
-                    "label": Object {
-                      "defaultMessage": "Edit in Level0",
-                      "id": "KeyMapping.openEditor.editLevel0",
-                    },
-                  },
-                },
-                "taskCompletion": Object {
-                  "alreadyFixed": Object {
-                    "key": "x",
-                    "label": Object {
-                      "defaultMessage": "Already fixed",
-                      "id": "KeyMapping.taskCompletion.alreadyFixed",
-                    },
-                  },
-                  "falsePositive": Object {
-                    "key": "q",
-                    "label": Object {
-                      "defaultMessage": "Not an Issue",
-                      "id": "KeyMapping.taskCompletion.falsePositive",
-                    },
-                  },
-                  "fixed": Object {
-                    "key": "f",
-                    "label": Object {
-                      "defaultMessage": "I fixed it!",
-                      "id": "KeyMapping.taskCompletion.fixed",
-                    },
-                  },
-                  "skip": Object {
-                    "key": "w",
-                    "label": Object {
-                      "defaultMessage": "Skip",
-                      "id": "KeyMapping.taskCompletion.skip",
-                    },
-                  },
-                  "tooHard": Object {
-                    "key": "d",
-                    "label": Object {
-                      "defaultMessage": "Too difficult / Couldn't see",
-                      "id": "KeyMapping.taskCompletion.tooHard",
-                    },
-                  },
-                },
-                "taskEditing": Object {
-                  "cancel": Object {
-                    "key": "Escape",
-                    "keyLabel": Object {
-                      "defaultMessage": "ESC",
-                      "id": "KeyMapping.taskEditing.escapeLabel",
-                    },
-                    "label": Object {
-                      "defaultMessage": "Cancel Editing",
-                      "id": "KeyMapping.taskEditing.cancel",
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
                     },
                   },
                 },
@@ -14838,6 +15352,13 @@ ShallowWrapper {
                       "id": "KeyMapping.taskEditing.cancel",
                     },
                   },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
+                    },
+                  },
                 },
                 "taskReview": Object {
                   "nextTask": Object {
@@ -14987,6 +15508,171 @@ ShallowWrapper {
                     "label": Object {
                       "defaultMessage": "Cancel Editing",
                       "id": "KeyMapping.taskEditing.cancel",
+                    },
+                  },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
+                    },
+                  },
+                },
+                "taskReview": Object {
+                  "nextTask": Object {
+                    "key": "l",
+                    "label": Object {
+                      "defaultMessage": "Next Task",
+                      "id": "KeyMapping.taskReview.nextTask",
+                    },
+                  },
+                  "prevTask": Object {
+                    "key": "h",
+                    "label": Object {
+                      "defaultMessage": "Previous Task",
+                      "id": "KeyMapping.taskReview.prevTask",
+                    },
+                  },
+                },
+              },
+              "mapBounds": Object {
+                "task": Object {
+                  "bounds": Array [
+                    0,
+                    0,
+                    0,
+                    0,
+                  ],
+                },
+              },
+              "nextTask": [Function],
+              "saveTask": [Function],
+              "setTaskBeingCompleted": [Function],
+              "setTaskLoadBy": [Function],
+              "task": Object {
+                "id": 123,
+                "parent": Object {
+                  "id": 321,
+                },
+                "status": 0,
+              },
+              "taskLoadBy": "random",
+              "unsaveTask": [Function],
+              "user": Object {
+                "id": 357,
+                "isLoggedIn": true,
+                "settings": Object {
+                  "defaultEditor": 1,
+                },
+              },
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "activateKeyboardShortcutGroup": [Function],
+              "challengeId": 321,
+              "closeEditor": [Function],
+              "completeTask": [Function],
+              "deactivateKeyboardShortcutGroup": [Function],
+              "editTask": [Function],
+              "editor": Object {
+                "success": true,
+                "taskId": 123,
+              },
+              "intl": Object {
+                "formatMessage": [Function],
+              },
+              "keyboardShortcutGroups": Object {
+                "openEditor": Object {
+                  "editId": Object {
+                    "key": "e",
+                    "label": Object {
+                      "defaultMessage": "Edit in Id",
+                      "id": "KeyMapping.openEditor.editId",
+                    },
+                  },
+                  "editJosm": Object {
+                    "key": "r",
+                    "label": Object {
+                      "defaultMessage": "Edit in JOSM",
+                      "id": "KeyMapping.openEditor.editJosm",
+                    },
+                  },
+                  "editJosmLayer": Object {
+                    "key": "t",
+                    "label": Object {
+                      "defaultMessage": "Edit in new JOSM layer",
+                      "id": "KeyMapping.openEditor.editJosmLayer",
+                    },
+                  },
+                  "editLevel0": Object {
+                    "key": "l",
+                    "label": Object {
+                      "defaultMessage": "Edit in Level0",
+                      "id": "KeyMapping.openEditor.editLevel0",
+                    },
+                  },
+                },
+                "taskCompletion": Object {
+                  "alreadyFixed": Object {
+                    "key": "x",
+                    "label": Object {
+                      "defaultMessage": "Already fixed",
+                      "id": "KeyMapping.taskCompletion.alreadyFixed",
+                    },
+                  },
+                  "falsePositive": Object {
+                    "key": "q",
+                    "label": Object {
+                      "defaultMessage": "Not an Issue",
+                      "id": "KeyMapping.taskCompletion.falsePositive",
+                    },
+                  },
+                  "fixed": Object {
+                    "key": "f",
+                    "label": Object {
+                      "defaultMessage": "I fixed it!",
+                      "id": "KeyMapping.taskCompletion.fixed",
+                    },
+                  },
+                  "skip": Object {
+                    "key": "w",
+                    "label": Object {
+                      "defaultMessage": "Skip",
+                      "id": "KeyMapping.taskCompletion.skip",
+                    },
+                  },
+                  "tooHard": Object {
+                    "key": "d",
+                    "label": Object {
+                      "defaultMessage": "Too difficult / Couldn't see",
+                      "id": "KeyMapping.taskCompletion.tooHard",
+                    },
+                  },
+                },
+                "taskEditing": Object {
+                  "cancel": Object {
+                    "key": "Escape",
+                    "keyLabel": Object {
+                      "defaultMessage": "ESC",
+                      "id": "KeyMapping.taskEditing.escapeLabel",
+                    },
+                    "label": Object {
+                      "defaultMessage": "Cancel Editing",
+                      "id": "KeyMapping.taskEditing.cancel",
+                    },
+                  },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
                     },
                   },
                 },
@@ -15154,6 +15840,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -15326,6 +16019,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -15480,6 +16180,13 @@ ShallowWrapper {
                                         "label": Object {
                                           "defaultMessage": "Cancel Editing",
                                           "id": "KeyMapping.taskEditing.cancel",
+                                        },
+                                      },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
                                         },
                                       },
                                     },
@@ -15638,6 +16345,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -15791,6 +16505,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -15948,6 +16669,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -16101,6 +16829,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -16263,6 +16998,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -16429,6 +17171,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -16590,6 +17339,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -16743,6 +17499,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -16900,6 +17663,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -17055,6 +17825,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -17202,6 +17979,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -17354,155 +18138,11 @@ ShallowWrapper {
                         "id": "KeyMapping.taskEditing.cancel",
                       },
                     },
-                  },
-                  "taskReview": Object {
-                    "nextTask": Object {
-                      "key": "l",
+                    "fitBounds": Object {
+                      "key": "0",
                       "label": Object {
-                        "defaultMessage": "Next Task",
-                        "id": "KeyMapping.taskReview.nextTask",
-                      },
-                    },
-                    "prevTask": Object {
-                      "key": "h",
-                      "label": Object {
-                        "defaultMessage": "Previous Task",
-                        "id": "KeyMapping.taskReview.prevTask",
-                      },
-                    },
-                  },
-                },
-                "mapBounds": Object {
-                  "task": Object {
-                    "bounds": Array [
-                      0,
-                      0,
-                      0,
-                      0,
-                    ],
-                  },
-                },
-                "nextTask": [Function],
-                "saveTask": [Function],
-                "setTaskBeingCompleted": [Function],
-                "setTaskLoadBy": [Function],
-                "task": Object {
-                  "id": 123,
-                  "parent": Object {
-                    "id": 321,
-                  },
-                  "status": 0,
-                },
-                "taskLoadBy": "random",
-                "unsaveTask": [Function],
-                "user": Object {
-                  "id": 357,
-                  "isLoggedIn": true,
-                  "settings": Object {
-                    "defaultEditor": 1,
-                  },
-                },
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "activateKeyboardShortcutGroup": [Function],
-                "challengeId": 321,
-                "closeEditor": [Function],
-                "completeTask": [Function],
-                "deactivateKeyboardShortcutGroup": [Function],
-                "editTask": [Function],
-                "editor": Object {
-                  "success": true,
-                  "taskId": 123,
-                },
-                "intl": Object {
-                  "formatMessage": [Function],
-                },
-                "keyboardShortcutGroups": Object {
-                  "openEditor": Object {
-                    "editId": Object {
-                      "key": "e",
-                      "label": Object {
-                        "defaultMessage": "Edit in Id",
-                        "id": "KeyMapping.openEditor.editId",
-                      },
-                    },
-                    "editJosm": Object {
-                      "key": "r",
-                      "label": Object {
-                        "defaultMessage": "Edit in JOSM",
-                        "id": "KeyMapping.openEditor.editJosm",
-                      },
-                    },
-                    "editJosmLayer": Object {
-                      "key": "t",
-                      "label": Object {
-                        "defaultMessage": "Edit in new JOSM layer",
-                        "id": "KeyMapping.openEditor.editJosmLayer",
-                      },
-                    },
-                    "editLevel0": Object {
-                      "key": "l",
-                      "label": Object {
-                        "defaultMessage": "Edit in Level0",
-                        "id": "KeyMapping.openEditor.editLevel0",
-                      },
-                    },
-                  },
-                  "taskCompletion": Object {
-                    "alreadyFixed": Object {
-                      "key": "x",
-                      "label": Object {
-                        "defaultMessage": "Already fixed",
-                        "id": "KeyMapping.taskCompletion.alreadyFixed",
-                      },
-                    },
-                    "falsePositive": Object {
-                      "key": "q",
-                      "label": Object {
-                        "defaultMessage": "Not an Issue",
-                        "id": "KeyMapping.taskCompletion.falsePositive",
-                      },
-                    },
-                    "fixed": Object {
-                      "key": "f",
-                      "label": Object {
-                        "defaultMessage": "I fixed it!",
-                        "id": "KeyMapping.taskCompletion.fixed",
-                      },
-                    },
-                    "skip": Object {
-                      "key": "w",
-                      "label": Object {
-                        "defaultMessage": "Skip",
-                        "id": "KeyMapping.taskCompletion.skip",
-                      },
-                    },
-                    "tooHard": Object {
-                      "key": "d",
-                      "label": Object {
-                        "defaultMessage": "Too difficult / Couldn't see",
-                        "id": "KeyMapping.taskCompletion.tooHard",
-                      },
-                    },
-                  },
-                  "taskEditing": Object {
-                    "cancel": Object {
-                      "key": "Escape",
-                      "keyLabel": Object {
-                        "defaultMessage": "ESC",
-                        "id": "KeyMapping.taskEditing.escapeLabel",
-                      },
-                      "label": Object {
-                        "defaultMessage": "Cancel Editing",
-                        "id": "KeyMapping.taskEditing.cancel",
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
                       },
                     },
                   },
@@ -17656,6 +18296,13 @@ ShallowWrapper {
                         "id": "KeyMapping.taskEditing.cancel",
                       },
                     },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
+                      },
+                    },
                   },
                   "taskReview": Object {
                     "nextTask": Object {
@@ -17805,6 +18452,171 @@ ShallowWrapper {
                       "label": Object {
                         "defaultMessage": "Cancel Editing",
                         "id": "KeyMapping.taskEditing.cancel",
+                      },
+                    },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
+                      },
+                    },
+                  },
+                  "taskReview": Object {
+                    "nextTask": Object {
+                      "key": "l",
+                      "label": Object {
+                        "defaultMessage": "Next Task",
+                        "id": "KeyMapping.taskReview.nextTask",
+                      },
+                    },
+                    "prevTask": Object {
+                      "key": "h",
+                      "label": Object {
+                        "defaultMessage": "Previous Task",
+                        "id": "KeyMapping.taskReview.prevTask",
+                      },
+                    },
+                  },
+                },
+                "mapBounds": Object {
+                  "task": Object {
+                    "bounds": Array [
+                      0,
+                      0,
+                      0,
+                      0,
+                    ],
+                  },
+                },
+                "nextTask": [Function],
+                "saveTask": [Function],
+                "setTaskBeingCompleted": [Function],
+                "setTaskLoadBy": [Function],
+                "task": Object {
+                  "id": 123,
+                  "parent": Object {
+                    "id": 321,
+                  },
+                  "status": 0,
+                },
+                "taskLoadBy": "random",
+                "unsaveTask": [Function],
+                "user": Object {
+                  "id": 357,
+                  "isLoggedIn": true,
+                  "settings": Object {
+                    "defaultEditor": 1,
+                  },
+                },
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "activateKeyboardShortcutGroup": [Function],
+                "challengeId": 321,
+                "closeEditor": [Function],
+                "completeTask": [Function],
+                "deactivateKeyboardShortcutGroup": [Function],
+                "editTask": [Function],
+                "editor": Object {
+                  "success": true,
+                  "taskId": 123,
+                },
+                "intl": Object {
+                  "formatMessage": [Function],
+                },
+                "keyboardShortcutGroups": Object {
+                  "openEditor": Object {
+                    "editId": Object {
+                      "key": "e",
+                      "label": Object {
+                        "defaultMessage": "Edit in Id",
+                        "id": "KeyMapping.openEditor.editId",
+                      },
+                    },
+                    "editJosm": Object {
+                      "key": "r",
+                      "label": Object {
+                        "defaultMessage": "Edit in JOSM",
+                        "id": "KeyMapping.openEditor.editJosm",
+                      },
+                    },
+                    "editJosmLayer": Object {
+                      "key": "t",
+                      "label": Object {
+                        "defaultMessage": "Edit in new JOSM layer",
+                        "id": "KeyMapping.openEditor.editJosmLayer",
+                      },
+                    },
+                    "editLevel0": Object {
+                      "key": "l",
+                      "label": Object {
+                        "defaultMessage": "Edit in Level0",
+                        "id": "KeyMapping.openEditor.editLevel0",
+                      },
+                    },
+                  },
+                  "taskCompletion": Object {
+                    "alreadyFixed": Object {
+                      "key": "x",
+                      "label": Object {
+                        "defaultMessage": "Already fixed",
+                        "id": "KeyMapping.taskCompletion.alreadyFixed",
+                      },
+                    },
+                    "falsePositive": Object {
+                      "key": "q",
+                      "label": Object {
+                        "defaultMessage": "Not an Issue",
+                        "id": "KeyMapping.taskCompletion.falsePositive",
+                      },
+                    },
+                    "fixed": Object {
+                      "key": "f",
+                      "label": Object {
+                        "defaultMessage": "I fixed it!",
+                        "id": "KeyMapping.taskCompletion.fixed",
+                      },
+                    },
+                    "skip": Object {
+                      "key": "w",
+                      "label": Object {
+                        "defaultMessage": "Skip",
+                        "id": "KeyMapping.taskCompletion.skip",
+                      },
+                    },
+                    "tooHard": Object {
+                      "key": "d",
+                      "label": Object {
+                        "defaultMessage": "Too difficult / Couldn't see",
+                        "id": "KeyMapping.taskCompletion.tooHard",
+                      },
+                    },
+                  },
+                  "taskEditing": Object {
+                    "cancel": Object {
+                      "key": "Escape",
+                      "keyLabel": Object {
+                        "defaultMessage": "ESC",
+                        "id": "KeyMapping.taskEditing.escapeLabel",
+                      },
+                      "label": Object {
+                        "defaultMessage": "Cancel Editing",
+                        "id": "KeyMapping.taskEditing.cancel",
+                      },
+                    },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
                       },
                     },
                   },
@@ -17975,6 +18787,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -18140,6 +18959,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -18302,6 +19128,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -18456,6 +19289,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -18605,6 +19445,13 @@ ShallowWrapper {
                                             "label": Object {
                                               "defaultMessage": "Cancel Editing",
                                               "id": "KeyMapping.taskEditing.cancel",
+                                            },
+                                          },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
                                             },
                                           },
                                         },
@@ -18757,6 +19604,13 @@ ShallowWrapper {
                                               "id": "KeyMapping.taskEditing.cancel",
                                             },
                                           },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
+                                            },
+                                          },
                                         },
                                         "taskReview": Object {
                                           "nextTask": Object {
@@ -18907,6 +19761,13 @@ ShallowWrapper {
                                               "id": "KeyMapping.taskEditing.cancel",
                                             },
                                           },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
+                                            },
+                                          },
                                         },
                                         "taskReview": Object {
                                           "nextTask": Object {
@@ -19055,6 +19916,13 @@ ShallowWrapper {
                                             "label": Object {
                                               "defaultMessage": "Cancel Editing",
                                               "id": "KeyMapping.taskEditing.cancel",
+                                            },
+                                          },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
                                             },
                                           },
                                         },
@@ -19216,6 +20084,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -19372,6 +20247,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -19533,6 +20415,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -19681,6 +20570,13 @@ ShallowWrapper {
                                               "label": Object {
                                                 "defaultMessage": "Cancel Editing",
                                                 "id": "KeyMapping.taskEditing.cancel",
+                                              },
+                                            },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
                                               },
                                             },
                                           },
@@ -19833,6 +20729,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -19983,6 +20886,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -20127,6 +21037,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -20276,152 +21193,11 @@ ShallowWrapper {
                       "id": "KeyMapping.taskEditing.cancel",
                     },
                   },
-                },
-                "taskReview": Object {
-                  "nextTask": Object {
-                    "key": "l",
+                  "fitBounds": Object {
+                    "key": "0",
                     "label": Object {
-                      "defaultMessage": "Next Task",
-                      "id": "KeyMapping.taskReview.nextTask",
-                    },
-                  },
-                  "prevTask": Object {
-                    "key": "h",
-                    "label": Object {
-                      "defaultMessage": "Previous Task",
-                      "id": "KeyMapping.taskReview.prevTask",
-                    },
-                  },
-                },
-              },
-              "mapBounds": Object {
-                "task": Object {
-                  "bounds": Array [
-                    0,
-                    0,
-                    0,
-                    0,
-                  ],
-                },
-              },
-              "nextTask": [Function],
-              "saveTask": [Function],
-              "setTaskBeingCompleted": [Function],
-              "setTaskLoadBy": [Function],
-              "task": Object {
-                "id": 123,
-                "parent": Object {
-                  "id": 321,
-                },
-                "status": 0,
-              },
-              "taskLoadBy": "random",
-              "unsaveTask": [Function],
-              "user": Object {
-                "id": 357,
-                "isLoggedIn": true,
-                "settings": Object {
-                  "defaultEditor": 1,
-                },
-              },
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "activateKeyboardShortcutGroup": [Function],
-              "challengeId": 321,
-              "closeEditor": [Function],
-              "completeTask": [Function],
-              "deactivateKeyboardShortcutGroup": [Function],
-              "editTask": [Function],
-              "editor": Object {},
-              "intl": Object {
-                "formatMessage": [Function],
-              },
-              "keyboardShortcutGroups": Object {
-                "openEditor": Object {
-                  "editId": Object {
-                    "key": "e",
-                    "label": Object {
-                      "defaultMessage": "Edit in Id",
-                      "id": "KeyMapping.openEditor.editId",
-                    },
-                  },
-                  "editJosm": Object {
-                    "key": "r",
-                    "label": Object {
-                      "defaultMessage": "Edit in JOSM",
-                      "id": "KeyMapping.openEditor.editJosm",
-                    },
-                  },
-                  "editJosmLayer": Object {
-                    "key": "t",
-                    "label": Object {
-                      "defaultMessage": "Edit in new JOSM layer",
-                      "id": "KeyMapping.openEditor.editJosmLayer",
-                    },
-                  },
-                  "editLevel0": Object {
-                    "key": "l",
-                    "label": Object {
-                      "defaultMessage": "Edit in Level0",
-                      "id": "KeyMapping.openEditor.editLevel0",
-                    },
-                  },
-                },
-                "taskCompletion": Object {
-                  "alreadyFixed": Object {
-                    "key": "x",
-                    "label": Object {
-                      "defaultMessage": "Already fixed",
-                      "id": "KeyMapping.taskCompletion.alreadyFixed",
-                    },
-                  },
-                  "falsePositive": Object {
-                    "key": "q",
-                    "label": Object {
-                      "defaultMessage": "Not an Issue",
-                      "id": "KeyMapping.taskCompletion.falsePositive",
-                    },
-                  },
-                  "fixed": Object {
-                    "key": "f",
-                    "label": Object {
-                      "defaultMessage": "I fixed it!",
-                      "id": "KeyMapping.taskCompletion.fixed",
-                    },
-                  },
-                  "skip": Object {
-                    "key": "w",
-                    "label": Object {
-                      "defaultMessage": "Skip",
-                      "id": "KeyMapping.taskCompletion.skip",
-                    },
-                  },
-                  "tooHard": Object {
-                    "key": "d",
-                    "label": Object {
-                      "defaultMessage": "Too difficult / Couldn't see",
-                      "id": "KeyMapping.taskCompletion.tooHard",
-                    },
-                  },
-                },
-                "taskEditing": Object {
-                  "cancel": Object {
-                    "key": "Escape",
-                    "keyLabel": Object {
-                      "defaultMessage": "ESC",
-                      "id": "KeyMapping.taskEditing.escapeLabel",
-                    },
-                    "label": Object {
-                      "defaultMessage": "Cancel Editing",
-                      "id": "KeyMapping.taskEditing.cancel",
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
                     },
                   },
                 },
@@ -20572,6 +21348,13 @@ ShallowWrapper {
                       "id": "KeyMapping.taskEditing.cancel",
                     },
                   },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
+                    },
+                  },
                 },
                 "taskReview": Object {
                   "nextTask": Object {
@@ -20718,6 +21501,168 @@ ShallowWrapper {
                     "label": Object {
                       "defaultMessage": "Cancel Editing",
                       "id": "KeyMapping.taskEditing.cancel",
+                    },
+                  },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
+                    },
+                  },
+                },
+                "taskReview": Object {
+                  "nextTask": Object {
+                    "key": "l",
+                    "label": Object {
+                      "defaultMessage": "Next Task",
+                      "id": "KeyMapping.taskReview.nextTask",
+                    },
+                  },
+                  "prevTask": Object {
+                    "key": "h",
+                    "label": Object {
+                      "defaultMessage": "Previous Task",
+                      "id": "KeyMapping.taskReview.prevTask",
+                    },
+                  },
+                },
+              },
+              "mapBounds": Object {
+                "task": Object {
+                  "bounds": Array [
+                    0,
+                    0,
+                    0,
+                    0,
+                  ],
+                },
+              },
+              "nextTask": [Function],
+              "saveTask": [Function],
+              "setTaskBeingCompleted": [Function],
+              "setTaskLoadBy": [Function],
+              "task": Object {
+                "id": 123,
+                "parent": Object {
+                  "id": 321,
+                },
+                "status": 0,
+              },
+              "taskLoadBy": "random",
+              "unsaveTask": [Function],
+              "user": Object {
+                "id": 357,
+                "isLoggedIn": true,
+                "settings": Object {
+                  "defaultEditor": 1,
+                },
+              },
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "activateKeyboardShortcutGroup": [Function],
+              "challengeId": 321,
+              "closeEditor": [Function],
+              "completeTask": [Function],
+              "deactivateKeyboardShortcutGroup": [Function],
+              "editTask": [Function],
+              "editor": Object {},
+              "intl": Object {
+                "formatMessage": [Function],
+              },
+              "keyboardShortcutGroups": Object {
+                "openEditor": Object {
+                  "editId": Object {
+                    "key": "e",
+                    "label": Object {
+                      "defaultMessage": "Edit in Id",
+                      "id": "KeyMapping.openEditor.editId",
+                    },
+                  },
+                  "editJosm": Object {
+                    "key": "r",
+                    "label": Object {
+                      "defaultMessage": "Edit in JOSM",
+                      "id": "KeyMapping.openEditor.editJosm",
+                    },
+                  },
+                  "editJosmLayer": Object {
+                    "key": "t",
+                    "label": Object {
+                      "defaultMessage": "Edit in new JOSM layer",
+                      "id": "KeyMapping.openEditor.editJosmLayer",
+                    },
+                  },
+                  "editLevel0": Object {
+                    "key": "l",
+                    "label": Object {
+                      "defaultMessage": "Edit in Level0",
+                      "id": "KeyMapping.openEditor.editLevel0",
+                    },
+                  },
+                },
+                "taskCompletion": Object {
+                  "alreadyFixed": Object {
+                    "key": "x",
+                    "label": Object {
+                      "defaultMessage": "Already fixed",
+                      "id": "KeyMapping.taskCompletion.alreadyFixed",
+                    },
+                  },
+                  "falsePositive": Object {
+                    "key": "q",
+                    "label": Object {
+                      "defaultMessage": "Not an Issue",
+                      "id": "KeyMapping.taskCompletion.falsePositive",
+                    },
+                  },
+                  "fixed": Object {
+                    "key": "f",
+                    "label": Object {
+                      "defaultMessage": "I fixed it!",
+                      "id": "KeyMapping.taskCompletion.fixed",
+                    },
+                  },
+                  "skip": Object {
+                    "key": "w",
+                    "label": Object {
+                      "defaultMessage": "Skip",
+                      "id": "KeyMapping.taskCompletion.skip",
+                    },
+                  },
+                  "tooHard": Object {
+                    "key": "d",
+                    "label": Object {
+                      "defaultMessage": "Too difficult / Couldn't see",
+                      "id": "KeyMapping.taskCompletion.tooHard",
+                    },
+                  },
+                },
+                "taskEditing": Object {
+                  "cancel": Object {
+                    "key": "Escape",
+                    "keyLabel": Object {
+                      "defaultMessage": "ESC",
+                      "id": "KeyMapping.taskEditing.escapeLabel",
+                    },
+                    "label": Object {
+                      "defaultMessage": "Cancel Editing",
+                      "id": "KeyMapping.taskEditing.cancel",
+                    },
+                  },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
                     },
                   },
                 },
@@ -20882,6 +21827,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -21044,6 +21996,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -21198,6 +22157,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -21347,6 +22313,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -21499,6 +22472,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -21649,6 +22629,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -21797,6 +22784,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -21958,6 +22952,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -22114,6 +23115,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -22275,6 +23283,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -22423,6 +23438,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -22575,6 +23597,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -22725,6 +23754,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -22869,6 +23905,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -23018,152 +24061,11 @@ ShallowWrapper {
                         "id": "KeyMapping.taskEditing.cancel",
                       },
                     },
-                  },
-                  "taskReview": Object {
-                    "nextTask": Object {
-                      "key": "l",
+                    "fitBounds": Object {
+                      "key": "0",
                       "label": Object {
-                        "defaultMessage": "Next Task",
-                        "id": "KeyMapping.taskReview.nextTask",
-                      },
-                    },
-                    "prevTask": Object {
-                      "key": "h",
-                      "label": Object {
-                        "defaultMessage": "Previous Task",
-                        "id": "KeyMapping.taskReview.prevTask",
-                      },
-                    },
-                  },
-                },
-                "mapBounds": Object {
-                  "task": Object {
-                    "bounds": Array [
-                      0,
-                      0,
-                      0,
-                      0,
-                    ],
-                  },
-                },
-                "nextTask": [Function],
-                "saveTask": [Function],
-                "setTaskBeingCompleted": [Function],
-                "setTaskLoadBy": [Function],
-                "task": Object {
-                  "id": 123,
-                  "parent": Object {
-                    "id": 321,
-                  },
-                  "status": 0,
-                },
-                "taskLoadBy": "random",
-                "unsaveTask": [Function],
-                "user": Object {
-                  "id": 357,
-                  "isLoggedIn": true,
-                  "settings": Object {
-                    "defaultEditor": 1,
-                  },
-                },
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "activateKeyboardShortcutGroup": [Function],
-                "challengeId": 321,
-                "closeEditor": [Function],
-                "completeTask": [Function],
-                "deactivateKeyboardShortcutGroup": [Function],
-                "editTask": [Function],
-                "editor": Object {},
-                "intl": Object {
-                  "formatMessage": [Function],
-                },
-                "keyboardShortcutGroups": Object {
-                  "openEditor": Object {
-                    "editId": Object {
-                      "key": "e",
-                      "label": Object {
-                        "defaultMessage": "Edit in Id",
-                        "id": "KeyMapping.openEditor.editId",
-                      },
-                    },
-                    "editJosm": Object {
-                      "key": "r",
-                      "label": Object {
-                        "defaultMessage": "Edit in JOSM",
-                        "id": "KeyMapping.openEditor.editJosm",
-                      },
-                    },
-                    "editJosmLayer": Object {
-                      "key": "t",
-                      "label": Object {
-                        "defaultMessage": "Edit in new JOSM layer",
-                        "id": "KeyMapping.openEditor.editJosmLayer",
-                      },
-                    },
-                    "editLevel0": Object {
-                      "key": "l",
-                      "label": Object {
-                        "defaultMessage": "Edit in Level0",
-                        "id": "KeyMapping.openEditor.editLevel0",
-                      },
-                    },
-                  },
-                  "taskCompletion": Object {
-                    "alreadyFixed": Object {
-                      "key": "x",
-                      "label": Object {
-                        "defaultMessage": "Already fixed",
-                        "id": "KeyMapping.taskCompletion.alreadyFixed",
-                      },
-                    },
-                    "falsePositive": Object {
-                      "key": "q",
-                      "label": Object {
-                        "defaultMessage": "Not an Issue",
-                        "id": "KeyMapping.taskCompletion.falsePositive",
-                      },
-                    },
-                    "fixed": Object {
-                      "key": "f",
-                      "label": Object {
-                        "defaultMessage": "I fixed it!",
-                        "id": "KeyMapping.taskCompletion.fixed",
-                      },
-                    },
-                    "skip": Object {
-                      "key": "w",
-                      "label": Object {
-                        "defaultMessage": "Skip",
-                        "id": "KeyMapping.taskCompletion.skip",
-                      },
-                    },
-                    "tooHard": Object {
-                      "key": "d",
-                      "label": Object {
-                        "defaultMessage": "Too difficult / Couldn't see",
-                        "id": "KeyMapping.taskCompletion.tooHard",
-                      },
-                    },
-                  },
-                  "taskEditing": Object {
-                    "cancel": Object {
-                      "key": "Escape",
-                      "keyLabel": Object {
-                        "defaultMessage": "ESC",
-                        "id": "KeyMapping.taskEditing.escapeLabel",
-                      },
-                      "label": Object {
-                        "defaultMessage": "Cancel Editing",
-                        "id": "KeyMapping.taskEditing.cancel",
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
                       },
                     },
                   },
@@ -23314,6 +24216,13 @@ ShallowWrapper {
                         "id": "KeyMapping.taskEditing.cancel",
                       },
                     },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
+                      },
+                    },
                   },
                   "taskReview": Object {
                     "nextTask": Object {
@@ -23460,6 +24369,168 @@ ShallowWrapper {
                       "label": Object {
                         "defaultMessage": "Cancel Editing",
                         "id": "KeyMapping.taskEditing.cancel",
+                      },
+                    },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
+                      },
+                    },
+                  },
+                  "taskReview": Object {
+                    "nextTask": Object {
+                      "key": "l",
+                      "label": Object {
+                        "defaultMessage": "Next Task",
+                        "id": "KeyMapping.taskReview.nextTask",
+                      },
+                    },
+                    "prevTask": Object {
+                      "key": "h",
+                      "label": Object {
+                        "defaultMessage": "Previous Task",
+                        "id": "KeyMapping.taskReview.prevTask",
+                      },
+                    },
+                  },
+                },
+                "mapBounds": Object {
+                  "task": Object {
+                    "bounds": Array [
+                      0,
+                      0,
+                      0,
+                      0,
+                    ],
+                  },
+                },
+                "nextTask": [Function],
+                "saveTask": [Function],
+                "setTaskBeingCompleted": [Function],
+                "setTaskLoadBy": [Function],
+                "task": Object {
+                  "id": 123,
+                  "parent": Object {
+                    "id": 321,
+                  },
+                  "status": 0,
+                },
+                "taskLoadBy": "random",
+                "unsaveTask": [Function],
+                "user": Object {
+                  "id": 357,
+                  "isLoggedIn": true,
+                  "settings": Object {
+                    "defaultEditor": 1,
+                  },
+                },
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "activateKeyboardShortcutGroup": [Function],
+                "challengeId": 321,
+                "closeEditor": [Function],
+                "completeTask": [Function],
+                "deactivateKeyboardShortcutGroup": [Function],
+                "editTask": [Function],
+                "editor": Object {},
+                "intl": Object {
+                  "formatMessage": [Function],
+                },
+                "keyboardShortcutGroups": Object {
+                  "openEditor": Object {
+                    "editId": Object {
+                      "key": "e",
+                      "label": Object {
+                        "defaultMessage": "Edit in Id",
+                        "id": "KeyMapping.openEditor.editId",
+                      },
+                    },
+                    "editJosm": Object {
+                      "key": "r",
+                      "label": Object {
+                        "defaultMessage": "Edit in JOSM",
+                        "id": "KeyMapping.openEditor.editJosm",
+                      },
+                    },
+                    "editJosmLayer": Object {
+                      "key": "t",
+                      "label": Object {
+                        "defaultMessage": "Edit in new JOSM layer",
+                        "id": "KeyMapping.openEditor.editJosmLayer",
+                      },
+                    },
+                    "editLevel0": Object {
+                      "key": "l",
+                      "label": Object {
+                        "defaultMessage": "Edit in Level0",
+                        "id": "KeyMapping.openEditor.editLevel0",
+                      },
+                    },
+                  },
+                  "taskCompletion": Object {
+                    "alreadyFixed": Object {
+                      "key": "x",
+                      "label": Object {
+                        "defaultMessage": "Already fixed",
+                        "id": "KeyMapping.taskCompletion.alreadyFixed",
+                      },
+                    },
+                    "falsePositive": Object {
+                      "key": "q",
+                      "label": Object {
+                        "defaultMessage": "Not an Issue",
+                        "id": "KeyMapping.taskCompletion.falsePositive",
+                      },
+                    },
+                    "fixed": Object {
+                      "key": "f",
+                      "label": Object {
+                        "defaultMessage": "I fixed it!",
+                        "id": "KeyMapping.taskCompletion.fixed",
+                      },
+                    },
+                    "skip": Object {
+                      "key": "w",
+                      "label": Object {
+                        "defaultMessage": "Skip",
+                        "id": "KeyMapping.taskCompletion.skip",
+                      },
+                    },
+                    "tooHard": Object {
+                      "key": "d",
+                      "label": Object {
+                        "defaultMessage": "Too difficult / Couldn't see",
+                        "id": "KeyMapping.taskCompletion.tooHard",
+                      },
+                    },
+                  },
+                  "taskEditing": Object {
+                    "cancel": Object {
+                      "key": "Escape",
+                      "keyLabel": Object {
+                        "defaultMessage": "ESC",
+                        "id": "KeyMapping.taskEditing.escapeLabel",
+                      },
+                      "label": Object {
+                        "defaultMessage": "Cancel Editing",
+                        "id": "KeyMapping.taskEditing.cancel",
+                      },
+                    },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
                       },
                     },
                   },
@@ -23630,6 +24701,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -23796,6 +24874,13 @@ ShallowWrapper {
                                       "id": "KeyMapping.taskEditing.cancel",
                                     },
                                   },
+                                  "fitBounds": Object {
+                                    "key": "0",
+                                    "label": Object {
+                                      "defaultMessage": "Fit Map to Task Features",
+                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                    },
+                                  },
                                 },
                                 "taskReview": Object {
                                   "nextTask": Object {
@@ -23956,6 +25041,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -24109,6 +25201,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -24272,6 +25371,13 @@ ShallowWrapper {
                                               "id": "KeyMapping.taskEditing.cancel",
                                             },
                                           },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
+                                            },
+                                          },
                                         },
                                         "taskReview": Object {
                                           "nextTask": Object {
@@ -24432,6 +25538,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -24585,6 +25698,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -24753,6 +25873,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -24918,6 +26045,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -25080,6 +26214,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -25234,6 +26375,13 @@ ShallowWrapper {
                                     "id": "KeyMapping.taskEditing.cancel",
                                   },
                                 },
+                                "fitBounds": Object {
+                                  "key": "0",
+                                  "label": Object {
+                                    "defaultMessage": "Fit Map to Task Features",
+                                    "id": "KeyMapping.taskEditing.fitBounds",
+                                  },
+                                },
                               },
                               "taskReview": Object {
                                 "nextTask": Object {
@@ -25383,6 +26531,13 @@ ShallowWrapper {
                                             "label": Object {
                                               "defaultMessage": "Cancel Editing",
                                               "id": "KeyMapping.taskEditing.cancel",
+                                            },
+                                          },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
                                             },
                                           },
                                         },
@@ -25535,6 +26690,13 @@ ShallowWrapper {
                                               "id": "KeyMapping.taskEditing.cancel",
                                             },
                                           },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
+                                            },
+                                          },
                                         },
                                         "taskReview": Object {
                                           "nextTask": Object {
@@ -25685,6 +26847,13 @@ ShallowWrapper {
                                               "id": "KeyMapping.taskEditing.cancel",
                                             },
                                           },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
+                                            },
+                                          },
                                         },
                                         "taskReview": Object {
                                           "nextTask": Object {
@@ -25833,6 +27002,13 @@ ShallowWrapper {
                                             "label": Object {
                                               "defaultMessage": "Cancel Editing",
                                               "id": "KeyMapping.taskEditing.cancel",
+                                            },
+                                          },
+                                          "fitBounds": Object {
+                                            "key": "0",
+                                            "label": Object {
+                                              "defaultMessage": "Fit Map to Task Features",
+                                              "id": "KeyMapping.taskEditing.fitBounds",
                                             },
                                           },
                                         },
@@ -25994,6 +27170,13 @@ ShallowWrapper {
                   "id": "KeyMapping.taskEditing.cancel",
                 },
               },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
+                },
+              },
             },
             "taskReview": Object {
               "nextTask": Object {
@@ -26150,6 +27333,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -26311,6 +27501,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -26459,6 +27656,13 @@ ShallowWrapper {
                                               "label": Object {
                                                 "defaultMessage": "Cancel Editing",
                                                 "id": "KeyMapping.taskEditing.cancel",
+                                              },
+                                            },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
                                               },
                                             },
                                           },
@@ -26611,6 +27815,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -26761,6 +27972,13 @@ ShallowWrapper {
                                                 "id": "KeyMapping.taskEditing.cancel",
                                               },
                                             },
+                                            "fitBounds": Object {
+                                              "key": "0",
+                                              "label": Object {
+                                                "defaultMessage": "Fit Map to Task Features",
+                                                "id": "KeyMapping.taskEditing.fitBounds",
+                                              },
+                                            },
                                           },
                                           "taskReview": Object {
                                             "nextTask": Object {
@@ -26905,6 +28123,13 @@ ShallowWrapper {
                 "label": Object {
                   "defaultMessage": "Cancel Editing",
                   "id": "KeyMapping.taskEditing.cancel",
+                },
+              },
+              "fitBounds": Object {
+                "key": "0",
+                "label": Object {
+                  "defaultMessage": "Fit Map to Task Features",
+                  "id": "KeyMapping.taskEditing.fitBounds",
                 },
               },
             },
@@ -27054,152 +28279,11 @@ ShallowWrapper {
                       "id": "KeyMapping.taskEditing.cancel",
                     },
                   },
-                },
-                "taskReview": Object {
-                  "nextTask": Object {
-                    "key": "l",
+                  "fitBounds": Object {
+                    "key": "0",
                     "label": Object {
-                      "defaultMessage": "Next Task",
-                      "id": "KeyMapping.taskReview.nextTask",
-                    },
-                  },
-                  "prevTask": Object {
-                    "key": "h",
-                    "label": Object {
-                      "defaultMessage": "Previous Task",
-                      "id": "KeyMapping.taskReview.prevTask",
-                    },
-                  },
-                },
-              },
-              "mapBounds": Object {
-                "task": Object {
-                  "bounds": Array [
-                    0,
-                    0,
-                    0,
-                    0,
-                  ],
-                },
-              },
-              "nextTask": [Function],
-              "saveTask": [Function],
-              "setTaskBeingCompleted": [Function],
-              "setTaskLoadBy": [Function],
-              "task": Object {
-                "id": 123,
-                "parent": Object {
-                  "id": 321,
-                },
-                "status": 0,
-              },
-              "taskLoadBy": "random",
-              "unsaveTask": [Function],
-              "user": Object {
-                "id": 357,
-                "isLoggedIn": true,
-                "settings": Object {
-                  "defaultEditor": 1,
-                },
-              },
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "activateKeyboardShortcutGroup": [Function],
-              "challengeId": 321,
-              "closeEditor": [Function],
-              "completeTask": [Function],
-              "deactivateKeyboardShortcutGroup": [Function],
-              "editTask": [Function],
-              "editor": Object {},
-              "intl": Object {
-                "formatMessage": [Function],
-              },
-              "keyboardShortcutGroups": Object {
-                "openEditor": Object {
-                  "editId": Object {
-                    "key": "e",
-                    "label": Object {
-                      "defaultMessage": "Edit in Id",
-                      "id": "KeyMapping.openEditor.editId",
-                    },
-                  },
-                  "editJosm": Object {
-                    "key": "r",
-                    "label": Object {
-                      "defaultMessage": "Edit in JOSM",
-                      "id": "KeyMapping.openEditor.editJosm",
-                    },
-                  },
-                  "editJosmLayer": Object {
-                    "key": "t",
-                    "label": Object {
-                      "defaultMessage": "Edit in new JOSM layer",
-                      "id": "KeyMapping.openEditor.editJosmLayer",
-                    },
-                  },
-                  "editLevel0": Object {
-                    "key": "l",
-                    "label": Object {
-                      "defaultMessage": "Edit in Level0",
-                      "id": "KeyMapping.openEditor.editLevel0",
-                    },
-                  },
-                },
-                "taskCompletion": Object {
-                  "alreadyFixed": Object {
-                    "key": "x",
-                    "label": Object {
-                      "defaultMessage": "Already fixed",
-                      "id": "KeyMapping.taskCompletion.alreadyFixed",
-                    },
-                  },
-                  "falsePositive": Object {
-                    "key": "q",
-                    "label": Object {
-                      "defaultMessage": "Not an Issue",
-                      "id": "KeyMapping.taskCompletion.falsePositive",
-                    },
-                  },
-                  "fixed": Object {
-                    "key": "f",
-                    "label": Object {
-                      "defaultMessage": "I fixed it!",
-                      "id": "KeyMapping.taskCompletion.fixed",
-                    },
-                  },
-                  "skip": Object {
-                    "key": "w",
-                    "label": Object {
-                      "defaultMessage": "Skip",
-                      "id": "KeyMapping.taskCompletion.skip",
-                    },
-                  },
-                  "tooHard": Object {
-                    "key": "d",
-                    "label": Object {
-                      "defaultMessage": "Too difficult / Couldn't see",
-                      "id": "KeyMapping.taskCompletion.tooHard",
-                    },
-                  },
-                },
-                "taskEditing": Object {
-                  "cancel": Object {
-                    "key": "Escape",
-                    "keyLabel": Object {
-                      "defaultMessage": "ESC",
-                      "id": "KeyMapping.taskEditing.escapeLabel",
-                    },
-                    "label": Object {
-                      "defaultMessage": "Cancel Editing",
-                      "id": "KeyMapping.taskEditing.cancel",
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
                     },
                   },
                 },
@@ -27350,6 +28434,13 @@ ShallowWrapper {
                       "id": "KeyMapping.taskEditing.cancel",
                     },
                   },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
+                    },
+                  },
                 },
                 "taskReview": Object {
                   "nextTask": Object {
@@ -27496,6 +28587,168 @@ ShallowWrapper {
                     "label": Object {
                       "defaultMessage": "Cancel Editing",
                       "id": "KeyMapping.taskEditing.cancel",
+                    },
+                  },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
+                    },
+                  },
+                },
+                "taskReview": Object {
+                  "nextTask": Object {
+                    "key": "l",
+                    "label": Object {
+                      "defaultMessage": "Next Task",
+                      "id": "KeyMapping.taskReview.nextTask",
+                    },
+                  },
+                  "prevTask": Object {
+                    "key": "h",
+                    "label": Object {
+                      "defaultMessage": "Previous Task",
+                      "id": "KeyMapping.taskReview.prevTask",
+                    },
+                  },
+                },
+              },
+              "mapBounds": Object {
+                "task": Object {
+                  "bounds": Array [
+                    0,
+                    0,
+                    0,
+                    0,
+                  ],
+                },
+              },
+              "nextTask": [Function],
+              "saveTask": [Function],
+              "setTaskBeingCompleted": [Function],
+              "setTaskLoadBy": [Function],
+              "task": Object {
+                "id": 123,
+                "parent": Object {
+                  "id": 321,
+                },
+                "status": 0,
+              },
+              "taskLoadBy": "random",
+              "unsaveTask": [Function],
+              "user": Object {
+                "id": 357,
+                "isLoggedIn": true,
+                "settings": Object {
+                  "defaultEditor": 1,
+                },
+              },
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "activateKeyboardShortcutGroup": [Function],
+              "challengeId": 321,
+              "closeEditor": [Function],
+              "completeTask": [Function],
+              "deactivateKeyboardShortcutGroup": [Function],
+              "editTask": [Function],
+              "editor": Object {},
+              "intl": Object {
+                "formatMessage": [Function],
+              },
+              "keyboardShortcutGroups": Object {
+                "openEditor": Object {
+                  "editId": Object {
+                    "key": "e",
+                    "label": Object {
+                      "defaultMessage": "Edit in Id",
+                      "id": "KeyMapping.openEditor.editId",
+                    },
+                  },
+                  "editJosm": Object {
+                    "key": "r",
+                    "label": Object {
+                      "defaultMessage": "Edit in JOSM",
+                      "id": "KeyMapping.openEditor.editJosm",
+                    },
+                  },
+                  "editJosmLayer": Object {
+                    "key": "t",
+                    "label": Object {
+                      "defaultMessage": "Edit in new JOSM layer",
+                      "id": "KeyMapping.openEditor.editJosmLayer",
+                    },
+                  },
+                  "editLevel0": Object {
+                    "key": "l",
+                    "label": Object {
+                      "defaultMessage": "Edit in Level0",
+                      "id": "KeyMapping.openEditor.editLevel0",
+                    },
+                  },
+                },
+                "taskCompletion": Object {
+                  "alreadyFixed": Object {
+                    "key": "x",
+                    "label": Object {
+                      "defaultMessage": "Already fixed",
+                      "id": "KeyMapping.taskCompletion.alreadyFixed",
+                    },
+                  },
+                  "falsePositive": Object {
+                    "key": "q",
+                    "label": Object {
+                      "defaultMessage": "Not an Issue",
+                      "id": "KeyMapping.taskCompletion.falsePositive",
+                    },
+                  },
+                  "fixed": Object {
+                    "key": "f",
+                    "label": Object {
+                      "defaultMessage": "I fixed it!",
+                      "id": "KeyMapping.taskCompletion.fixed",
+                    },
+                  },
+                  "skip": Object {
+                    "key": "w",
+                    "label": Object {
+                      "defaultMessage": "Skip",
+                      "id": "KeyMapping.taskCompletion.skip",
+                    },
+                  },
+                  "tooHard": Object {
+                    "key": "d",
+                    "label": Object {
+                      "defaultMessage": "Too difficult / Couldn't see",
+                      "id": "KeyMapping.taskCompletion.tooHard",
+                    },
+                  },
+                },
+                "taskEditing": Object {
+                  "cancel": Object {
+                    "key": "Escape",
+                    "keyLabel": Object {
+                      "defaultMessage": "ESC",
+                      "id": "KeyMapping.taskEditing.escapeLabel",
+                    },
+                    "label": Object {
+                      "defaultMessage": "Cancel Editing",
+                      "id": "KeyMapping.taskEditing.cancel",
+                    },
+                  },
+                  "fitBounds": Object {
+                    "key": "0",
+                    "label": Object {
+                      "defaultMessage": "Fit Map to Task Features",
+                      "id": "KeyMapping.taskEditing.fitBounds",
                     },
                   },
                 },
@@ -27660,6 +28913,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -27822,6 +29082,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -27976,6 +29243,13 @@ ShallowWrapper {
                                           "id": "KeyMapping.taskEditing.cancel",
                                         },
                                       },
+                                      "fitBounds": Object {
+                                        "key": "0",
+                                        "label": Object {
+                                          "defaultMessage": "Fit Map to Task Features",
+                                          "id": "KeyMapping.taskEditing.fitBounds",
+                                        },
+                                      },
                                     },
                                     "taskReview": Object {
                                       "nextTask": Object {
@@ -28125,6 +29399,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -28277,6 +29558,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -28427,6 +29715,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -28575,6 +29870,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -28736,6 +30038,13 @@ ShallowWrapper {
                     "id": "KeyMapping.taskEditing.cancel",
                   },
                 },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
+                  },
+                },
               },
               "taskReview": Object {
                 "nextTask": Object {
@@ -28892,6 +30201,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -29053,6 +30369,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -29201,6 +30524,13 @@ ShallowWrapper {
                                                     "label": Object {
                                                       "defaultMessage": "Cancel Editing",
                                                       "id": "KeyMapping.taskEditing.cancel",
+                                                    },
+                                                  },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
                                                     },
                                                   },
                                                 },
@@ -29353,6 +30683,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -29503,6 +30840,13 @@ ShallowWrapper {
                                                       "id": "KeyMapping.taskEditing.cancel",
                                                     },
                                                   },
+                                                  "fitBounds": Object {
+                                                    "key": "0",
+                                                    "label": Object {
+                                                      "defaultMessage": "Fit Map to Task Features",
+                                                      "id": "KeyMapping.taskEditing.fitBounds",
+                                                    },
+                                                  },
                                                 },
                                                 "taskReview": Object {
                                                   "nextTask": Object {
@@ -29647,6 +30991,13 @@ ShallowWrapper {
                   "label": Object {
                     "defaultMessage": "Cancel Editing",
                     "id": "KeyMapping.taskEditing.cancel",
+                  },
+                },
+                "fitBounds": Object {
+                  "key": "0",
+                  "label": Object {
+                    "defaultMessage": "Fit Map to Task Features",
+                    "id": "KeyMapping.taskEditing.fitBounds",
                   },
                 },
               },
@@ -29796,152 +31147,11 @@ ShallowWrapper {
                         "id": "KeyMapping.taskEditing.cancel",
                       },
                     },
-                  },
-                  "taskReview": Object {
-                    "nextTask": Object {
-                      "key": "l",
+                    "fitBounds": Object {
+                      "key": "0",
                       "label": Object {
-                        "defaultMessage": "Next Task",
-                        "id": "KeyMapping.taskReview.nextTask",
-                      },
-                    },
-                    "prevTask": Object {
-                      "key": "h",
-                      "label": Object {
-                        "defaultMessage": "Previous Task",
-                        "id": "KeyMapping.taskReview.prevTask",
-                      },
-                    },
-                  },
-                },
-                "mapBounds": Object {
-                  "task": Object {
-                    "bounds": Array [
-                      0,
-                      0,
-                      0,
-                      0,
-                    ],
-                  },
-                },
-                "nextTask": [Function],
-                "saveTask": [Function],
-                "setTaskBeingCompleted": [Function],
-                "setTaskLoadBy": [Function],
-                "task": Object {
-                  "id": 123,
-                  "parent": Object {
-                    "id": 321,
-                  },
-                  "status": 0,
-                },
-                "taskLoadBy": "random",
-                "unsaveTask": [Function],
-                "user": Object {
-                  "id": 357,
-                  "isLoggedIn": true,
-                  "settings": Object {
-                    "defaultEditor": 1,
-                  },
-                },
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "activateKeyboardShortcutGroup": [Function],
-                "challengeId": 321,
-                "closeEditor": [Function],
-                "completeTask": [Function],
-                "deactivateKeyboardShortcutGroup": [Function],
-                "editTask": [Function],
-                "editor": Object {},
-                "intl": Object {
-                  "formatMessage": [Function],
-                },
-                "keyboardShortcutGroups": Object {
-                  "openEditor": Object {
-                    "editId": Object {
-                      "key": "e",
-                      "label": Object {
-                        "defaultMessage": "Edit in Id",
-                        "id": "KeyMapping.openEditor.editId",
-                      },
-                    },
-                    "editJosm": Object {
-                      "key": "r",
-                      "label": Object {
-                        "defaultMessage": "Edit in JOSM",
-                        "id": "KeyMapping.openEditor.editJosm",
-                      },
-                    },
-                    "editJosmLayer": Object {
-                      "key": "t",
-                      "label": Object {
-                        "defaultMessage": "Edit in new JOSM layer",
-                        "id": "KeyMapping.openEditor.editJosmLayer",
-                      },
-                    },
-                    "editLevel0": Object {
-                      "key": "l",
-                      "label": Object {
-                        "defaultMessage": "Edit in Level0",
-                        "id": "KeyMapping.openEditor.editLevel0",
-                      },
-                    },
-                  },
-                  "taskCompletion": Object {
-                    "alreadyFixed": Object {
-                      "key": "x",
-                      "label": Object {
-                        "defaultMessage": "Already fixed",
-                        "id": "KeyMapping.taskCompletion.alreadyFixed",
-                      },
-                    },
-                    "falsePositive": Object {
-                      "key": "q",
-                      "label": Object {
-                        "defaultMessage": "Not an Issue",
-                        "id": "KeyMapping.taskCompletion.falsePositive",
-                      },
-                    },
-                    "fixed": Object {
-                      "key": "f",
-                      "label": Object {
-                        "defaultMessage": "I fixed it!",
-                        "id": "KeyMapping.taskCompletion.fixed",
-                      },
-                    },
-                    "skip": Object {
-                      "key": "w",
-                      "label": Object {
-                        "defaultMessage": "Skip",
-                        "id": "KeyMapping.taskCompletion.skip",
-                      },
-                    },
-                    "tooHard": Object {
-                      "key": "d",
-                      "label": Object {
-                        "defaultMessage": "Too difficult / Couldn't see",
-                        "id": "KeyMapping.taskCompletion.tooHard",
-                      },
-                    },
-                  },
-                  "taskEditing": Object {
-                    "cancel": Object {
-                      "key": "Escape",
-                      "keyLabel": Object {
-                        "defaultMessage": "ESC",
-                        "id": "KeyMapping.taskEditing.escapeLabel",
-                      },
-                      "label": Object {
-                        "defaultMessage": "Cancel Editing",
-                        "id": "KeyMapping.taskEditing.cancel",
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
                       },
                     },
                   },
@@ -30092,6 +31302,13 @@ ShallowWrapper {
                         "id": "KeyMapping.taskEditing.cancel",
                       },
                     },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
+                      },
+                    },
                   },
                   "taskReview": Object {
                     "nextTask": Object {
@@ -30238,6 +31455,168 @@ ShallowWrapper {
                       "label": Object {
                         "defaultMessage": "Cancel Editing",
                         "id": "KeyMapping.taskEditing.cancel",
+                      },
+                    },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
+                      },
+                    },
+                  },
+                  "taskReview": Object {
+                    "nextTask": Object {
+                      "key": "l",
+                      "label": Object {
+                        "defaultMessage": "Next Task",
+                        "id": "KeyMapping.taskReview.nextTask",
+                      },
+                    },
+                    "prevTask": Object {
+                      "key": "h",
+                      "label": Object {
+                        "defaultMessage": "Previous Task",
+                        "id": "KeyMapping.taskReview.prevTask",
+                      },
+                    },
+                  },
+                },
+                "mapBounds": Object {
+                  "task": Object {
+                    "bounds": Array [
+                      0,
+                      0,
+                      0,
+                      0,
+                    ],
+                  },
+                },
+                "nextTask": [Function],
+                "saveTask": [Function],
+                "setTaskBeingCompleted": [Function],
+                "setTaskLoadBy": [Function],
+                "task": Object {
+                  "id": 123,
+                  "parent": Object {
+                    "id": 321,
+                  },
+                  "status": 0,
+                },
+                "taskLoadBy": "random",
+                "unsaveTask": [Function],
+                "user": Object {
+                  "id": 357,
+                  "isLoggedIn": true,
+                  "settings": Object {
+                    "defaultEditor": 1,
+                  },
+                },
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "activateKeyboardShortcutGroup": [Function],
+                "challengeId": 321,
+                "closeEditor": [Function],
+                "completeTask": [Function],
+                "deactivateKeyboardShortcutGroup": [Function],
+                "editTask": [Function],
+                "editor": Object {},
+                "intl": Object {
+                  "formatMessage": [Function],
+                },
+                "keyboardShortcutGroups": Object {
+                  "openEditor": Object {
+                    "editId": Object {
+                      "key": "e",
+                      "label": Object {
+                        "defaultMessage": "Edit in Id",
+                        "id": "KeyMapping.openEditor.editId",
+                      },
+                    },
+                    "editJosm": Object {
+                      "key": "r",
+                      "label": Object {
+                        "defaultMessage": "Edit in JOSM",
+                        "id": "KeyMapping.openEditor.editJosm",
+                      },
+                    },
+                    "editJosmLayer": Object {
+                      "key": "t",
+                      "label": Object {
+                        "defaultMessage": "Edit in new JOSM layer",
+                        "id": "KeyMapping.openEditor.editJosmLayer",
+                      },
+                    },
+                    "editLevel0": Object {
+                      "key": "l",
+                      "label": Object {
+                        "defaultMessage": "Edit in Level0",
+                        "id": "KeyMapping.openEditor.editLevel0",
+                      },
+                    },
+                  },
+                  "taskCompletion": Object {
+                    "alreadyFixed": Object {
+                      "key": "x",
+                      "label": Object {
+                        "defaultMessage": "Already fixed",
+                        "id": "KeyMapping.taskCompletion.alreadyFixed",
+                      },
+                    },
+                    "falsePositive": Object {
+                      "key": "q",
+                      "label": Object {
+                        "defaultMessage": "Not an Issue",
+                        "id": "KeyMapping.taskCompletion.falsePositive",
+                      },
+                    },
+                    "fixed": Object {
+                      "key": "f",
+                      "label": Object {
+                        "defaultMessage": "I fixed it!",
+                        "id": "KeyMapping.taskCompletion.fixed",
+                      },
+                    },
+                    "skip": Object {
+                      "key": "w",
+                      "label": Object {
+                        "defaultMessage": "Skip",
+                        "id": "KeyMapping.taskCompletion.skip",
+                      },
+                    },
+                    "tooHard": Object {
+                      "key": "d",
+                      "label": Object {
+                        "defaultMessage": "Too difficult / Couldn't see",
+                        "id": "KeyMapping.taskCompletion.tooHard",
+                      },
+                    },
+                  },
+                  "taskEditing": Object {
+                    "cancel": Object {
+                      "key": "Escape",
+                      "keyLabel": Object {
+                        "defaultMessage": "ESC",
+                        "id": "KeyMapping.taskEditing.escapeLabel",
+                      },
+                      "label": Object {
+                        "defaultMessage": "Cancel Editing",
+                        "id": "KeyMapping.taskEditing.cancel",
+                      },
+                    },
+                    "fitBounds": Object {
+                      "key": "0",
+                      "label": Object {
+                        "defaultMessage": "Fit Map to Task Features",
+                        "id": "KeyMapping.taskEditing.fitBounds",
                       },
                     },
                   },

--- a/src/components/TaskPane/ActiveTaskDetails/KeyboardShortcutReference/KeyboardShortcutReference.scss
+++ b/src/components/TaskPane/ActiveTaskDetails/KeyboardShortcutReference/KeyboardShortcutReference.scss
@@ -33,7 +33,6 @@
         float: left;
         min-width: 40px;
         margin-right: 15px;
-        margin-top: -3px;
         color: $primary;
         font-family: monospace;
         font-weight: $weight-bold;

--- a/src/components/TaskPane/TaskMap/__snapshots__/TaskMap.test.js.snap
+++ b/src/components/TaskPane/TaskMap/__snapshots__/TaskMap.test.js.snap
@@ -84,7 +84,7 @@ ShallowWrapper {
           <ZoomControl
                     position="topright"
           />
-          <InjectIntl(FitBoundsControl) />
+          <Connect(InjectIntl(FitBoundsControl)) />
           <InjectIntl(SourcedTileLayer)
                     centerPoint={
                               Object {
@@ -157,7 +157,7 @@ ShallowWrapper {
             <ZoomControl
               position="topright"
 />,
-            <InjectIntl(FitBoundsControl) />,
+            <Connect(InjectIntl(FitBoundsControl)) />,
             <InjectIntl(SourcedTileLayer)
               centerPoint={
                             Object {
@@ -302,7 +302,7 @@ ShallowWrapper {
             <ZoomControl
                         position="topright"
             />
-            <InjectIntl(FitBoundsControl) />
+            <Connect(InjectIntl(FitBoundsControl)) />
             <InjectIntl(SourcedTileLayer)
                         centerPoint={
                                     Object {
@@ -375,7 +375,7 @@ ShallowWrapper {
               <ZoomControl
                 position="topright"
 />,
-              <InjectIntl(FitBoundsControl) />,
+              <Connect(InjectIntl(FitBoundsControl)) />,
               <InjectIntl(SourcedTileLayer)
                 centerPoint={
                                 Object {

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -415,6 +415,7 @@
   "KeyMapping.openEditor.editJosmLayer": "Edit in new JOSM layer",
   "KeyMapping.openEditor.editLevel0": "Edit in Level0",
   "KeyMapping.taskEditing.cancel": "Cancel Editing",
+  "KeyMapping.taskEditing.fitBounds": "Fit Map to Task Features",
   "KeyMapping.taskEditing.escapeLabel": "ESC",
   "KeyMapping.taskCompletion.skip": "Skip",
   "KeyMapping.taskCompletion.falsePositive": "Not an Issue",

--- a/src/services/KeyboardShortcuts/KeyMappings.js
+++ b/src/services/KeyboardShortcuts/KeyMappings.js
@@ -20,7 +20,8 @@ export default {
     editLevel0: {key: 'l', label: messages.editLevel0},
   },
   taskEditing: {
-    cancel: {key: 'Escape', label: messages.cancel, keyLabel: messages.escapeLabel}
+    cancel: {key: 'Escape', label: messages.cancel, keyLabel: messages.escapeLabel},
+    fitBounds: {key: '0', label: messages.fitBounds},
   },
   taskCompletion: {
     skip: {key: 'w', label: messages.skip},

--- a/src/services/KeyboardShortcuts/Messages.js
+++ b/src/services/KeyboardShortcuts/Messages.js
@@ -29,6 +29,11 @@ export default defineMessages({
     defaultMessage: "Cancel Editing",
   },
 
+  fitBounds: {
+    id: "KeyMapping.taskEditing.fitBounds",
+    defaultMessage: "Fit Map to Task Features",
+  },
+
   escapeLabel: {
     id: "KeyMapping.taskEditing.escapeLabel",
     defaultMessage: "ESC",


### PR DESCRIPTION
Add `0` keyboard shortcut (next to `-` and `+` zoom out/in) for
fitting the task map bounds to the task features when completing a task