### PR TITLE
Allow map coordinates to be given in search box

### DIFF
--- a/src/components/ChallengePane/ChallengeFilterSubnav/ChallengeFilterSubnav.js
+++ b/src/components/ChallengePane/ChallengeFilterSubnav/ChallengeFilterSubnav.js
@@ -5,6 +5,7 @@ import SearchBox from '../../SearchBox/SearchBox'
 import MobileFilterMenu from '../../MobileFilterMenu/MobileFilterMenu'
 import WithCurrentUser from '../../HOCs/WithCurrentUser/WithCurrentUser'
 import WithChallengeSearch from '../../HOCs/WithSearch/WithChallengeSearch'
+import WithCommandInterpreter from '../../HOCs/WithCommandInterpreter/WithCommandInterpreter'
 import FilterByDifficulty from './FilterByDifficulty'
 import FilterByKeyword from './FilterByKeyword'
 import FilterByLocation from './FilterByLocation'
@@ -13,6 +14,7 @@ import messages from './Messages'
 
 // Setup child components with necessary HOCs
 const LocationFilter = WithCurrentUser(FilterByLocation)
+const CommandSearchBox = WithCommandInterpreter(SearchBox)
 
 /**
  * ChallengeFilterSubnav presents a navigation bar that contains options
@@ -43,7 +45,7 @@ export class ChallengeFilterSubnav extends Component {
               <LocationFilter {...this.props} />
             </MediaQuery>
 
-            <SearchBox className='navbar-item'
+            <CommandSearchBox className='navbar-item'
                              placeholder={this.props.intl.formatMessage(messages.searchLabel)}
                              {...this.props} />
           </div>

--- a/src/components/ChallengePane/ChallengeFilterSubnav/FilterByKeyword.js
+++ b/src/components/ChallengePane/ChallengeFilterSubnav/FilterByKeyword.js
@@ -76,7 +76,7 @@ export class FilterByKeyword extends Component {
       Renderable: OtherKeywordsOption,
       ownProps: {
         searchQuery: {query: otherKeyword},
-        setSearch: this.setOtherKeywords,
+        executeSearch: this.setOtherKeywords,
         clearSearch: this.clearOtherKeywords,
         placeholder: '',
       },

--- a/src/components/ChallengePane/ChallengeFilterSubnav/__snapshots__/ChallengeFilterSubnav.test.js.snap
+++ b/src/components/ChallengePane/ChallengeFilterSubnav/__snapshots__/ChallengeFilterSubnav.test.js.snap
@@ -228,7 +228,7 @@ ShallowWrapper {
                                 }
                         />
                 </MediaQuery>
-                <SearchBox
+                <Component
                         challenges={
                                 Array [
                                         Object {
@@ -259,7 +259,6 @@ ShallowWrapper {
                                       }
                         }
                         placeholder={undefined}
-                        searchQuery={Object {}}
                         setSearch={[Function]}
                         user={
                                 Object {
@@ -449,7 +448,7 @@ ShallowWrapper {
                               }
                     />
           </MediaQuery>
-          <SearchBox
+          <Component
                     challenges={
                               Array [
                                         Object {
@@ -480,7 +479,6 @@ ShallowWrapper {
                                       }
                     }
                     placeholder={undefined}
-                    searchQuery={Object {}}
                     setSearch={[Function]}
                     user={
                               Object {
@@ -667,7 +665,7 @@ ShallowWrapper {
                             }
               />
 </MediaQuery>,
-            <SearchBox
+            <Component
               challenges={
                             Array [
                                           Object {
@@ -698,7 +696,6 @@ ShallowWrapper {
                                         }
               }
               placeholder={undefined}
-              searchQuery={Object {}}
               setSearch={[Function]}
               user={
                             Object {
@@ -1091,7 +1088,6 @@ ShallowWrapper {
                 "formatMessage": [Function],
               },
               "placeholder": undefined,
-              "searchQuery": Object {},
               "setSearch": [Function],
               "user": Object {
                 "id": 11,
@@ -1290,7 +1286,7 @@ ShallowWrapper {
                                         }
                               />
                     </MediaQuery>
-                    <SearchBox
+                    <Component
                               challenges={
                                         Array [
                                                   Object {
@@ -1321,7 +1317,6 @@ ShallowWrapper {
                                                 }
                               }
                               placeholder={undefined}
-                              searchQuery={Object {}}
                               setSearch={[Function]}
                               user={
                                         Object {
@@ -1511,7 +1506,7 @@ ShallowWrapper {
                                     }
                         />
             </MediaQuery>
-            <SearchBox
+            <Component
                         challenges={
                                     Array [
                                                 Object {
@@ -1542,7 +1537,6 @@ ShallowWrapper {
                                               }
                         }
                         placeholder={undefined}
-                        searchQuery={Object {}}
                         setSearch={[Function]}
                         user={
                                     Object {
@@ -1729,7 +1723,7 @@ ShallowWrapper {
                                 }
                 />
 </MediaQuery>,
-              <SearchBox
+              <Component
                 challenges={
                                 Array [
                                                 Object {
@@ -1760,7 +1754,6 @@ ShallowWrapper {
                                               }
                 }
                 placeholder={undefined}
-                searchQuery={Object {}}
                 setSearch={[Function]}
                 user={
                                 Object {
@@ -2153,7 +2146,6 @@ ShallowWrapper {
                   "formatMessage": [Function],
                 },
                 "placeholder": undefined,
-                "searchQuery": Object {},
                 "setSearch": [Function],
                 "user": Object {
                   "id": 11,

--- a/src/components/ChallengePane/ChallengeFilterSubnav/__snapshots__/FilterByKeyword.test.js.snap
+++ b/src/components/ChallengePane/ChallengeFilterSubnav/__snapshots__/FilterByKeyword.test.js.snap
@@ -112,11 +112,11 @@ ShallowWrapper {
           "key": "other",
           "ownProps": Object {
             "clearSearch": [Function],
+            "executeSearch": [Function],
             "placeholder": "",
             "searchQuery": Object {
               "query": "C",
             },
-            "setSearch": [Function],
           },
           "text": undefined,
           "value": "other",
@@ -190,11 +190,11 @@ ShallowWrapper {
             "key": "other",
             "ownProps": Object {
               "clearSearch": [Function],
+              "executeSearch": [Function],
               "placeholder": "",
               "searchQuery": Object {
                 "query": "C",
               },
-              "setSearch": [Function],
             },
             "text": undefined,
             "value": "other",

--- a/src/components/HOCs/WithCommandInterpreter/WithCommandInterpreter.js
+++ b/src/components/HOCs/WithCommandInterpreter/WithCommandInterpreter.js
@@ -12,7 +12,7 @@ import _omit from 'lodash/omit'
  *
  * Supported Actions:
  *    m/  => Execute a map bounds search with either a bounding box or a centerpoint
- *    default => Execute a standard search query
+ *    s/ or default => Execute a standard search query
  *
  * @author [Kelli Rotstan](https://github.com/krotstan)
  */
@@ -50,8 +50,14 @@ const WithCommandInterpreter = function(WrappedComponent) {
         }
       }
       else {
+        let query = commandString
+
+        if (_startsWith(commandString, 's/') && commandString.length > 2) {
+          query = commandString.substr(2)
+        }
+
         // Standard search query
-        this.props.setSearch(commandString)
+        this.props.setSearch(query)
       }
 
       this.setState({commandString})

--- a/src/components/HOCs/WithCommandInterpreter/WithCommandInterpreter.js
+++ b/src/components/HOCs/WithCommandInterpreter/WithCommandInterpreter.js
@@ -1,0 +1,100 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+import _startsWith from 'lodash/startsWith'
+import _split from 'lodash/split'
+import _map from 'lodash/map'
+import _omit from 'lodash/omit'
+
+/**
+ * WithCommandInterpreter interprets search strings to
+ * determine what action should be performed.
+ *
+ * Supported Actions:
+ *    m/  => Execute a map bounds search with either a bounding box or a centerpoint
+ *    default => Execute a standard search query
+ *
+ * @author [Kelli Rotstan](https://github.com/krotstan)
+ */
+const WithCommandInterpreter = function(WrappedComponent) {
+  return class extends Component {
+    state = {
+      commandString: null,
+    }
+
+    /**
+     * Executes the appropriate search type based on the start of
+     * the query string
+     */
+    executeCommand = commandString => {
+      if (_startsWith(commandString, 'm/') && commandString.length > 2) {
+        const query = commandString.substr(2)
+        let bounds = null
+
+        // If four points are given then we have a bounding box
+        if (_split(query, ',').length === 4) {
+          bounds = _map(_split(query, ','), (point) => parseFloat(point))
+
+        }
+        // If only two points are given then we have a center point
+        else if (_split(query, ',').length === 2) {
+          const centerpoint = _map(_split(query, ','), (point) => parseFloat(point))
+          bounds = this.determineBoundingBox(...centerpoint)
+        }
+
+        if (bounds) {
+          // We need to clear the search first so that any string searches won't
+          // be hanging around in redux
+          this.props.clearSearch()
+          this.props.setChallengeSearchMapBounds(bounds, 3, true)
+        }
+      }
+      else {
+        // Standard search query
+        this.props.setSearch(commandString)
+      }
+
+      this.setState({commandString})
+    }
+
+    clearSearch = commandString => {
+      this.props.clearSearch()
+      this.setState({commandString: null})
+    }
+
+    /**
+    * Returns the bouding box from the given centerpoint coordinates
+    */
+    determineBoundingBox(centerpointLong, centerpointLat) {
+      const bboxWidth = parseFloat(process.env.REACT_APP_NEARBY_LONGITUDE_LENGTH)
+      const bboxHeight = parseFloat(process.env.REACT_APP_NEARBY_LATITUDE_LENGTH)
+
+      // Build WSEN bounds array
+      return ([
+        centerpointLong - (bboxWidth / 2.0),
+        centerpointLat - (bboxHeight / 2.0),
+        centerpointLong + (bboxWidth / 2.0),
+        centerpointLat + (bboxHeight / 2.0)
+      ])
+    }
+
+    render() {
+      return <WrappedComponent {..._omit(this.props, ['searchQuery', 'clearSearch',
+                                          'executeSearch'])}
+                               searchQuery={{query: this.state.commandString}}
+                               executeSearch={this.executeCommand}
+                               clearSearch={this.clearSearch} />
+    }
+  }
+}
+
+WithCommandInterpreter.propTypes = {
+  /** Invoked to execute a search query with search text */
+  setSearch: PropTypes.func,
+  /** Invoked to execute a map bounds search */
+  setChallengeSearchMapBounds: PropTypes.func,
+  /** Invoked when the user clears the search text or changes search type */
+  clearSearch: PropTypes.func.isRequired,
+}
+
+export default WithCommandInterpreter

--- a/src/components/HOCs/WithCommandInterpreter/WithCommandInterpreter.js
+++ b/src/components/HOCs/WithCommandInterpreter/WithCommandInterpreter.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
-import _startsWith from 'lodash/startsWith'
 import _split from 'lodash/split'
 import _map from 'lodash/map'
 import _omit from 'lodash/omit'
@@ -22,66 +21,14 @@ const WithCommandInterpreter = function(WrappedComponent) {
       commandString: null,
     }
 
-    /**
-     * Executes the appropriate search type based on the start of
-     * the query string
-     */
-    executeCommand = commandString => {
-      if (_startsWith(commandString, 'm/') && commandString.length > 2) {
-        const query = commandString.substr(2)
-        let bounds = null
-
-        // If four points are given then we have a bounding box
-        if (_split(query, ',').length === 4) {
-          bounds = _map(_split(query, ','), (point) => parseFloat(point))
-
-        }
-        // If only two points are given then we have a center point
-        else if (_split(query, ',').length === 2) {
-          const centerpoint = _map(_split(query, ','), (point) => parseFloat(point))
-          bounds = this.determineBoundingBox(...centerpoint)
-        }
-
-        if (bounds) {
-          // We need to clear the search first so that any string searches won't
-          // be hanging around in redux
-          this.props.clearSearch()
-          this.props.setChallengeSearchMapBounds(bounds, 3, true)
-        }
-      }
-      else {
-        let query = commandString
-
-        if (_startsWith(commandString, 's/') && commandString.length > 2) {
-          query = commandString.substr(2)
-        }
-
-        // Standard search query
-        this.props.setSearch(query)
-      }
-
+    executeSearch = commandString => {
+      executeCommand(this.props, commandString)
       this.setState({commandString})
     }
 
     clearSearch = commandString => {
       this.props.clearSearch()
       this.setState({commandString: null})
-    }
-
-    /**
-    * Returns the bouding box from the given centerpoint coordinates
-    */
-    determineBoundingBox(centerpointLong, centerpointLat) {
-      const bboxWidth = parseFloat(process.env.REACT_APP_NEARBY_LONGITUDE_LENGTH)
-      const bboxHeight = parseFloat(process.env.REACT_APP_NEARBY_LATITUDE_LENGTH)
-
-      // Build WSEN bounds array
-      return ([
-        centerpointLong - (bboxWidth / 2.0),
-        centerpointLat - (bboxHeight / 2.0),
-        centerpointLong + (bboxWidth / 2.0),
-        centerpointLat + (bboxHeight / 2.0)
-      ])
     }
 
     render() {
@@ -92,6 +39,64 @@ const WithCommandInterpreter = function(WrappedComponent) {
                                clearSearch={this.clearSearch} />
     }
   }
+}
+
+/**
+ * Executes the appropriate search type based on the start of
+ * the query string
+ */
+export const executeCommand = (props, commandString) => {
+  const command = commandString.length > 2 ? commandString.substring(0, 2) : null
+  let query = commandString.substring(2)
+
+  switch(command) {
+    case 'm/':
+      let bounds = null
+
+      // If four points are given then we have a bounding box
+      if (_split(query, ',').length === 4) {
+        bounds = _map(_split(query, ','), (point) => parseFloat(point))
+
+      }
+      // If only two points are given then we have a center point
+      else if (_split(query, ',').length === 2) {
+        const centerpoint = _map(_split(query, ','), (point) => parseFloat(point))
+        bounds = determineBoundingBox(...centerpoint)
+      }
+
+      if (bounds) {
+        // We need to clear the search first so that any string searches won't
+        // be hanging around in redux
+        props.clearSearch()
+        props.setChallengeSearchMapBounds(bounds, 3, true)
+      }
+      break;
+    case 's/':
+    default:
+      if (command !== 's/') {
+        query = commandString
+      }
+
+      // Standard search query
+      props.setSearch(query)
+      break;
+  }
+}
+
+/**
+* Returns the bouding box from the given centerpoint coordinates
+*/
+const determineBoundingBox = (centerpointLong, centerpointLat) => {
+  const bboxWidth = parseFloat(process.env.REACT_APP_NEARBY_LONGITUDE_LENGTH)
+  const bboxHeight = parseFloat(process.env.REACT_APP_NEARBY_LATITUDE_LENGTH)
+
+  // Build WSEN bounds array
+  return ([
+    centerpointLong - (bboxWidth / 2.0),
+    centerpointLat - (bboxHeight / 2.0),
+    centerpointLong + (bboxWidth / 2.0),
+    centerpointLat + (bboxHeight / 2.0)
+  ])
 }
 
 WithCommandInterpreter.propTypes = {

--- a/src/components/HOCs/WithCommandInterpreter/WithCommandInterpreter.test.js
+++ b/src/components/HOCs/WithCommandInterpreter/WithCommandInterpreter.test.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react'
+import _findIndex from 'lodash/findIndex'
+import { executeCommand } from './WithCommandInterpreter'
+
+let basicProps = {}
+
+beforeEach(() => {
+  basicProps.setSearch = jest.fn()
+  basicProps.clearSearch = jest.fn()
+  basicProps.setChallengeSearchMapBounds = jest.fn()
+})
+
+
+test("executeCommand recognizes s/", () => {
+  //const wrapper = new (WithCommandInterpreter(<div />))
+
+  executeCommand(basicProps, "s/hello world")
+  expect(basicProps.setSearch).toHaveBeenCalledWith("hello world")
+})
+
+test("executeCommand recognizes m/ with 4 bounds", () => {
+  //const wrapper = new (WithCommandInterpreter(<div />))
+
+  executeCommand(basicProps, "m/1.1,2.2,3.3,4.4")
+  expect(basicProps.setSearch).not.toHaveBeenCalled()
+  expect(basicProps.setChallengeSearchMapBounds).toHaveBeenCalledWith([1.1, 2.2, 3.3, 4.4], 3, true)
+})
+
+test("executeCommand recognizes m/ with 2 bounds as centerpoint", () => {
+  //const wrapper = new (WithCommandInterpreter(<div />))
+
+  executeCommand(basicProps, "m/1,4")
+  expect(basicProps.setSearch).not.toHaveBeenCalled()
+  expect(basicProps.setChallengeSearchMapBounds).toHaveBeenCalledWith([0.625, 3.625, 1.375, 4.375], 3, true)
+})

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -34,7 +34,7 @@ export default class SearchBox extends Component {
    * @private
    */
   queryChanged = (e) => {
-    this.props.setSearch(e.target.value)
+    this.props.executeSearch(e.target.value)
   }
 
   render() {
@@ -83,7 +83,7 @@ export default class SearchBox extends Component {
 
 SearchBox.propTypes = {
   /** Invoked when the user modifies the search text */
-  setSearch: PropTypes.func.isRequired,
+  executeSearch: PropTypes.func.isRequired,
   /** Invoked when the user clears the search text */
   clearSearch: PropTypes.func.isRequired,
   /** Invoked if user explicitly signals completion of search */

--- a/src/components/SearchBox/SearchBox.test.js
+++ b/src/components/SearchBox/SearchBox.test.js
@@ -8,7 +8,7 @@ let basicProps = null
 
 beforeEach(() => {
   basicProps = Object.assign({}, propsFixture)
-  basicProps.setSearch = jest.fn()
+  basicProps.executeSearch = jest.fn()
   basicProps.clearSearch = jest.fn()
   basicProps.fetchResults = jest.fn()
   basicProps.deactivate = jest.fn()
@@ -120,13 +120,13 @@ test("placeholder props is inserted into text box", () => {
   expect(wrapper).toMatchSnapshot()
 })
 
-test("setSearch called when the query in box is changed", () => {
+test("executeSearch called when the query in box is changed", () => {
   const wrapper = shallow(
     <SearchBox {...basicProps} />
   )
 
   wrapper.find('.search-box__input').simulate('change', { target: { value: 'Hello' } })
-  expect(basicProps.setSearch).toHaveBeenCalled()
+  expect(basicProps.executeSearch).toHaveBeenCalled()
   expect(wrapper).toMatchSnapshot()
 })
 

--- a/src/components/SearchBox/__snapshots__/SearchBox.test.js.snap
+++ b/src/components/SearchBox/__snapshots__/SearchBox.test.js.snap
@@ -8,13 +8,13 @@ ShallowWrapper {
     className="my-class"
     clearSearch={[Function]}
     deactivate={[Function]}
+    executeSearch={[Function]}
     fetchResults={[Function]}
     searchQuery={
         Object {
             "query": "",
           }
     }
-    setSearch={[Function]}
 />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -356,13 +356,13 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SearchBox
     clearSearch={[Function]}
     deactivate={[Function]}
+    executeSearch={[Function]}
     fetchResults={[Function]}
     searchQuery={
         Object {
             "query": "test me",
           }
     }
-    setSearch={[Function]}
 />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -746,13 +746,13 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SearchBox
     clearSearch={[Function]}
     deactivate={[Function]}
+    executeSearch={[Function]}
     fetchResults={[Function]}
     searchQuery={
         Object {
             "query": "",
           }
     }
-    setSearch={[Function]}
 />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -1094,13 +1094,13 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SearchBox
     clearSearch={[Function]}
     deactivate={[Function]}
+    executeSearch={[Function]}
     fetchResults={[Function]}
     searchQuery={
         Object {
             "query": "some query",
           }
     }
-    setSearch={[Function]}
     showDoneButton={true}
 />,
   Symbol(enzyme.__renderer__): Object {
@@ -1571,13 +1571,13 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SearchBox
     clearSearch={[Function]}
     deactivate={[Function]}
+    executeSearch={[Function]}
     fetchResults={[Function]}
     searchQuery={
         Object {
             "query": "",
           }
     }
-    setSearch={[Function]}
 />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -1919,13 +1919,13 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SearchBox
     clearSearch={[Function]}
     deactivate={[Function]}
+    executeSearch={[Function]}
     fetchResults={[Function]}
     searchQuery={
         Object {
             "query": "",
           }
     }
-    setSearch={[Function]}
 />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -2267,13 +2267,13 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SearchBox
     clearSearch={[Function]}
     deactivate={[Function]}
+    executeSearch={[Function]}
     fetchResults={[Function]}
     searchQuery={
         Object {
             "query": "test me",
           }
     }
-    setSearch={[Function]}
     showDoneButton={false}
 />,
   Symbol(enzyme.__renderer__): Object {
@@ -2658,13 +2658,13 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SearchBox
     clearSearch={[Function]}
     deactivate={[Function]}
+    executeSearch={[Function]}
     fetchResults={[Function]}
     searchQuery={
         Object {
             "query": "",
           }
     }
-    setSearch={[Function]}
     suppressIcon={true}
 />,
   Symbol(enzyme.__renderer__): Object {
@@ -2955,14 +2955,362 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SearchBox
     clearSearch={[Function]}
     deactivate={[Function]}
+    executeSearch={[Function]}
     fetchResults={[Function]}
     searchQuery={
         Object {
             "query": "",
           }
     }
-    setSearch={[Function]}
     suppressIcon={false}
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": <div
+        className="search-box__search-field"
+>
+        <div
+                className="control-wrapper"
+        >
+                <SvgSymbol
+                        className="search-box__icon"
+                        sym="search-icon"
+                        viewBox="0 0 20 20"
+                />
+                <div
+                        className="control is-medium"
+                >
+                        <input
+                                className="input is-medium search-box__input"
+                                maxLength="63"
+                                onChange={[Function]}
+                                onKeyDown={[Function]}
+                                placeholder={undefined}
+                                type="text"
+                                value=""
+                        />
+                </div>
+        </div>
+</div>,
+      "className": "search-box",
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <div
+            className="control-wrapper"
+>
+            <SvgSymbol
+                        className="search-box__icon"
+                        sym="search-icon"
+                        viewBox="0 0 20 20"
+            />
+            <div
+                        className="control is-medium"
+            >
+                        <input
+                                    className="input is-medium search-box__input"
+                                    maxLength="63"
+                                    onChange={[Function]}
+                                    onKeyDown={[Function]}
+                                    placeholder={undefined}
+                                    type="text"
+                                    value=""
+                        />
+            </div>
+</div>,
+          null,
+          null,
+        ],
+        "className": "search-box__search-field",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <SvgSymbol
+                className="search-box__icon"
+                sym="search-icon"
+                viewBox="0 0 20 20"
+/>,
+              <div
+                className="control is-medium"
+>
+                <input
+                                className="input is-medium search-box__input"
+                                maxLength="63"
+                                onChange={[Function]}
+                                onKeyDown={[Function]}
+                                placeholder={undefined}
+                                type="text"
+                                value=""
+                />
+</div>,
+            ],
+            "className": "control-wrapper",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "className": "search-box__icon",
+                "sym": "search-icon",
+                "viewBox": "0 0 20 20",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <input
+                  className="input is-medium search-box__input"
+                  maxLength="63"
+                  onChange={[Function]}
+                  onKeyDown={[Function]}
+                  placeholder={undefined}
+                  type="text"
+                  value=""
+/>,
+                "className": "control is-medium",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "className": "input is-medium search-box__input",
+                  "maxLength": "63",
+                  "onChange": [Function],
+                  "onKeyDown": [Function],
+                  "placeholder": undefined,
+                  "type": "text",
+                  "value": "",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": "input",
+              },
+              "type": "div",
+            },
+          ],
+          "type": "div",
+        },
+        null,
+        null,
+      ],
+      "type": "div",
+    },
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": <div
+          className="search-box__search-field"
+>
+          <div
+                    className="control-wrapper"
+          >
+                    <SvgSymbol
+                              className="search-box__icon"
+                              sym="search-icon"
+                              viewBox="0 0 20 20"
+                    />
+                    <div
+                              className="control is-medium"
+                    >
+                              <input
+                                        className="input is-medium search-box__input"
+                                        maxLength="63"
+                                        onChange={[Function]}
+                                        onKeyDown={[Function]}
+                                        placeholder={undefined}
+                                        type="text"
+                                        value=""
+                              />
+                    </div>
+          </div>
+</div>,
+        "className": "search-box",
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <div
+              className="control-wrapper"
+>
+              <SvgSymbol
+                            className="search-box__icon"
+                            sym="search-icon"
+                            viewBox="0 0 20 20"
+              />
+              <div
+                            className="control is-medium"
+              >
+                            <input
+                                          className="input is-medium search-box__input"
+                                          maxLength="63"
+                                          onChange={[Function]}
+                                          onKeyDown={[Function]}
+                                          placeholder={undefined}
+                                          type="text"
+                                          value=""
+                            />
+              </div>
+</div>,
+            null,
+            null,
+          ],
+          "className": "search-box__search-field",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <SvgSymbol
+                  className="search-box__icon"
+                  sym="search-icon"
+                  viewBox="0 0 20 20"
+/>,
+                <div
+                  className="control is-medium"
+>
+                  <input
+                                    className="input is-medium search-box__input"
+                                    maxLength="63"
+                                    onChange={[Function]}
+                                    onKeyDown={[Function]}
+                                    placeholder={undefined}
+                                    type="text"
+                                    value=""
+                  />
+</div>,
+              ],
+              "className": "control-wrapper",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "className": "search-box__icon",
+                  "sym": "search-icon",
+                  "viewBox": "0 0 20 20",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": <input
+                    className="input is-medium search-box__input"
+                    maxLength="63"
+                    onChange={[Function]}
+                    onKeyDown={[Function]}
+                    placeholder={undefined}
+                    type="text"
+                    value=""
+/>,
+                  "className": "control is-medium",
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "className": "input is-medium search-box__input",
+                    "maxLength": "63",
+                    "onChange": [Function],
+                    "onKeyDown": [Function],
+                    "placeholder": undefined,
+                    "type": "text",
+                    "value": "",
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": "input",
+                },
+                "type": "div",
+              },
+            ],
+            "type": "div",
+          },
+          null,
+          null,
+        ],
+        "type": "div",
+      },
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`executeSearch called when the query in box is changed 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <SearchBox
+    clearSearch={[Function]}
+    deactivate={[Function]}
+    executeSearch={[Function]}
+    fetchResults={[Function]}
+    searchQuery={
+        Object {
+            "query": "",
+          }
+    }
 />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -3304,6 +3652,7 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SearchBox
     clearSearch={[Function]}
     deactivate={[Function]}
+    executeSearch={[Function]}
     fetchResults={[Function]}
     searchQuery={
         Object {
@@ -3313,7 +3662,6 @@ ShallowWrapper {
             "query": "test me",
           }
     }
-    setSearch={[Function]}
 />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -3697,13 +4045,13 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SearchBox
     clearSearch={[Function]}
     deactivate={[Function]}
+    executeSearch={[Function]}
     fetchResults={[Function]}
     searchQuery={
         Object {
             "query": "",
           }
     }
-    setSearch={[Function]}
 />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -4045,6 +4393,7 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SearchBox
     clearSearch={[Function]}
     deactivate={[Function]}
+    executeSearch={[Function]}
     fetchResults={[Function]}
     placeholder="some text here"
     searchQuery={
@@ -4052,7 +4401,6 @@ ShallowWrapper {
             "query": "",
           }
     }
-    setSearch={[Function]}
 />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -4387,354 +4735,6 @@ ShallowWrapper {
 }
 `;
 
-exports[`setSearch called when the query in box is changed 1`] = `
-ShallowWrapper {
-  "length": 1,
-  Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <SearchBox
-    clearSearch={[Function]}
-    deactivate={[Function]}
-    fetchResults={[Function]}
-    searchQuery={
-        Object {
-            "query": "",
-          }
-    }
-    setSearch={[Function]}
-/>,
-  Symbol(enzyme.__renderer__): Object {
-    "batchedUpdates": [Function],
-    "getNode": [Function],
-    "render": [Function],
-    "simulateEvent": [Function],
-    "unmount": [Function],
-  },
-  Symbol(enzyme.__node__): Object {
-    "instance": null,
-    "key": undefined,
-    "nodeType": "host",
-    "props": Object {
-      "children": <div
-        className="search-box__search-field"
->
-        <div
-                className="control-wrapper"
-        >
-                <SvgSymbol
-                        className="search-box__icon"
-                        sym="search-icon"
-                        viewBox="0 0 20 20"
-                />
-                <div
-                        className="control is-medium"
-                >
-                        <input
-                                className="input is-medium search-box__input"
-                                maxLength="63"
-                                onChange={[Function]}
-                                onKeyDown={[Function]}
-                                placeholder={undefined}
-                                type="text"
-                                value=""
-                        />
-                </div>
-        </div>
-</div>,
-      "className": "search-box",
-    },
-    "ref": null,
-    "rendered": Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "host",
-      "props": Object {
-        "children": Array [
-          <div
-            className="control-wrapper"
->
-            <SvgSymbol
-                        className="search-box__icon"
-                        sym="search-icon"
-                        viewBox="0 0 20 20"
-            />
-            <div
-                        className="control is-medium"
-            >
-                        <input
-                                    className="input is-medium search-box__input"
-                                    maxLength="63"
-                                    onChange={[Function]}
-                                    onKeyDown={[Function]}
-                                    placeholder={undefined}
-                                    type="text"
-                                    value=""
-                        />
-            </div>
-</div>,
-          null,
-          null,
-        ],
-        "className": "search-box__search-field",
-      },
-      "ref": null,
-      "rendered": Array [
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "host",
-          "props": Object {
-            "children": Array [
-              <SvgSymbol
-                className="search-box__icon"
-                sym="search-icon"
-                viewBox="0 0 20 20"
-/>,
-              <div
-                className="control is-medium"
->
-                <input
-                                className="input is-medium search-box__input"
-                                maxLength="63"
-                                onChange={[Function]}
-                                onKeyDown={[Function]}
-                                placeholder={undefined}
-                                type="text"
-                                value=""
-                />
-</div>,
-            ],
-            "className": "control-wrapper",
-          },
-          "ref": null,
-          "rendered": Array [
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "className": "search-box__icon",
-                "sym": "search-icon",
-                "viewBox": "0 0 20 20",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "children": <input
-                  className="input is-medium search-box__input"
-                  maxLength="63"
-                  onChange={[Function]}
-                  onKeyDown={[Function]}
-                  placeholder={undefined}
-                  type="text"
-                  value=""
-/>,
-                "className": "control is-medium",
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "className": "input is-medium search-box__input",
-                  "maxLength": "63",
-                  "onChange": [Function],
-                  "onKeyDown": [Function],
-                  "placeholder": undefined,
-                  "type": "text",
-                  "value": "",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": "input",
-              },
-              "type": "div",
-            },
-          ],
-          "type": "div",
-        },
-        null,
-        null,
-      ],
-      "type": "div",
-    },
-    "type": "div",
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "host",
-      "props": Object {
-        "children": <div
-          className="search-box__search-field"
->
-          <div
-                    className="control-wrapper"
-          >
-                    <SvgSymbol
-                              className="search-box__icon"
-                              sym="search-icon"
-                              viewBox="0 0 20 20"
-                    />
-                    <div
-                              className="control is-medium"
-                    >
-                              <input
-                                        className="input is-medium search-box__input"
-                                        maxLength="63"
-                                        onChange={[Function]}
-                                        onKeyDown={[Function]}
-                                        placeholder={undefined}
-                                        type="text"
-                                        value=""
-                              />
-                    </div>
-          </div>
-</div>,
-        "className": "search-box",
-      },
-      "ref": null,
-      "rendered": Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "host",
-        "props": Object {
-          "children": Array [
-            <div
-              className="control-wrapper"
->
-              <SvgSymbol
-                            className="search-box__icon"
-                            sym="search-icon"
-                            viewBox="0 0 20 20"
-              />
-              <div
-                            className="control is-medium"
-              >
-                            <input
-                                          className="input is-medium search-box__input"
-                                          maxLength="63"
-                                          onChange={[Function]}
-                                          onKeyDown={[Function]}
-                                          placeholder={undefined}
-                                          type="text"
-                                          value=""
-                            />
-              </div>
-</div>,
-            null,
-            null,
-          ],
-          "className": "search-box__search-field",
-        },
-        "ref": null,
-        "rendered": Array [
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": Array [
-                <SvgSymbol
-                  className="search-box__icon"
-                  sym="search-icon"
-                  viewBox="0 0 20 20"
-/>,
-                <div
-                  className="control is-medium"
->
-                  <input
-                                    className="input is-medium search-box__input"
-                                    maxLength="63"
-                                    onChange={[Function]}
-                                    onKeyDown={[Function]}
-                                    placeholder={undefined}
-                                    type="text"
-                                    value=""
-                  />
-</div>,
-              ],
-              "className": "control-wrapper",
-            },
-            "ref": null,
-            "rendered": Array [
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "className": "search-box__icon",
-                  "sym": "search-icon",
-                  "viewBox": "0 0 20 20",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": <input
-                    className="input is-medium search-box__input"
-                    maxLength="63"
-                    onChange={[Function]}
-                    onKeyDown={[Function]}
-                    placeholder={undefined}
-                    type="text"
-                    value=""
-/>,
-                  "className": "control is-medium",
-                },
-                "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "className": "input is-medium search-box__input",
-                    "maxLength": "63",
-                    "onChange": [Function],
-                    "onKeyDown": [Function],
-                    "placeholder": undefined,
-                    "type": "text",
-                    "value": "",
-                  },
-                  "ref": null,
-                  "rendered": null,
-                  "type": "input",
-                },
-                "type": "div",
-              },
-            ],
-            "type": "div",
-          },
-          null,
-          null,
-        ],
-        "type": "div",
-      },
-      "type": "div",
-    },
-  ],
-  Symbol(enzyme.__options__): Object {
-    "adapter": ReactSixteenAdapter {
-      "options": Object {
-        "enableComponentDidUpdateOnSetState": true,
-      },
-    },
-  },
-}
-`;
-
 exports[`shows a clear button if there is a query in the search box 1`] = `
 ShallowWrapper {
   "length": 1,
@@ -4742,13 +4742,13 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SearchBox
     clearSearch={[Function]}
     deactivate={[Function]}
+    executeSearch={[Function]}
     fetchResults={[Function]}
     searchQuery={
         Object {
             "query": "test me",
           }
     }
-    setSearch={[Function]}
 />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -5132,13 +5132,13 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SearchBox
     clearSearch={[Function]}
     deactivate={[Function]}
+    executeSearch={[Function]}
     fetchResults={[Function]}
     searchQuery={
         Object {
             "query": "test Me",
           }
     }
-    setSearch={[Function]}
     showDoneButton={true}
 />,
   Symbol(enzyme.__renderer__): Object {


### PR DESCRIPTION
Add support for supplying an optional command to the start of a search query to change search type behavior. (eg. m/ would execute a map search)

This allows for giving coordinates in the search box and to move the challenge search map accordingly:

* 4 coordinates as a bounding box

* 2 coordinates as a centerpoint
