### PR TITLE
Change retrieveChallengeTask to throw errors from server

### DIFF
--- a/src/components/ChallengePane/ChallengeResultItem/ChallengeResultItem.js
+++ b/src/components/ChallengePane/ChallengeResultItem/ChallengeResultItem.js
@@ -43,8 +43,6 @@ export class ChallengeResultItem extends Component {
      * ensure our state is synced up with any prop changes.
      **/
     isBrowsing: _get(this.props, 'browsedChallenge.id') === this.props.challenge.id,
-    /** Set to true when the user indicates they wish to start the challenge */
-    isStarting: false,
   }
 
   componentDidMount() {
@@ -147,10 +145,7 @@ export class ChallengeResultItem extends Component {
    * @private
    */
   startChallenge = () => {
-    if (!this.state.isStarting) {
-      this.props.startChallenge(this.props.challenge)
-      this.setState({isStarting: true})
-    }
+    this.props.startChallenge(this.props.challenge)
   }
 
   render() {
@@ -252,7 +247,7 @@ export class ChallengeResultItem extends Component {
               <div className="field is-grouped">
                 <p className="control">
                   <button className={classNames("button is-outlined start-challenge",
-                                                {"is-loading": this.state.isStarting})}
+                                                {"is-loading": this.props.isStarting})}
                           onClick={this.startChallenge}>
                     <FormattedMessage {...messages.start} />
                   </button>
@@ -298,6 +293,8 @@ ChallengeResultItem.propTypes = {
   saveChallenge: PropTypes.func.isRequired,
   /** Invoked when a user indicates they wish to unsave/bookmark a challenge */
   unsaveChallenge: PropTypes.func.isRequired,
+  /** Indicates whether the challenge is in the middle of being started */
+  isStarting: PropTypes.bool.isRequired,
 }
 
 export default injectIntl(ChallengeResultItem)

--- a/src/components/ChallengePane/ChallengeResultItem/ChallengeResultItem.test.js
+++ b/src/components/ChallengePane/ChallengeResultItem/ChallengeResultItem.test.js
@@ -30,6 +30,7 @@ beforeEach(() => {
     startBrowsingChallenge: jest.fn(),
     stopBrowsingChallenge: jest.fn(),
     intl: {formatMessage: jest.fn()},
+    isStarting: false,
   }
 })
 

--- a/src/components/ChallengePane/ChallengeResultItem/__snapshots__/ChallengeResultItem.test.js.snap
+++ b/src/components/ChallengePane/ChallengeResultItem/__snapshots__/ChallengeResultItem.test.js.snap
@@ -34,6 +34,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    isStarting={false}
     saveChallenge={[Function]}
     startBrowsingChallenge={[Function]}
     startChallenge={[Function]}
@@ -1507,6 +1508,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    isStarting={false}
     saveChallenge={[Function]}
     startBrowsingChallenge={[Function]}
     startChallenge={[Function]}
@@ -2082,6 +2084,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    isStarting={false}
     saveChallenge={[Function]}
     startBrowsingChallenge={[Function]}
     startChallenge={[Function]}
@@ -2658,6 +2661,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    isStarting={false}
     saveChallenge={[Function]}
     startBrowsingChallenge={[Function]}
     startChallenge={[Function]}
@@ -3300,6 +3304,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    isStarting={false}
     saveChallenge={[Function]}
     startBrowsingChallenge={[Function]}
     startChallenge={[Function]}
@@ -3804,6 +3809,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    isStarting={false}
     saveChallenge={[Function]}
     startBrowsingChallenge={[Function]}
     startChallenge={[Function]}
@@ -4319,6 +4325,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    isStarting={false}
     saveChallenge={[Function]}
     startBrowsingChallenge={[Function]}
     startChallenge={[Function]}
@@ -6047,6 +6054,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    isStarting={false}
     saveChallenge={[Function]}
     startBrowsingChallenge={[Function]}
     startChallenge={[Function]}
@@ -6551,6 +6559,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    isStarting={false}
     saveChallenge={[Function]}
     startBrowsingChallenge={[Function]}
     startChallenge={[Function]}
@@ -7066,6 +7075,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    isStarting={false}
     saveChallenge={[Function]}
     startBrowsingChallenge={[Function]}
     startChallenge={[Function]}
@@ -8805,6 +8815,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    isStarting={false}
     saveChallenge={[Function]}
     startBrowsingChallenge={[Function]}
     startChallenge={[Function]}
@@ -8921,7 +8932,7 @@ ShallowWrapper {
                                                   className="control"
                                         >
                                                   <button
-                                                            className="button is-outlined start-challenge is-loading"
+                                                            className="button is-outlined start-challenge"
                                                             onClick={[Function]}
                                                   >
                                                             <FormattedMessage
@@ -9177,7 +9188,7 @@ ShallowWrapper {
                                                 className="control"
                                     >
                                                 <button
-                                                            className="button is-outlined start-challenge is-loading"
+                                                            className="button is-outlined start-challenge"
                                                             onClick={[Function]}
                                                 >
                                                             <FormattedMessage
@@ -9268,7 +9279,7 @@ ShallowWrapper {
                                                 className="control"
                                 >
                                                 <button
-                                                                className="button is-outlined start-challenge is-loading"
+                                                                className="button is-outlined start-challenge"
                                                                 onClick={[Function]}
                                                 >
                                                                 <FormattedMessage
@@ -9445,7 +9456,7 @@ ShallowWrapper {
                                         className="control"
                     >
                                         <button
-                                                            className="button is-outlined start-challenge is-loading"
+                                                            className="button is-outlined start-challenge"
                                                             onClick={[Function]}
                                         >
                                                             <FormattedMessage
@@ -9488,7 +9499,7 @@ ShallowWrapper {
                         className="control"
 >
                         <button
-                                                className="button is-outlined start-challenge is-loading"
+                                                className="button is-outlined start-challenge"
                                                 onClick={[Function]}
                         >
                                                 <FormattedMessage
@@ -9525,7 +9536,7 @@ ShallowWrapper {
                       "nodeType": "host",
                       "props": Object {
                         "children": <button
-                          className="button is-outlined start-challenge is-loading"
+                          className="button is-outlined start-challenge"
                           onClick={[Function]}
 >
                           <FormattedMessage
@@ -9547,7 +9558,7 @@ ShallowWrapper {
                             id="Challenge.controls.start.label"
                             values={Object {}}
 />,
-                          "className": "button is-outlined start-challenge is-loading",
+                          "className": "button is-outlined start-challenge",
                           "onClick": [Function],
                         },
                         "ref": null,
@@ -9759,7 +9770,7 @@ ShallowWrapper {
                                                             className="control"
                                                 >
                                                             <button
-                                                                        className="button is-outlined start-challenge is-loading"
+                                                                        className="button is-outlined start-challenge"
                                                                         onClick={[Function]}
                                                             >
                                                                         <FormattedMessage
@@ -10015,7 +10026,7 @@ ShallowWrapper {
                                                         className="control"
                                           >
                                                         <button
-                                                                      className="button is-outlined start-challenge is-loading"
+                                                                      className="button is-outlined start-challenge"
                                                                       onClick={[Function]}
                                                         >
                                                                       <FormattedMessage
@@ -10106,7 +10117,7 @@ ShallowWrapper {
                                                       className="control"
                                     >
                                                       <button
-                                                                        className="button is-outlined start-challenge is-loading"
+                                                                        className="button is-outlined start-challenge"
                                                                         onClick={[Function]}
                                                       >
                                                                         <FormattedMessage
@@ -10283,7 +10294,7 @@ ShallowWrapper {
                                             className="control"
                       >
                                             <button
-                                                                  className="button is-outlined start-challenge is-loading"
+                                                                  className="button is-outlined start-challenge"
                                                                   onClick={[Function]}
                                             >
                                                                   <FormattedMessage
@@ -10326,7 +10337,7 @@ ShallowWrapper {
                           className="control"
 >
                           <button
-                                                    className="button is-outlined start-challenge is-loading"
+                                                    className="button is-outlined start-challenge"
                                                     onClick={[Function]}
                           >
                                                     <FormattedMessage
@@ -10363,7 +10374,7 @@ ShallowWrapper {
                         "nodeType": "host",
                         "props": Object {
                           "children": <button
-                            className="button is-outlined start-challenge is-loading"
+                            className="button is-outlined start-challenge"
                             onClick={[Function]}
 >
                             <FormattedMessage
@@ -10385,7 +10396,7 @@ ShallowWrapper {
                               id="Challenge.controls.start.label"
                               values={Object {}}
 />,
-                            "className": "button is-outlined start-challenge is-loading",
+                            "className": "button is-outlined start-challenge",
                             "onClick": [Function],
                           },
                           "ref": null,
@@ -10544,6 +10555,7 @@ ShallowWrapper {
             "formatMessage": [Function],
           }
     }
+    isStarting={false}
     saveChallenge={[Function]}
     startBrowsingChallenge={[Function]}
     startChallenge={[Function]}

--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
@@ -113,9 +113,16 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
      * Invoke to mark as a task as complete with the given status
      */
     completeTask: (taskId, challengeId, taskStatus, comment, taskLoadBy) => {
-      dispatch(
+      return dispatch(
         completeTask(taskId, challengeId, taskStatus)
       ).then(() => {
+        // Start loading the next task from the challenge.
+        nextRandomTask(dispatch, ownProps, taskId, taskLoadBy).then(newTask =>
+          visitNewTask(ownProps, taskId, newTask)
+        ).catch(error => {
+          ownProps.history.push(`/browse/challenges/${challengeId}`)
+        })
+
         if (_isString(comment) && comment.length > 0) {
           dispatch(addTaskComment(taskId, comment, taskStatus))
         }
@@ -127,11 +134,6 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
           dispatch(renewVirtualChallenge(ownProps.virtualChallengeId))
         }
       })
-
-      // Load the next task from the challenge.
-      return nextRandomTask(dispatch, ownProps, taskId, taskLoadBy).then(newTask =>
-        visitNewTask(ownProps, taskId, newTask)
-      )
     },
 
     /**

--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.test.js
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.test.js
@@ -123,7 +123,7 @@ test("completeTask does not call addComment if no comment", async () => {
   expect(addTaskComment).not.toHaveBeenCalled()
 })
 
-test("completeTask calls loadRandomTaskFromChallenge without proximate task by default", () => {
+test("completeTask calls loadRandomTaskFromChallenge without proximate task by default",  async () => {
   const dispatch  = jest.fn(() => Promise.resolve())
   const history = {
    push: jest.fn(),
@@ -131,11 +131,11 @@ test("completeTask calls loadRandomTaskFromChallenge without proximate task by d
 
   const mappedProps = mapDispatchToProps(dispatch, {history, challengeId: challenge.id})
 
-  mappedProps.completeTask(task.id, challenge.id, completionStatus)
+  await mappedProps.completeTask(task.id, challenge.id, completionStatus)
   expect(loadRandomTaskFromChallenge).toBeCalledWith(challenge.id, undefined)
 })
 
-test("completeTask calls loadRandomTaskFromChallenge with task if proximate load method", () => {
+test("completeTask calls loadRandomTaskFromChallenge with task if proximate load method", async () => {
   const dispatch  = jest.fn(() => Promise.resolve())
   const history = {
    push: jest.fn(),
@@ -143,7 +143,7 @@ test("completeTask calls loadRandomTaskFromChallenge with task if proximate load
 
   const mappedProps = mapDispatchToProps(dispatch, {history, challengeId: challenge.id})
 
-  mappedProps.completeTask(task.id, challenge.id,
+  await mappedProps.completeTask(task.id, challenge.id,
                            completionStatus, "", TaskLoadMethod.proximity)
   expect(loadRandomTaskFromChallenge).toBeCalledWith(challenge.id, task.id)
 })

--- a/src/components/HOCs/WithOptionalManagement/WithOptionalManagement.js
+++ b/src/components/HOCs/WithOptionalManagement/WithOptionalManagement.js
@@ -28,10 +28,15 @@ const WithOptionalManagement = function(WrappedComponent) {
       }
     }
 
+    setActive = (activeState) => {
+      this.setState({isActive: activeState})
+    }
+
     render() {
       return <WrappedComponent isActive={this.isActive}
                                toggleActive={this.toggleActive}
-                               {..._omit(this.props, ['isActive', 'toggleActive'])} />
+                               setActive={this.setActive}
+                               {..._omit(this.props, ['isActive', 'toggleActive', 'setActive'])} />
     }
   }
 }

--- a/src/components/LoadRandomChallengeTask/LoadRandomChallengeTask.js
+++ b/src/components/LoadRandomChallengeTask/LoadRandomChallengeTask.js
@@ -21,6 +21,9 @@ const _LoadRandomChallengeTask = class extends Component {
             this.props.history.push('/')
           }
         })
+        .catch(error => {
+          this.props.history.push(`/browse/challenges/${challengeId}`)
+        })
     }
   }
 

--- a/src/components/LoadRandomVirtualChallengeTask/LoadRandomVirtualChallengeTask.js
+++ b/src/components/LoadRandomVirtualChallengeTask/LoadRandomVirtualChallengeTask.js
@@ -17,6 +17,8 @@ const _LoadRandomVirtualChallengeTask = class extends Component {
         virtualChallengeId
       ).then(task => this.props.history.replace(
                 `/virtual/${virtualChallengeId}/task/${task.id}`)
+      ).catch(error =>
+        this.props.history.push(`/browse/challenges`)
       )
     }
   }

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -426,8 +426,9 @@ export const deleteTask = function(taskId) {
  */
 export const retrieveChallengeTask = function(dispatch, endpoint) {
   return endpoint.execute().then(normalizedTaskResults => {
-    if (!_isNumber(normalizedTaskResults.result) &&
-        _isEmpty(normalizedTaskResults.result)) {
+    if (!normalizedTaskResults ||
+        (!_isNumber(normalizedTaskResults.result) &&
+         _isEmpty(normalizedTaskResults.result))) {
       return null
     }
 
@@ -462,6 +463,7 @@ export const retrieveChallengeTask = function(dispatch, endpoint) {
   }).catch((error) => {
     dispatch(addError(AppErrors.task.fetchFailure))
     console.log(error.response || error)
+    throw error
   })
 }
 


### PR DESCRIPTION
* Changes retrieveChallengeTask to throw error received from server
    
* Moves isStarting flag for spinner on 'start challenge' button into WithStartChallenge 
   to prevent infinite spinning on error
    
* Displays error when no more tasks are retrieved and redirects to challenge browse 
   instead of Congratulations message.

* completeTask now waits for setting the task status to finish before retrieving next task so
   it knows if the challenge has been truly completed
