### PR TITLE
Challenge search map reverts to default when clicking link

### DIFF
--- a/src/components/ChallengeSearchMap/ChallengeSearchMap.js
+++ b/src/components/ChallengeSearchMap/ChallengeSearchMap.js
@@ -156,7 +156,7 @@ export class ChallengeSearchMap extends Component {
     )
 
     // If the app is still loading then we have no initialBounds
-    const initialBounds = !this.props.loadedFromRouteDone ? null : _get(this.props, 'mapBounds.bounds')
+    const initialBounds = _get(this.props, 'mapBounds.bounds')
 
     return (
       <div key='ChallengeSearchMap'

--- a/src/components/ChallengeSearchMap/__snapshots__/ChallengeSearchMap.test.js.snap
+++ b/src/components/ChallengeSearchMap/__snapshots__/ChallengeSearchMap.test.js.snap
@@ -72,7 +72,18 @@ ShallowWrapper {
                               "lng": 45,
                             }
           }
-          initialBounds={null}
+          initialBounds={
+                    Object {
+                              "_northEast": Object {
+                                "lat": 0,
+                                "lng": 0,
+                              },
+                              "_southWest": Object {
+                                "lat": 0,
+                                "lng": 0,
+                              },
+                            }
+          }
           justFitFeatures={false}
           maxZoom={18}
           minZoom={2}
@@ -184,7 +195,16 @@ ShallowWrapper {
             Array [],
             false,
           ],
-          "initialBounds": null,
+          "initialBounds": Object {
+            "_northEast": Object {
+              "lat": 0,
+              "lng": 0,
+            },
+            "_southWest": Object {
+              "lat": 0,
+              "lng": 0,
+            },
+          },
           "justFitFeatures": false,
           "maxZoom": 18,
           "minZoom": 2,
@@ -281,7 +301,18 @@ ShallowWrapper {
                                     "lng": 45,
                                   }
             }
-            initialBounds={null}
+            initialBounds={
+                        Object {
+                                    "_northEast": Object {
+                                      "lat": 0,
+                                      "lng": 0,
+                                    },
+                                    "_southWest": Object {
+                                      "lat": 0,
+                                      "lng": 0,
+                                    },
+                                  }
+            }
             justFitFeatures={false}
             maxZoom={18}
             minZoom={2}
@@ -393,7 +424,16 @@ ShallowWrapper {
               Array [],
               false,
             ],
-            "initialBounds": null,
+            "initialBounds": Object {
+              "_northEast": Object {
+                "lat": 0,
+                "lng": 0,
+              },
+              "_southWest": Object {
+                "lat": 0,
+                "lng": 0,
+              },
+            },
             "justFitFeatures": false,
             "maxZoom": 18,
             "minZoom": 2,

--- a/src/components/HOCs/WithSearchRoute/WithSearchRoute.js
+++ b/src/components/HOCs/WithSearchRoute/WithSearchRoute.js
@@ -113,7 +113,6 @@ export const WithSearchRoute = function(WrappedComponent, searchGroup) {
       return (
         <WrappedComponent {...this.props}
                             isLoading={this.props.isLoading || !this.state.loadedFromRoute}
-                            loadedFromRouteDone={this.state.loadedFromRoute}
                             setSearch={this.setSearch}
                             clearSearch={this.clearSearch}
                             setSearchSort={this.setSearchSort}


### PR DESCRIPTION
When clicking the 'challenges' link the challenge search map
would always revert to the default map because WithSearchRoute
wanted it to if no map bounds were on the URL. While this is
logically correct it made for unexpected behavior from a user's
perspective.