### PR TITLE
Initial page "more results" button missing

### DIFF
--- a/src/components/HOCs/WithPagedChallenges/WithPagedChallenges.js
+++ b/src/components/HOCs/WithPagedChallenges/WithPagedChallenges.js
@@ -17,7 +17,7 @@ export default function(WrappedComponent,
 
       let pagedChallenges = this.props[challengesProp]
 
-      const hasMoreResults = (pagedChallenges.length > numberResultsToShow) || this.props.isLoading
+      const hasMoreResults = (pagedChallenges.length >= numberResultsToShow) || this.props.isLoading
       pagedChallenges = _slice(pagedChallenges, 0, numberResultsToShow)
 
       if (_isEmpty(outputProp)) {

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ const {store} = initializePersistedStore(store => {
     extendedFind({sortCriteria: {sortBy: SortOptions.popular},
                   challengeStatus: [ChallengeStatus.ready,
                     ChallengeStatus.partiallyLoaded,
-                    ChallengeStatus.none, 
+                    ChallengeStatus.none,
                     ChallengeStatus.empty]}, RESULTS_PER_PAGE)
   )
 


### PR DESCRIPTION
When loading from a fresh cache the initial "more results" button was missing because it had the exact number of results requested to display. Changed the initial seed to populate with one extra so the button will show.
