### PR TITLE
Add 'clear filters' to admin tasks table

### DIFF
--- a/src/components/AdminPane/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
+++ b/src/components/AdminPane/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
@@ -7,9 +7,9 @@ import _isEmpty from 'lodash/isEmpty'
 import _isArray from 'lodash/isArray'
 import _differenceBy from 'lodash/differenceBy'
 import _omit from 'lodash/omit'
-import { TaskStatus }
+import { TaskStatus, keysByStatus }
        from '../../../../services/Task/TaskStatus/TaskStatus'
-import { TaskPriority }
+import { TaskPriority, keysByPriority }
        from '../../../../services/Task/TaskPriority/TaskPriority'
 
 /**
@@ -211,6 +211,14 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
       this.setState({selectedTasks: new Map(this.state.selectedTasks)})
     }
 
+    clearAllFilters = () => {
+      const filteredTasks = this.filterTasks(keysByStatus, keysByPriority)
+      const selectedTasks = this.unselectExcludedTasks(filteredTasks)
+      this.setState({filteredTasks, selectedTasks,
+                     includeStatuses: _fromPairs(_map(TaskStatus, status => [status, true])),
+                     includePriorities: _fromPairs(_map(TaskPriority, priority => [priority, true])), })
+    }
+
     componentDidMount() {
       const filteredTasks = this.filterTasks(this.state.includeStatuses,
                                              this.state.includePriorities)
@@ -245,6 +253,7 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
                                selectTasksWithPriority={this.selectTasksWithPriority}
                                allTasksAreSelected={this.allTasksAreSelected}
                                someTasksAreSelected={this.someTasksAreSelected}
+                               clearAllFilters={this.clearAllFilters}
                                {..._omit(this.props, outputProp)} />
     }
   }

--- a/src/components/AdminPane/Manage/ChallengeDashboard/ChallengeDashboard.scss
+++ b/src/components/AdminPane/Manage/ChallengeDashboard/ChallengeDashboard.scss
@@ -228,5 +228,16 @@
       margin-left: 10px;
       margin-top: 4px;
     }
+
+    &__clear-filters-control.button {
+      color: white;
+      margin-right: 45px;
+      fill: white;
+
+      &:hover {
+        color: $black;
+        fill: $black;
+      }
+    }
   }
 }

--- a/src/components/AdminPane/Manage/ChallengeTaskMap/ChallengeTaskMap.js
+++ b/src/components/AdminPane/Manage/ChallengeTaskMap/ChallengeTaskMap.js
@@ -27,6 +27,8 @@ import EnhancedMap from '../../../EnhancedMap/EnhancedMap'
 import SourcedTileLayer from '../../../EnhancedMap/SourcedTileLayer/SourcedTileLayer'
 import LayerToggle from '../../../EnhancedMap/LayerToggle/LayerToggle'
 import WithVisibleLayer from '../../../HOCs/WithVisibleLayer/WithVisibleLayer'
+import FitBoundsControl
+       from '../../../EnhancedMap/FitBoundsControl/FitBoundsControl'
 import WithIntersectingOverlays
        from '../../../HOCs/WithIntersectingOverlays/WithIntersectingOverlays'
 import WithStatus from '../../../HOCs/WithStatus/WithStatus'
@@ -102,6 +104,12 @@ export class ChallengeTaskMap extends Component {
     // the clustered tasks themselves change
     if (_get(nextProps, 'taskInfo.tasks.length') !==
         _get(this.props, 'taskInfo.tasks.length')) {
+      return true
+    }
+
+    // If the map bounds have changed
+    if (_get(nextProps, 'currentSearch.challengeOwner.mapBounds.bounds') !==
+        this.currentBounds) {
       return true
     }
 
@@ -302,10 +310,11 @@ export class ChallengeTaskMap extends Component {
                      setInitialBounds={false}
                      initialBounds = {_get(this.props, 'lastBounds', this.currentBounds)}
                      zoomControl={false} animate={true}
-                     features={this.props.lastBounds ? undefined : bounding}
-                     justFitFeatures={markers.length > 0}
+                     features={bounding}
+                     justFitFeatures={false}
                      onBoundsChange={this.updateBounds}>
           <ZoomControl position='topright' />
+          <FitBoundsControl />
           <SourcedTileLayer {...this.props} zIndex={1} />
           {overlayLayers}
           {markers.length > 0 &&

--- a/src/components/AdminPane/Manage/ChallengeTaskMap/ChallengeTaskMap.scss
+++ b/src/components/AdminPane/Manage/ChallengeTaskMap/ChallengeTaskMap.scss
@@ -84,3 +84,18 @@
     @include colored-cluster(#AA6C39, #D49A6A, #552700);
   }
 }
+
+.challenge-task-map__recenter {
+  z-index: 5;
+  .recenter-control {
+    svg {
+      width: 19px;
+      height: auto;
+      fill: $green;
+    }
+
+    &:hover {
+      background-color: $grey-lightest-more;
+    }
+  }
+}

--- a/src/components/AdminPane/Manage/ChallengeTaskMap/Messages.js
+++ b/src/components/AdminPane/Manage/ChallengeTaskMap/Messages.js
@@ -29,4 +29,3 @@ export default defineMessages({
     defaultMessage: "Status:",
   },
 })
-

--- a/src/components/AdminPane/Manage/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/AdminPane/Manage/TaskAnalysisTable/TaskAnalysisTable.js
@@ -43,7 +43,7 @@ export class TaskAnalysisTable extends Component {
 
     const manager = AsManager(this.props.user)
 
-    const taskBaseRoute = 
+    const taskBaseRoute =
       `/admin/project/${this.props.challenge.parent.id}` +
       `/challenge/${this.props.challenge.id}/task`
 
@@ -144,6 +144,8 @@ export class TaskAnalysisTable extends Component {
                                     countShown,
                                     countTotal: this.props.totalTaskCount,
                                   }} />
+
+            {this.props.totalTaskCount !== countShown ? this.props.clearFiltersControl : null}
           </div>
         )
       },

--- a/src/components/AdminPane/Manage/ViewChallengeTasks/Messages.js
+++ b/src/components/AdminPane/Manage/ViewChallengeTasks/Messages.js
@@ -71,5 +71,10 @@ export default defineMessages({
   exportCSVLabel: {
     id: "Admin.manageTasks.controls.exportCSV.label",
     defaultMessage: "Export CSV",
-  }
+  },
+
+  clearFiltersLabel: {
+    id: "Admin.manageTasks.controls.clearFilters.label",
+    defaultMessage: "Clear Filters",
+  },
 })

--- a/src/components/EnhancedMap/EnhancedMap.js
+++ b/src/components/EnhancedMap/EnhancedMap.js
@@ -205,13 +205,13 @@ export default class EnhancedMap extends Map {
       }
     }
 
-    if (this.props.initialBounds && _isEmpty(this.props.features)) {
+    if (this.props.initialBounds) {
       this.leafletElement.fitBounds(this.props.initialBounds)
     }
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (this.props.initialBounds && _isEmpty(this.props.features)) {
+    if (this.props.initialBounds) {
       this.leafletElement.fitBounds(this.props.initialBounds)
     }
     else if (!this.props.center.equals(prevProps.center)) {

--- a/src/components/EnhancedMap/FitBoundsControl/FitBoundsControl.js
+++ b/src/components/EnhancedMap/FitBoundsControl/FitBoundsControl.js
@@ -30,7 +30,9 @@ const FitBoundsLeafletControl = Control.extend({
       }
     })
 
-    map.fitBounds(geoJSONFeatures.getBounds().pad(0.5))
+    if (geoJSONFeatures.getLayers().length !== 0) {
+      map.fitBounds(geoJSONFeatures.getBounds().pad(0.5))
+    }
   },
 
   onAdd: function(map) {

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -238,6 +238,7 @@
   "Admin.manageTasks.controls.changePriority.label": "Change Priority",
   "Admin.manageTasks.priorityLabel": "Priority",
   "Admin.manageTasks.controls.exportCSV.label": "Export CSV",
+  "Admin.manageTasks.controls.clearFilters.label": "Clear Filters",
   "Metrics.tasks.evaluatedByUser.label": "Tasks Evaluated by Users",
   "AutosuggestTextBox.labels.noResults": "No matches",
   "Form.textUpload.prompt": "Drop GeoJSON file here or click to select file",


### PR DESCRIPTION
* Add 'clear filters' control that shows if the number of tasks being
shown do not equal the total number of tasks. When clicked the
status filters, priority filters, and map bounds are all reset.

* Also add target icon to challenge tasks map that will reset map
  bounds to initial map bounds which show all tasks