### PR TITLE
Revert change to search map loses location

### DIFF
--- a/src/components/ChallengeSearchMap/ChallengeSearchMap.js
+++ b/src/components/ChallengeSearchMap/ChallengeSearchMap.js
@@ -156,7 +156,7 @@ export class ChallengeSearchMap extends Component {
     )
 
     // If the app is still loading then we have no initialBounds
-    const initialBounds = _get(this.props, 'mapBounds.bounds')
+    const initialBounds = !this.props.loadedFromRouteDone ? null : _get(this.props, 'mapBounds.bounds')
 
     return (
       <div key='ChallengeSearchMap'

--- a/src/components/ChallengeSearchMap/__snapshots__/ChallengeSearchMap.test.js.snap
+++ b/src/components/ChallengeSearchMap/__snapshots__/ChallengeSearchMap.test.js.snap
@@ -72,18 +72,7 @@ ShallowWrapper {
                               "lng": 45,
                             }
           }
-          initialBounds={
-                    Object {
-                              "_northEast": Object {
-                                "lat": 0,
-                                "lng": 0,
-                              },
-                              "_southWest": Object {
-                                "lat": 0,
-                                "lng": 0,
-                              },
-                            }
-          }
+          initialBounds={null}
           justFitFeatures={false}
           maxZoom={18}
           minZoom={2}
@@ -195,16 +184,7 @@ ShallowWrapper {
             Array [],
             false,
           ],
-          "initialBounds": Object {
-            "_northEast": Object {
-              "lat": 0,
-              "lng": 0,
-            },
-            "_southWest": Object {
-              "lat": 0,
-              "lng": 0,
-            },
-          },
+          "initialBounds": null,
           "justFitFeatures": false,
           "maxZoom": 18,
           "minZoom": 2,
@@ -301,18 +281,7 @@ ShallowWrapper {
                                     "lng": 45,
                                   }
             }
-            initialBounds={
-                        Object {
-                                    "_northEast": Object {
-                                      "lat": 0,
-                                      "lng": 0,
-                                    },
-                                    "_southWest": Object {
-                                      "lat": 0,
-                                      "lng": 0,
-                                    },
-                                  }
-            }
+            initialBounds={null}
             justFitFeatures={false}
             maxZoom={18}
             minZoom={2}
@@ -424,16 +393,7 @@ ShallowWrapper {
               Array [],
               false,
             ],
-            "initialBounds": Object {
-              "_northEast": Object {
-                "lat": 0,
-                "lng": 0,
-              },
-              "_southWest": Object {
-                "lat": 0,
-                "lng": 0,
-              },
-            },
+            "initialBounds": null,
             "justFitFeatures": false,
             "maxZoom": 18,
             "minZoom": 2,

--- a/src/components/HOCs/WithSearchRoute/WithSearchRoute.js
+++ b/src/components/HOCs/WithSearchRoute/WithSearchRoute.js
@@ -113,6 +113,7 @@ export const WithSearchRoute = function(WrappedComponent, searchGroup) {
       return (
         <WrappedComponent {...this.props}
                             isLoading={this.props.isLoading || !this.state.loadedFromRoute}
+                            loadedFromRouteDone={this.state.loadedFromRoute || _isEmpty(this.props.history.location.search)}
                             setSearch={this.setSearch}
                             clearSearch={this.clearSearch}
                             setSearchSort={this.setSearchSort}


### PR DESCRIPTION
Reverts the prior change to search map loses location and fixes
in a different way by checking if the url has no search parameters
and then it will use the value from redux.
