### PR TITLE
Add specific message for narrow browser windows

### DIFF
--- a/src/components/AdminPane/AdminPane.js
+++ b/src/components/AdminPane/AdminPane.js
@@ -5,8 +5,8 @@ import MediaQuery from 'react-responsive'
 import AsManager from '../../interactions/User/AsManager'
 import WithCurrentUser from '../HOCs/WithCurrentUser/WithCurrentUser'
 import WithChallenges from '../HOCs/WithChallenges/WithChallenges'
-import MobileNotSupported
-       from '../MobileNotSupported/MobileNotSupported'
+import ScreenTooNarrow
+       from '../ScreenTooNarrow/ScreenTooNarrow'
 import EditChallenge from './Manage/ManageChallenges/EditChallenge/EditChallenge'
 import EditProject from './Manage/EditProject/EditProject'
 import EditTask from './Manage/ManageTasks/EditTask/EditTask'
@@ -50,7 +50,7 @@ export class AdminPane extends Component {
     return (
       <React.Fragment>
         <MediaQuery query="(max-width: 1023px)">
-          <MobileNotSupported forPage widenDisplay />
+          <ScreenTooNarrow />
         </MediaQuery>
 
         <MediaQuery query="(min-width: 1024px)">

--- a/src/components/ScreenTooNarrow/Messages.js
+++ b/src/components/ScreenTooNarrow/Messages.js
@@ -1,0 +1,16 @@
+import { defineMessages } from 'react-intl'
+
+/**
+ * Internationalized messages for use with ScreenTooNarrow
+ */
+export default defineMessages({
+  header: {
+    id: "ScreenTooNarrow.header",
+    defaultMessage: "Please widen your browser window"
+  },
+
+  message: {
+    id: "ScreenTooNarrow.message",
+    defaultMessage: "This page is not yet compatible with smaller screens. Please expand your browser window or switch to a larger device or display."
+  },
+})

--- a/src/components/ScreenTooNarrow/ScreenTooNarrow.js
+++ b/src/components/ScreenTooNarrow/ScreenTooNarrow.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react'
+import { FormattedMessage } from 'react-intl'
+import Sprites from '../Sprites/Sprites'
+import SvgSymbol from '../SvgSymbol/SvgSymbol'
+import messages from './Messages'
+import './ScreenTooNarrow.css'
+
+/**
+ * ScreenTooNarrow displays a message indicating that the user's screen/window
+ * is too narrow to display the current page
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
+export default class ScreenTooNarrow extends Component {
+  render() {
+    return (
+      <div className="screen-too-narrow">
+        <div className="screen-too-narrow__header">
+          <SvgSymbol viewBox='0 0 20 20' sym="computer-icon" />
+          <div>
+            <h1 className="title"><FormattedMessage {...messages.header} /></h1>
+            <p className="screen-too-narrow__message">
+              <FormattedMessage {...messages.message} />
+            </p>
+          </div>
+        </div>
+        <Sprites />
+      </div>
+    )
+  }
+}

--- a/src/components/ScreenTooNarrow/ScreenTooNarrow.scss
+++ b/src/components/ScreenTooNarrow/ScreenTooNarrow.scss
@@ -1,0 +1,46 @@
+@import 'variables.scss';
+
+.screen-too-narrow {
+  padding: 30px 20px;
+  max-width: 100%;
+  background-color: $app-background;
+  min-height: $mobile-full-screen-pane;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    margin: 30px;
+
+    svg {
+      width: 80px;
+      height: 80px;
+      fill: $grey-dark;
+      margin-right: 20px;
+    }
+
+    h1.title {
+      margin-bottom: 5px;
+    }
+  }
+
+  @media(max-width: $app-mobile-break) {
+    .screen-too-narrow__header {
+      margin: 0;
+      padding: 5px;
+
+      svg {
+        width: auto;
+        height: 60px;
+      }
+
+      h1.title {
+        font-size: $size-7;
+        font-weight: $weight-semibold;
+      }
+
+      .screen-too-narrow__message {
+        font-size: $size-8;
+      }
+    }
+  }
+}

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -313,6 +313,8 @@
   "PageNotFound.returnTo": "Return to",
   "PageNotFound.homePage": "home page",
   "PastDurationSelector.pastMonths.selectOption": "Past {months, plural, one {Month} =12 {Year} other {# Months}}",
+  "ScreenTooNarrow.header": "Please widen your browser window",
+  "ScreenTooNarrow.message": "This page is not yet compatible with smaller screens. Please expand your browser window or switch to a larger device or display.",
   "ShareLink.controls.copy.label": "Copy",
   "SignIn.control.label": "Sign in",
   "Task.controls.moreOptions.label": "More Options",


### PR DESCRIPTION
Rather than piggybacking on MobileNotSupported, add an explicit
ScreenTooNarrow message for display when a user's browser window is too
narrow and needs to be widened for proper display