### PR TITLE
Disable 'reset status to created' button if no tasks are selected

### DIFF
--- a/src/components/AdminPane/Manage/ViewChallenge/ViewChallengeTasks.js
+++ b/src/components/AdminPane/Manage/ViewChallenge/ViewChallengeTasks.js
@@ -225,6 +225,7 @@ export class ViewChallengeTasks extends Component {
              {manager.canWriteProject(this.props.challenge.parent) &&
               <ConfirmAction>
                 <button className="button is-rounded is-outlined is-primary"
+                        disabled={!this.props.someTasksAreSelected() && !this.props.allTasksAreSelected()}
                         onClick={this.markAsCreated}>
                   <FormattedMessage {...messages.markCreatedLabel} />
                 </button>


### PR DESCRIPTION
If no tasks are selected than the 'reset status to created' button will now be disabled.