### PR TITLE
Allow map wrapping. Closes #593

### DIFF
--- a/src/components/AdminPane/Manage/ChallengeTaskMap/ChallengeTaskMap.js
+++ b/src/components/AdminPane/Manage/ChallengeTaskMap/ChallengeTaskMap.js
@@ -309,7 +309,7 @@ export class ChallengeTaskMap extends Component {
                      zoom={_get(this.props.lastZoom, 3)} minZoom={1} maxZoom={18}
                      setInitialBounds={false}
                      initialBounds = {_get(this.props, 'lastBounds', this.currentBounds)}
-                     zoomControl={false} animate={true}
+                     zoomControl={false} animate={true} worldCopyJump={true}
                      features={bounding}
                      justFitFeatures={false}
                      onBoundsChange={this.updateBounds}>

--- a/src/components/ChallengeBrowseMap/ChallengeBrowseMap.js
+++ b/src/components/ChallengeBrowseMap/ChallengeBrowseMap.js
@@ -143,7 +143,7 @@ export class ChallengeBrowseMap extends Component {
         <EnhancedMap center={latLng(0, 45)} zoom={3} minZoom={2} maxZoom={18}
                      setInitialBounds={false}
                      initialBounds = {this.currentBounds}
-                     zoomControl={false} animate={true}
+                     zoomControl={false} animate={true} worldCopyJump={true}
                      features={bounding}
                      justFitFeatures={hasTaskMarkers}
                      onBoundsChange={this.updateBounds}>

--- a/src/components/ChallengeBrowseMap/__snapshots__/ChallengeBrowseMap.test.js.snap
+++ b/src/components/ChallengeBrowseMap/__snapshots__/ChallengeBrowseMap.test.js.snap
@@ -99,6 +99,7 @@ ShallowWrapper {
           minZoom={2}
           onBoundsChange={[Function]}
           setInitialBounds={false}
+          worldCopyJump={true}
           zoom={3}
           zoomControl={false}
 >
@@ -240,6 +241,7 @@ ShallowWrapper {
           "minZoom": 2,
           "onBoundsChange": [Function],
           "setInitialBounds": false,
+          "worldCopyJump": true,
           "zoom": 3,
           "zoomControl": false,
         },
@@ -364,6 +366,7 @@ ShallowWrapper {
             minZoom={2}
             onBoundsChange={[Function]}
             setInitialBounds={false}
+            worldCopyJump={true}
             zoom={3}
             zoomControl={false}
 >
@@ -505,6 +508,7 @@ ShallowWrapper {
             "minZoom": 2,
             "onBoundsChange": [Function],
             "setInitialBounds": false,
+            "worldCopyJump": true,
             "zoom": 3,
             "zoomControl": false,
           },
@@ -681,6 +685,7 @@ ShallowWrapper {
           minZoom={2}
           onBoundsChange={[Function]}
           setInitialBounds={false}
+          worldCopyJump={true}
           zoom={3}
           zoomControl={false}
 >
@@ -819,6 +824,7 @@ ShallowWrapper {
           "minZoom": 2,
           "onBoundsChange": [Function],
           "setInitialBounds": false,
+          "worldCopyJump": true,
           "zoom": 3,
           "zoomControl": false,
         },
@@ -933,6 +939,7 @@ ShallowWrapper {
             minZoom={2}
             onBoundsChange={[Function]}
             setInitialBounds={false}
+            worldCopyJump={true}
             zoom={3}
             zoomControl={false}
 >
@@ -1071,6 +1078,7 @@ ShallowWrapper {
             "minZoom": 2,
             "onBoundsChange": [Function],
             "setInitialBounds": false,
+            "worldCopyJump": true,
             "zoom": 3,
             "zoomControl": false,
           },
@@ -1240,6 +1248,7 @@ ShallowWrapper {
           minZoom={2}
           onBoundsChange={[Function]}
           setInitialBounds={false}
+          worldCopyJump={true}
           zoom={3}
           zoomControl={false}
 >
@@ -1381,6 +1390,7 @@ ShallowWrapper {
           "minZoom": 2,
           "onBoundsChange": [Function],
           "setInitialBounds": false,
+          "worldCopyJump": true,
           "zoom": 3,
           "zoomControl": false,
         },
@@ -1497,6 +1507,7 @@ ShallowWrapper {
             minZoom={2}
             onBoundsChange={[Function]}
             setInitialBounds={false}
+            worldCopyJump={true}
             zoom={3}
             zoomControl={false}
 >
@@ -1638,6 +1649,7 @@ ShallowWrapper {
             "minZoom": 2,
             "onBoundsChange": [Function],
             "setInitialBounds": false,
+            "worldCopyJump": true,
             "zoom": 3,
             "zoomControl": false,
           },

--- a/src/components/ChallengeSearchMap/ChallengeSearchMap.js
+++ b/src/components/ChallengeSearchMap/ChallengeSearchMap.js
@@ -165,7 +165,7 @@ export class ChallengeSearchMap extends Component {
         <EnhancedMap center={latLng(0, 45)} zoom={3} minZoom={2} maxZoom={18}
                      setInitialBounds={false}
                      initialBounds = {initialBounds}
-                     zoomControl={false} animate={true}
+                     zoomControl={false} animate={true} worldCopyJump={true}
                      onBoundsChange={this.updateBounds}>
           <ZoomControl position='topright' />
           <SourcedTileLayer {...this.props} zIndex={1} />

--- a/src/components/ChallengeSearchMap/__snapshots__/ChallengeSearchMap.test.js.snap
+++ b/src/components/ChallengeSearchMap/__snapshots__/ChallengeSearchMap.test.js.snap
@@ -78,6 +78,7 @@ ShallowWrapper {
           minZoom={2}
           onBoundsChange={[Function]}
           setInitialBounds={false}
+          worldCopyJump={true}
           zoom={3}
           zoomControl={false}
 >
@@ -190,6 +191,7 @@ ShallowWrapper {
           "minZoom": 2,
           "onBoundsChange": [Function],
           "setInitialBounds": false,
+          "worldCopyJump": true,
           "zoom": 3,
           "zoomControl": false,
         },
@@ -287,6 +289,7 @@ ShallowWrapper {
             minZoom={2}
             onBoundsChange={[Function]}
             setInitialBounds={false}
+            worldCopyJump={true}
             zoom={3}
             zoomControl={false}
 >
@@ -399,6 +402,7 @@ ShallowWrapper {
             "minZoom": 2,
             "onBoundsChange": [Function],
             "setInitialBounds": false,
+            "worldCopyJump": true,
             "zoom": 3,
             "zoomControl": false,
           },

--- a/src/components/EnhancedMap/EnhancedMap.js
+++ b/src/components/EnhancedMap/EnhancedMap.js
@@ -182,9 +182,6 @@ export default class EnhancedMap extends Map {
   componentDidMount() {
     super.componentDidMount()
 
-    // Don't allow wrapping of the map around the world.
-    this.leafletElement.setMaxBounds([[-90, -180], [90, 180]])
-
     // If there are geojson features, add them to the leaflet map and then
     // fit the map to the bounds of those features.
     if (this.props.features) {

--- a/src/components/InsetMap/InsetMap.js
+++ b/src/components/InsetMap/InsetMap.js
@@ -19,7 +19,7 @@ export default class InsetMap extends Component {
              zoom={this.props.fixedZoom}
              minZoom={this.props.fixedZoom}
              maxZoom={this.props.fixedZoom}
-             zoomControl={false}
+             zoomControl={false} worldCopyJump={true}
              attributionControl={false}>
           <SourcedTileLayer source={layerSource} skipAttribution={true} />
           <Marker position={this.props.centerPoint}

--- a/src/components/TaskPane/TaskMap/TaskMap.js
+++ b/src/components/TaskPane/TaskMap/TaskMap.js
@@ -209,7 +209,7 @@ export class TaskMap extends Component {
                      mapillaryLoading={this.state.mapillaryLayerLoading}
                      mapillaryCount={_get(this.props, 'task.mapillaryImages.length', 0)} />
         <EnhancedMap center={this.props.centerPoint} zoom={zoom} zoomControl={false}
-                     minZoom={minZoom} maxZoom={maxZoom}
+                     minZoom={minZoom} maxZoom={maxZoom} worldCopyJump={true}
                      features={_get(this.props.task, 'geometries.features')}
                      justFitFeatures={!this.state.showTaskFeatures}
                      fitFeaturesOnlyAsNecessary

--- a/src/components/TaskPane/TaskMap/__snapshots__/TaskMap.test.js.snap
+++ b/src/components/TaskPane/TaskMap/__snapshots__/TaskMap.test.js.snap
@@ -82,6 +82,7 @@ ShallowWrapper {
           minZoom={1}
           onBoundsChange={[Function]}
           setInitialBounds={true}
+          worldCopyJump={true}
           zoom={2}
           zoomControl={false}
 >
@@ -201,6 +202,7 @@ ShallowWrapper {
           "minZoom": 1,
           "onBoundsChange": [Function],
           "setInitialBounds": true,
+          "worldCopyJump": true,
           "zoom": 2,
           "zoomControl": false,
         },
@@ -312,6 +314,7 @@ ShallowWrapper {
             minZoom={1}
             onBoundsChange={[Function]}
             setInitialBounds={true}
+            worldCopyJump={true}
             zoom={2}
             zoomControl={false}
 >
@@ -431,6 +434,7 @@ ShallowWrapper {
             "minZoom": 1,
             "onBoundsChange": [Function],
             "setInitialBounds": true,
+            "worldCopyJump": true,
             "zoom": 2,
             "zoomControl": false,
           },


### PR DESCRIPTION
Allow map to wrap, using leaflet `worldCopyJump` option, instead of
simply restricting the map bounds