### PR TITLE
Exclude overlays as default basemap options

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step4Schema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step4Schema.js
@@ -11,6 +11,7 @@ import _get from 'lodash/get'
 import _without from 'lodash/without'
 import _map from 'lodash/map'
 import _isString from 'lodash/isString'
+import _filter from 'lodash/filter'
 import messages from './Messages'
 
 /**
@@ -33,7 +34,8 @@ export const jsSchema = intl => {
 
   const defaultBasemapChoices = [
     { id: ChallengeBasemap.none.toString(), name: localizedBasemapLabels.none }
-  ].concat(_map(LayerSources, source => ({id: source.id.toString(), name: source.name}))).concat([
+  ].concat(_map(_filter(LayerSources, source => !source.overlay),
+                source => ({id: source.id.toString(), name: source.name}))).concat([
     { id: ChallengeBasemap.custom.toString(), name: localizedBasemapLabels.custom }
   ])
 

--- a/src/components/UserProfile/UserSettings/UserSettingsSchema.js
+++ b/src/components/UserProfile/UserSettings/UserSettingsSchema.js
@@ -1,6 +1,7 @@
 import _map from 'lodash/map'
 import _values from 'lodash/values'
 import _without from 'lodash/without'
+import _filter from 'lodash/filter'
 import { Locale,
          localeLabels,
          defaultLocale } from '../../../services/User/Locale/Locale'
@@ -30,7 +31,8 @@ export const jsSchema = intl => {
 
   const defaultBasemapChoices = [
     { id: ChallengeBasemap.none.toString(), name: localizedBasemapLabels.none }
-  ].concat(_map(LayerSources, source => ({id: source.id, name: source.name}))).concat([
+  ].concat(_map(_filter(LayerSources, source => !source.overlay),
+                source => ({id: source.id, name: source.name}))).concat([
     { id: ChallengeBasemap.custom.toString(), name: localizedBasemapLabels.custom }
   ])
 


### PR DESCRIPTION
In user profile settings and challenge settings exclude any layer sources 
marked as an overlay from the dropdown options for default basemap