### PR TITLE
Route to browse-challenges page when intended

### DIFF
--- a/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.js
+++ b/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.js
@@ -196,7 +196,7 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
               _get(normalizedResults,
                    `entities.challenges.${normalizedResults.result}.deleted`)) {
             dispatch(addError(AppErrors.challenge.doesNotExist))
-            ownProps.history.push('/')
+            ownProps.history.push('/browse/challenges')
           }
         })
       },

--- a/src/components/HOCs/WithChallenge/WithChallenge.js
+++ b/src/components/HOCs/WithChallenge/WithChallenge.js
@@ -80,7 +80,7 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
               _get(normalizedResults,
                    `entities.challenges.${normalizedResults.result}.deleted`)) {
             dispatch(addError(AppErrors.challenge.doesNotExist))
-            ownProps.history.push('/')
+            ownProps.history.push('/browse/challenges')
           }
         })
       }

--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
@@ -111,7 +111,7 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
             _get(normalizedResults,
                  `entities.tasks.${normalizedResults.result}.deleted`)) {
           dispatch(addError(AppErrors.task.doesNotExist))
-          ownProps.history.push('/')
+          ownProps.history.push('/browse/challenges')
           return
         }
 
@@ -144,7 +144,7 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
       if (!_isFinite(normalizedResults.result) ||
           _get(normalizedResults, `entities.tasks.${normalizedResults.result}.deleted`)) {
         dispatch(addError(AppErrors.task.doesNotExist))
-        ownProps.history.push('/')
+        ownProps.history.push('/browse/challenges')
       }
 
       return normalizedResults
@@ -271,7 +271,7 @@ export const visitNewTask = function(props, currentTaskId, newTask) {
   else {
     // Assume challenge is complete. Redirect home with note to congratulate
     // user.
-    props.history.push('/', {congratulate: true})
+    props.history.push('/browse/challenges', {congratulate: true})
   }
 }
 

--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.test.js
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.test.js
@@ -207,7 +207,7 @@ test("completeTask routes the user home if the next task isn't new", async () =>
   const mappedProps = mapDispatchToProps(dispatch, {history})
 
   await mappedProps.completeTask(task.id, challenge.id, completionStatus)
-  expect(history.push).toBeCalledWith('/', {congratulate: true})
+  expect(history.push).toBeCalledWith('/browse/challenges', {congratulate: true})
 })
 
 test("completeTask routes the user home if there is no next task", async () => {
@@ -221,5 +221,5 @@ test("completeTask routes the user home if there is no next task", async () => {
   const mappedProps = mapDispatchToProps(dispatch, {history})
 
   await mappedProps.completeTask(task.id, challenge.id, completionStatus)
-  expect(history.push).toBeCalledWith('/', {congratulate: true})
+  expect(history.push).toBeCalledWith('/browse/challenges', {congratulate: true})
 })

--- a/src/components/HOCs/WithVirtualChallenge/WithVirtualChallenge.js
+++ b/src/components/HOCs/WithVirtualChallenge/WithVirtualChallenge.js
@@ -73,7 +73,7 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
         if (!results.result ||
             results.entities.virtualChallenges[results.result].expiry < Date.now()) {
           dispatch(addError(AppErrors.virtualChallenge.expired))
-          ownProps.history.push('/')
+          ownProps.history.push('/browse/challenges')
         }
       })
     }, FRESHNESS_THRESHOLD),

--- a/src/components/LoadRandomChallengeTask/LoadRandomChallengeTask.js
+++ b/src/components/LoadRandomChallengeTask/LoadRandomChallengeTask.js
@@ -18,7 +18,7 @@ const _LoadRandomChallengeTask = class extends Component {
                   `/challenge/${challengeId}/task/${task.id}`)
           }
           else {
-            this.props.history.push('/')
+            this.props.history.push('/browse/challenges')
           }
         })
         .catch(error => {


### PR DESCRIPTION
Prior to addition of a home page, the root route (`/`) went to the
browse-challenges page, but that is no longer true. Update various
locations that routed to root (often when punting after a failure) to
instead explicitly route to browse-challenges as intended