### PR TITLE
Fix layer toggle checkbox

### DIFF
--- a/src/components/EnhancedMap/LayerToggle/LayerToggle.js
+++ b/src/components/EnhancedMap/LayerToggle/LayerToggle.js
@@ -41,15 +41,13 @@ export class LayerToggle extends Component {
 
     const overlayToggles = _map(this.props.intersectingOverlays, layer => (
       <div key={layer.id} className="layer-toggle__option-controls">
-        <label className="checkbox"
-          onClick={e => {
-            e.preventDefault()
-            this.toggleOverlay(layer.id)
-          }}>
+        <div className="checkbox"
+          onClick={e => this.toggleOverlay(layer.id)}>
           <input type="checkbox"
                  checked={this.overlayVisible(layer.id)}
-                 onChange={_noop} /> {layer.name}
-        </label>
+                 onChange={_noop} />
+          <label>{layer.name}</label>
+        </div>
       </div>
     ))
 
@@ -76,16 +74,14 @@ export class LayerToggle extends Component {
             {overlayToggles}
             {this.props.toggleTaskFeatures &&
               <div className="layer-toggle__option-controls">
-                <label className="checkbox"
-                  onClick={e => {
-                    e.preventDefault()
-                    this.props.toggleTaskFeatures()
-                  }}>
+                <div className="checkbox"
+                  onClick={e => this.props.toggleTaskFeatures()}>
                   <input type="checkbox"
                          checked={this.props.showTaskFeatures}
                          onChange={_noop}
-                  /> <FormattedMessage {...messages.showTaskFeaturesLabel} />
-                </label>
+                  />
+                  <label><FormattedMessage {...messages.showTaskFeaturesLabel} /></label>
+                </div>
               </div>
             }
           </div>

--- a/src/components/EnhancedMap/LayerToggle/LayerToggle.scss
+++ b/src/components/EnhancedMap/LayerToggle/LayerToggle.scss
@@ -19,13 +19,17 @@
   }
 
   .layer-toggle__option-controls {
-    label {
+    div.checkbox {
       font-size: $size-7;
       padding-left: 1rem;
       color: $grey-dark;
 
       &:hover {
         color: $grey-dark;
+      }
+
+      label {
+        padding-left: 10px;
       }
     }
   }

--- a/src/components/HOCs/WithSearch/WithSearch.test.js
+++ b/src/components/HOCs/WithSearch/WithSearch.test.js
@@ -25,7 +25,7 @@ beforeEach(() => {
       challenges: {
         sort: {
           sortBy: 'created',
-          direction: 'asc'
+          direction: 'desc'
         },
         filters: {
           difficulty: 'hard',
@@ -103,24 +103,24 @@ test("mapDispatchToProps maps call setKeywordFilter", () => {
                                     expect.objectContaining({keywords}))
 })
 
-test("mapDispatchToProps maps call setSearchSort: 'name' sort gets an 'desc' direction", () => {
+test("mapDispatchToProps maps call setSearchSort: 'name' sort gets an 'asc' direction", () => {
   const dispatch = jest.fn()
   const mappedProps = mapDispatchToProps(dispatch, basicState, 'challenges')
   const sortSetting = {sortBy: 'name'}
 
   mappedProps.setSearchSort(sortSetting)
   expect(dispatch).toBeCalled()
-  expect(setSort).toBeCalledWith('challenges', {sortBy: 'name', direction: 'desc'})
+  expect(setSort).toBeCalledWith('challenges', {sortBy: 'name', direction: 'asc'})
 })
 
-test("mapDispatchToProps maps call setSearchSort: 'created' sort gets an 'asc' direction", () => {
+test("mapDispatchToProps maps call setSearchSort: 'created' sort gets an 'desc' direction", () => {
   const dispatch = jest.fn()
   const mappedProps = mapDispatchToProps(dispatch, basicState, 'challenges')
   const sortSetting = {sortBy: 'created'}
 
   mappedProps.setSearchSort(sortSetting)
   expect(dispatch).toBeCalled()
-  expect(setSort).toBeCalledWith('challenges', {sortBy: 'created', direction: 'asc'})
+  expect(setSort).toBeCalledWith('challenges', {sortBy: 'created', direction: 'desc'})
 })
 
 test("mapDispatchToProps maps call setSearchSort: 'xxx' sort is set to null", () => {

--- a/src/components/HOCs/WithSearch/__snapshots__/WithSearch.test.js.snap
+++ b/src/components/HOCs/WithSearch/__snapshots__/WithSearch.test.js.snap
@@ -59,7 +59,7 @@ Object {
         ],
       },
       "sort": Object {
-        "direction": "asc",
+        "direction": "desc",
         "sortBy": "created",
       },
     },
@@ -106,7 +106,7 @@ ShallowWrapper {
                 ],
               },
               "sort": Object {
-                "direction": "asc",
+                "direction": "desc",
                 "sortBy": "created",
               },
             },
@@ -147,7 +147,7 @@ ShallowWrapper {
             ],
           },
           "sort": Object {
-            "direction": "asc",
+            "direction": "desc",
             "sortBy": "created",
           },
         },
@@ -194,7 +194,7 @@ ShallowWrapper {
               ],
             },
             "sort": Object {
-              "direction": "asc",
+              "direction": "desc",
               "sortBy": "created",
             },
           },
@@ -251,7 +251,7 @@ ShallowWrapper {
                 ],
               },
               "sort": Object {
-                "direction": "asc",
+                "direction": "desc",
                 "sortBy": "created",
               },
             },
@@ -292,7 +292,7 @@ ShallowWrapper {
             ],
           },
           "sort": Object {
-            "direction": "asc",
+            "direction": "desc",
             "sortBy": "created",
           },
         },
@@ -339,7 +339,7 @@ ShallowWrapper {
               ],
             },
             "sort": Object {
-              "direction": "asc",
+              "direction": "desc",
               "sortBy": "created",
             },
           },


### PR DESCRIPTION
Overlay toggle and Task Features toggle would only correctly toggle as checked/unchecked if clicked on label instead of actual box.