### PR TITLE
Fix admin project search

### DIFF
--- a/src/components/AdminPane/Manage/ChallengeDashboard/ChallengeDashboard.js
+++ b/src/components/AdminPane/Manage/ChallengeDashboard/ChallengeDashboard.js
@@ -138,7 +138,7 @@ export class ChallengeDashboard extends Component {
           </nav>
 
           <div className="columns admin__manage__controls">
-            {hasTasks && isUsableChallengeStatus(status) &&
+            {hasTasks && isUsableChallengeStatus(status, true) &&
              <div className="column is-narrow admin__manage__controls--control">
                <Link to={`/challenge/${this.props.challenge.id}`}>
                  <FormattedMessage {...messages.startChallengeLabel} />

--- a/src/components/AdminPane/Manage/ViewChallengeTasks/ViewChallengeTasks.js
+++ b/src/components/AdminPane/Manage/ViewChallengeTasks/ViewChallengeTasks.js
@@ -5,6 +5,7 @@ import { FormattedMessage } from 'react-intl'
 import _get from 'lodash/get'
 import _map from 'lodash/map'
 import _reverse from 'lodash/reverse'
+import _noop from 'lodash/noop'
 import { ChallengeStatus }
        from '../../../../services/Challenge/ChallengeStatus/ChallengeStatus'
 import { TaskStatus,
@@ -214,6 +215,7 @@ export class ViewChallengeTasks extends Component {
                  checked={this.props.allTasksAreSelected()}
                  indeterminate={this.props.someTasksAreSelected()}
                  onClick={() => this.props.toggleAllTasksSelection()}
+                 onChange={_noop}
                />
              </label>
              <DeactivatableDropdownButton options={taskSelectionActions}

--- a/src/components/HOCs/WithSearch/WithSearch.js
+++ b/src/components/HOCs/WithSearch/WithSearch.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import _debounce from 'lodash/debounce'
 import _get from 'lodash/get'
 import _omit from 'lodash/omit'
 import _isFunction from 'lodash/isFunction'
@@ -67,7 +66,7 @@ export const _WithSearch = function(WrappedComponent, searchGroup, searchFunctio
       }
 
       if (!_isEqual(prevSearch, currentSearch)) {
-        debouncedFetch(this.props, searchFunction)
+        this.props.performSearch(this.props.searchCriteria, searchFunction)
       }
     }
 
@@ -96,9 +95,6 @@ export const _WithSearch = function(WrappedComponent, searchGroup, searchFunctio
      }
    }
 }
-
-const debouncedFetch = _debounce((props, searchFunction) =>
-    props.performSearch(props.searchCriteria, searchFunction), 1000, {leading: true})
 
 export const mapStateToProps = (state, searchGroup) => {
   return {

--- a/src/services/Project/Project.js
+++ b/src/services/Project/Project.js
@@ -116,12 +116,12 @@ export const fetchProject = function(projectId) {
  *
  * @param {string} query - the search string
  */
-export const searchProjects = function(query, onlyEnabled=false, limit=50) {
+export const searchProjects = function(searchCriteria, onlyEnabled=false, limit=50) {
   return function(dispatch) {
     return new Endpoint(api.projects.search, {
         schema: [ projectSchema() ],
         params: {
-          q: `%${query}%`,
+          q: `%${searchCriteria.query}%`,
           onlyEnabled: onlyEnabled ? 'true' : 'false',
           limit,
         }


### PR DESCRIPTION
* searchProjects was assuming the query parameter was string
but it was an object with a 'query' attribute

* temporarily removed debounce on withSearch.performSearch until we
can correctly handle combo searches. Debouncing was causing only one
search to be consistently executed