### PR TITLE
Fix switched 'asc' 'desc' flags on sorting by 'name' and 'created'

### DIFF
--- a/src/components/HOCs/WithSearch/WithSearch.js
+++ b/src/components/HOCs/WithSearch/WithSearch.js
@@ -143,10 +143,10 @@ export const mapDispatchToProps = (dispatch, ownProps, searchGroup) => ({
 
       switch(sortBy) {
         case SORT_NAME:
-          sort = {sortBy, direction: 'desc'}
+          sort = {sortBy, direction: 'asc'}
           break
         case SORT_CREATED:
-          sort = {sortBy, direction: 'asc'}
+          sort = {sortBy, direction: 'desc'}
           break
         default:
           sort = {sortBy: null, direction: null}


### PR DESCRIPTION
Fixes switched 'asc' and 'desc' flags when sorting by 'name' and 'created'