### PR TITLE
Support priority rules for numerical types

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-dropzone": "^4.2.3",
     "react-grid-layout": "^0.16.6",
     "react-intl": "^2.3.0",
-    "react-jsonschema-form": "^1.0.1",
+    "react-jsonschema-form": "^1.0.6",
     "react-jsonschema-form-async": "^0.2.0",
     "react-leaflet": "^1.8.0",
     "react-leaflet-markercluster": "^1.1.7",

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.scss
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.scss
@@ -13,4 +13,10 @@
       }
     }
   }
+
+  .rjsf .array-field .priority-rule {
+    input[type=text] {
+      max-width: 150px;
+    }
+  }
 }

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
@@ -308,8 +308,14 @@ will not be able to make sense of it.
     id: 'Admin.EditChallenge.form.step3.description',
     defaultMessage:
       "The priority of tasks can be defined as High, Medium and Low. All " +
-      "high priority tasks will be shown first, then medium and finally " +
-      "low.",
+      "high priority tasks will be offered to users first when working " +
+      "through a challenge, followed by medium and finally low priority " +
+      "tasks. Each task's priority is assigned automatically based on " +
+      "the rules you specify below, each of which is evaluated against the " +
+      "task's feature properties (OSM tags if you are using an Overpass " +
+      "query, otherwise whatever properties you've chosen to include in " +
+      "your GeoJSON). Tasks that don't pass any rules will be assigned " +
+      "the default priority.",
   },
 
   defaultPriorityLabel: {

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/PriorityRuleGroup.test.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/PriorityRuleGroup.test.js
@@ -6,23 +6,42 @@ describe("preparePriorityRuleGroupForSaving", () => {
   let equalsOperatorFormRule = null
   let containsOperatorFormRule = null
   let emptyOperatorFormRule = null
+  let eqOperatorFormRule = null
+  let lteOperatorFormRule = null
 
   beforeEach(() => {
     equalsOperatorFormRule = {
       key: "firstTag",
+      valueType: "string",
       operator: "equals",
       value: "foo",
     }
 
     containsOperatorFormRule = {
       key: "secondTag",
+      valueType: "string",
       operator: "contains",
       value: "bar",
     }
 
     emptyOperatorFormRule = {
       key: "thirdTag",
+      valueType: "string",
       operator: "is_empty",
+    }
+
+    eqOperatorFormRule = {
+      key: "fourthTag",
+      valueType: "integer",
+      operator: "==",
+      value: "123",
+    }
+
+    lteOperatorFormRule = {
+      key: "fifthTag",
+      valueType: "integer",
+      operator: "<=",
+      value: "456",
     }
 
     basicFormGroup = {
@@ -30,6 +49,8 @@ describe("preparePriorityRuleGroupForSaving", () => {
       rules: [
         equalsOperatorFormRule,
         containsOperatorFormRule,
+        eqOperatorFormRule,
+        lteOperatorFormRule,
       ],
     }
   })
@@ -61,6 +82,7 @@ describe("preparePriorityRuleGroupForSaving", () => {
 
     for (let i = 0; i < basicFormGroup.rules.length; i++) {
       expect(result.rules[i].operator).toEqual(basicFormGroup.rules[i].operator)
+      expect(result.rules[i].type).toEqual(basicFormGroup.rules[i].valueType)
       expect(result.rules[i].value).toEqual(
         `${basicFormGroup.rules[i].key}.${basicFormGroup.rules[i].value}`)
     }
@@ -80,6 +102,22 @@ describe("preparePriorityRuleGroupForSaving", () => {
 
     expect(result).toMatchSnapshot()
   })
+
+  test("default string operator is filled in if missing", () => {
+    delete equalsOperatorFormRule.operator
+    const result =
+      JSON.parse(preparePriorityRuleGroupForSaving(basicFormGroup))
+
+    expect(result.rules[0].operator).toEqual("equal")
+  })
+
+  test("default numeric operator is filled in if missing", () => {
+    delete eqOperatorFormRule.operator
+    const result =
+      JSON.parse(preparePriorityRuleGroupForSaving(basicFormGroup))
+
+    expect(result.rules[2].operator).toEqual("==")
+  })
 })
 
 describe("preparePriorityRuleGroupForForm", () => {
@@ -87,21 +125,38 @@ describe("preparePriorityRuleGroupForForm", () => {
   let equalsOperatorSavedRule = null
   let containsOperatorSavedRule = null
   let emptyOperatorSavedRule = null
+  let eqOperatorSavedRule = null
+  let lteOperatorSavedRule = null
 
   beforeEach(() => {
     equalsOperatorSavedRule = {
+      type: "string",
       operator: "equals",
       value: "firstTag.foo",
     }
 
     containsOperatorSavedRule = {
+      type: "string",
       operator: "contains",
       value: "secondTag.bar",
     }
 
     emptyOperatorSavedRule = {
+      type: "string",
       operator: "is_empty",
       value: "thirdTag. ",
+    }
+
+    eqOperatorSavedRule = {
+      type: "integer",
+      operator: "==",
+      value: "fourthTag.123",
+    }
+
+    lteOperatorSavedRule = {
+      type: "integer",
+      operator: "<=",
+      value: "fifthTag.456",
     }
 
     basicSavedGroup = {
@@ -129,6 +184,7 @@ describe("preparePriorityRuleGroupForForm", () => {
 
     for (let i = 0; i < basicSavedGroup.rules.length; i++) {
       const parsed = basicSavedGroup.rules[i].value.split('.')
+      expect(result.rules[i].valueType).toEqual(basicSavedGroup.rules[i].type)
       expect(result.rules[i].operator).toEqual(basicSavedGroup.rules[i].operator)
       expect(result.rules[i].key).toEqual(parsed[0])
       expect(result.rules[i].value).toEqual(parsed[1])

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step3Schema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step3Schema.js
@@ -45,24 +45,59 @@ export const jsSchema = intl => {
             items: {
               type: "object",
               properties: {
-                key: {
-                  title: "Key",
+                valueType: {
+                  title: "Property Type",
                   type: "string",
+                  enum: ["string", "integer", "double", "long"],
+                  default: "string",
                 },
-                operator: {
+                key: {
+                  title: "Property Name",
                   type: "string",
-                  enum: ["equal", "not_equal",
-                        "contains", "not_contains",
-                        "is_empty", "is_not_empty"],
-                  enumNames: ["equals", "doesn't equal",
-                              "contains", "doesn't contain",
-                              "is empty", "isn't empty"],
-                  default: "equal",
                 },
                 value: {
-                  title: "Value",
+                  title: "Property Value",
                   type: "string",
                 },
+              },
+              required: [ "valueType" ],
+              dependencies: { // Show operators appropriate to value type
+                valueType: {
+                  oneOf: [
+                    {
+                      properties: {
+                        valueType: {
+                          enum: ["string"],
+                        },
+                        operator: {
+                          title: "Operator",
+                          type: "string",
+                          enum: ["equal", "not_equal",
+                                "contains", "not_contains",
+                                "is_empty", "is_not_empty"],
+                          enumNames: ["equals", "doesn't equal",
+                                      "contains", "doesn't contain",
+                                      "is empty", "isn't empty"],
+                          default: "equal", // doesn't work, rjsf bug #768
+                        },
+                      },
+                    },
+                    {
+                      properties: {
+                        valueType: {
+                          enum: ["integer", "double", "long"],
+                        },
+                        operator: {
+                          title: "Operator",
+                          type: "string",
+                          enum: ["==", "!=", "<", "<=", ">", ">="],
+                          enumNames: ["=", "≠", "<", "<=", ">", ">="],
+                          default: "==", // doesn't work, rjsf bug #768
+                        },
+                      },
+                    }
+                  ]
+                }
               },
             },
           },
@@ -118,19 +153,24 @@ const priorityRuleGroupUISchema = {
   rules: {
     items: {
       "ui:options": { inline: true, label: false },
+      classNames: "priority-rule",
       keyType: {
         "ui:widget": "select",
       },
+      valueType: {
+        "ui:widget": "select",
+      },
       key: {
-        "ui:placeholder": "OSM Tag Name",
+        "ui:placeholder": "Property Name",
       },
       operator: {
         "ui:widget": "select",
       },
       value: {
-        "ui:placeholder": "Value",
+        "ui:placeholder": "Property Value",
       },
-    }
+      "ui:order": [ "valueType", "key", "operator", "value" ],
+    },
   },
 }
 

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/__snapshots__/PriorityRuleGroup.test.js.snap
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/__snapshots__/PriorityRuleGroup.test.js.snap
@@ -8,11 +8,13 @@ Object {
       "key": "firstTag",
       "operator": "equals",
       "value": "foo",
+      "valueType": "string",
     },
     Object {
       "key": "secondTag",
       "operator": "contains",
       "value": "bar",
+      "valueType": "string",
     },
   ],
 }
@@ -26,6 +28,7 @@ Object {
       "key": "thirdTag",
       "operator": "is_empty",
       "value": "",
+      "valueType": "string",
     },
   ],
 }
@@ -36,16 +39,24 @@ Object {
   "condition": "AND",
   "rules": Array [
     Object {
-      "field": "tag",
       "operator": "equals",
       "type": "string",
       "value": "firstTag.foo",
     },
     Object {
-      "field": "tag",
       "operator": "contains",
       "type": "string",
       "value": "secondTag.bar",
+    },
+    Object {
+      "operator": "==",
+      "type": "integer",
+      "value": "fourthTag.123",
+    },
+    Object {
+      "operator": "<=",
+      "type": "integer",
+      "value": "fifthTag.456",
     },
   ],
 }
@@ -56,7 +67,6 @@ Object {
   "condition": "AND",
   "rules": Array [
     Object {
-      "field": "tag",
       "operator": "is_empty",
       "type": "string",
       "value": "thirdTag. ",

--- a/src/components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
+++ b/src/components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
@@ -53,7 +53,8 @@ export const CustomFieldTemplate = props => {
 
 export const CustomArrayFieldTemplate = props => {
   const itemFields = _map(props.items, element =>
-    <div key={element.index} className="array-field__item">
+    <div key={element.index}
+         className={classNames("array-field__item", _get(props, 'uiSchema.items.classNames'))}>
       <div className={classNames({
         inline: _get(props, 'uiSchema.items.ui:options.inline')}
       )}>

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -134,7 +134,7 @@
   "Admin.EditChallenge.form.ignoreSourceErrors.label": "Ignore Errors",
   "Admin.EditChallenge.form.ignoreSourceErrors.description": "Proceed despite detected errors in source data. Only expert users who fully understand the implications should attempt this.",
   "Admin.EditChallenge.form.step3.label": "Priorities",
-  "Admin.EditChallenge.form.step3.description": "The priority of tasks can be defined as High, Medium and Low. All high priority tasks will be shown first, then medium and finally low.",
+  "Admin.EditChallenge.form.step3.description": "The priority of tasks can be defined as High, Medium and Low. All high priority tasks will be offered to users first when working through a challenge, followed by medium and finally low priority tasks. Each task's priority is assigned automatically based on the rules you specify below, each of which is evaluated against the task's feature properties (OSM tags if you are using an Overpass query, otherwise whatever properties you've chosen to include in your GeoJSON). Tasks that don't pass any rules will be assigned the default priority.",
   "Admin.EditChallenge.form.defaultPriority.label": "Default Priority",
   "Admin.EditChallenge.form.defaultPriority.description": "Default priority level for tasks in this challenge",
   "Admin.EditChallenge.form.step4.label": "Extra",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2536,6 +2536,10 @@ core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
 
+core-js@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -8047,14 +8051,15 @@ react-jsonschema-form-async@^0.2.0:
     lodash "^4.17.5"
     prop-types "^15.6.1"
 
-react-jsonschema-form@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/react-jsonschema-form/-/react-jsonschema-form-1.0.3.tgz#83bf8c5330651a949d8b0ac644fb92c6665348b5"
+react-jsonschema-form@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/react-jsonschema-form/-/react-jsonschema-form-1.0.6.tgz#ceef7c2c386e46a149ec94203547dd9111913e36"
   dependencies:
     ajv "^5.2.3"
+    babel-runtime "^6.26.0"
+    core-js "^2.5.7"
     lodash.topath "^4.5.2"
     prop-types "^15.5.8"
-    setimmediate "^1.0.5"
 
 react-leaflet-markercluster@^1.1.7:
   version "1.1.8"


### PR DESCRIPTION
* When setting up task priority rules during challenge creation, support
integer, double, and long value types along with their numerical
operators. This allows, for example, priority rules to be applied based
on whether tag or property values fall within a specified numerical
range.

* Update priority rule introduction and form labels to make clearer that
priority rules are working off feature properties

* Upgrade react-jsonschema-form package to latest minor update