### PR TITLE
Change Level0 keyboard shortcut to `v`

### DIFF
--- a/src/components/EnhancedMap/FitBoundsControl/FitBoundsControl.js
+++ b/src/components/EnhancedMap/FitBoundsControl/FitBoundsControl.js
@@ -89,14 +89,14 @@ const FitBoundsLeafletControl = Control.extend({
 const keyboardHandler = function(key, controlFunction) {
   return Handler.extend({
     addHooks: function() {
-      DomEvent.on(document, 'keypress', this.onKeypress, this)
+      DomEvent.on(document, 'keydown', this.onKeydown, this)
     },
 
     removeHooks: function() {
-      DomEvent.off(document, 'keypress', this.onKeypress, this)
+      DomEvent.off(document, 'keydown', this.onKeydown, this)
     },
 
-    onKeypress: function(event) {
+    onKeydown: function(event) {
       if (event.key === key) {
         controlFunction()
       }

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskAlreadyFixedControl/__snapshots__/TaskAlreadyFixedControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskAlreadyFixedControl/__snapshots__/TaskAlreadyFixedControl.test.js.snap
@@ -45,7 +45,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCancelEditingControl/__snapshots__/TaskCancelEditingControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCancelEditingControl/__snapshots__/TaskCancelEditingControl.test.js.snap
@@ -45,7 +45,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep1/__snapshots__/TaskCompletionStep1.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep1/__snapshots__/TaskCompletionStep1.test.js.snap
@@ -49,7 +49,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -271,7 +271,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -493,7 +493,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -724,7 +724,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -906,7 +906,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -1076,7 +1076,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -1246,7 +1246,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -1420,7 +1420,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -1586,7 +1586,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -1752,7 +1752,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -1929,7 +1929,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -2099,7 +2099,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -2269,7 +2269,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -2443,7 +2443,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -2609,7 +2609,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -2775,7 +2775,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -2959,7 +2959,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -3141,7 +3141,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -3311,7 +3311,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -3481,7 +3481,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -3655,7 +3655,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -3821,7 +3821,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -3987,7 +3987,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -4164,7 +4164,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -4334,7 +4334,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -4504,7 +4504,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -4678,7 +4678,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -4844,7 +4844,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -5010,7 +5010,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -5194,7 +5194,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -5376,7 +5376,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -5546,7 +5546,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -5716,7 +5716,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -5890,7 +5890,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -6056,7 +6056,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -6222,7 +6222,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -6399,7 +6399,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -6569,7 +6569,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -6739,7 +6739,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -6913,7 +6913,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -7079,7 +7079,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -7245,7 +7245,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep2/__snapshots__/TaskCompletionStep2.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep2/__snapshots__/TaskCompletionStep2.test.js.snap
@@ -50,7 +50,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -226,7 +226,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -395,7 +395,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -565,7 +565,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -734,7 +734,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -908,7 +908,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -1084,7 +1084,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -1253,7 +1253,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -1423,7 +1423,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -1592,7 +1592,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -1766,7 +1766,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -1942,7 +1942,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -2111,7 +2111,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -2281,7 +2281,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -2450,7 +2450,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -2624,7 +2624,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -2800,7 +2800,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -2969,7 +2969,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -3139,7 +3139,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -3308,7 +3308,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -3491,7 +3491,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -3672,7 +3672,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -3840,7 +3840,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -4008,7 +4008,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -4177,7 +4177,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -4346,7 +4346,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -4518,7 +4518,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -4682,7 +4682,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -4846,7 +4846,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -5011,7 +5011,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -5176,7 +5176,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -5351,7 +5351,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -5519,7 +5519,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -5687,7 +5687,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -5856,7 +5856,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -6025,7 +6025,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -6197,7 +6197,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -6361,7 +6361,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -6525,7 +6525,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -6690,7 +6690,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -6855,7 +6855,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -7038,7 +7038,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -7219,7 +7219,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -7387,7 +7387,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -7555,7 +7555,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -7724,7 +7724,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -7893,7 +7893,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -8065,7 +8065,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -8229,7 +8229,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -8393,7 +8393,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -8558,7 +8558,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -8723,7 +8723,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -8898,7 +8898,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -9066,7 +9066,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -9234,7 +9234,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -9403,7 +9403,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -9572,7 +9572,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -9744,7 +9744,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -9908,7 +9908,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -10072,7 +10072,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -10237,7 +10237,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -10402,7 +10402,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -10585,7 +10585,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -10766,7 +10766,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -10934,7 +10934,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -11102,7 +11102,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -11271,7 +11271,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -11440,7 +11440,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -11612,7 +11612,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -11776,7 +11776,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -11940,7 +11940,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -12105,7 +12105,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -12270,7 +12270,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -12445,7 +12445,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -12613,7 +12613,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -12781,7 +12781,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -12950,7 +12950,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -13119,7 +13119,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -13291,7 +13291,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -13455,7 +13455,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -13619,7 +13619,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -13784,7 +13784,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -13949,7 +13949,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -14132,7 +14132,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -14313,7 +14313,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -14481,7 +14481,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -14649,7 +14649,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -14818,7 +14818,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -14987,7 +14987,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -15159,7 +15159,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -15323,7 +15323,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -15487,7 +15487,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -15652,7 +15652,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -15817,7 +15817,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -15992,7 +15992,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -16160,7 +16160,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -16328,7 +16328,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -16497,7 +16497,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -16666,7 +16666,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -16838,7 +16838,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -17002,7 +17002,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -17166,7 +17166,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -17331,7 +17331,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -17496,7 +17496,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -17679,7 +17679,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -17860,7 +17860,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -18028,7 +18028,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -18196,7 +18196,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -18365,7 +18365,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -18534,7 +18534,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -18706,7 +18706,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -18870,7 +18870,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -19034,7 +19034,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -19199,7 +19199,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -19364,7 +19364,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -19539,7 +19539,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -19707,7 +19707,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -19875,7 +19875,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -20044,7 +20044,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -20213,7 +20213,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -20385,7 +20385,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -20549,7 +20549,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -20713,7 +20713,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -20878,7 +20878,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -21043,7 +21043,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskEditControl/__snapshots__/TaskEditControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskEditControl/__snapshots__/TaskEditControl.test.js.snap
@@ -44,7 +44,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -516,7 +516,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -856,7 +856,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFalsePositiveControl/__snapshots__/TaskFalsePositiveControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFalsePositiveControl/__snapshots__/TaskFalsePositiveControl.test.js.snap
@@ -46,7 +46,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFixedControl/__snapshots__/TaskFixedControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFixedControl/__snapshots__/TaskFixedControl.test.js.snap
@@ -45,7 +45,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskSkipControl/__snapshots__/TaskSkipControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskSkipControl/__snapshots__/TaskSkipControl.test.js.snap
@@ -46,7 +46,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskTooHardControl/__snapshots__/TaskTooHardControl.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskTooHardControl/__snapshots__/TaskTooHardControl.test.js.snap
@@ -45,7 +45,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/__snapshots__/ActiveTaskControls.test.js.snap
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/__snapshots__/ActiveTaskControls.test.js.snap
@@ -49,7 +49,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -254,7 +254,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -433,7 +433,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -609,7 +609,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -777,7 +777,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -942,7 +942,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -1106,7 +1106,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -1270,7 +1270,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -1434,7 +1434,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -1607,7 +1607,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -1779,7 +1779,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -1952,7 +1952,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -2116,7 +2116,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -2280,7 +2280,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -2444,7 +2444,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -2604,7 +2604,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -2765,7 +2765,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -2927,7 +2927,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -3089,7 +3089,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -3251,7 +3251,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -3427,7 +3427,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -3603,7 +3603,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -3771,7 +3771,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -3936,7 +3936,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -4100,7 +4100,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -4264,7 +4264,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -4428,7 +4428,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -4601,7 +4601,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -4773,7 +4773,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -4946,7 +4946,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -5110,7 +5110,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -5274,7 +5274,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -5438,7 +5438,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -5598,7 +5598,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -5759,7 +5759,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -5921,7 +5921,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -6083,7 +6083,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -6245,7 +6245,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -6427,7 +6427,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -6606,7 +6606,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -6773,7 +6773,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -6939,7 +6939,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -7105,7 +7105,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -7270,7 +7270,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -7434,7 +7434,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -7598,7 +7598,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -7762,7 +7762,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -7935,7 +7935,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -8100,7 +8100,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -8264,7 +8264,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -8435,7 +8435,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -8599,7 +8599,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -8763,7 +8763,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -8927,7 +8927,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -9087,7 +9087,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -9248,7 +9248,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -9410,7 +9410,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -9572,7 +9572,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -9734,7 +9734,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -9910,7 +9910,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -10077,7 +10077,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -10243,7 +10243,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -10409,7 +10409,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -10574,7 +10574,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -10738,7 +10738,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -10902,7 +10902,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -11066,7 +11066,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -11239,7 +11239,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -11404,7 +11404,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -11568,7 +11568,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -11739,7 +11739,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -11903,7 +11903,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -12067,7 +12067,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -12231,7 +12231,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -12391,7 +12391,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -12552,7 +12552,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -12714,7 +12714,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -12876,7 +12876,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -13038,7 +13038,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -13225,7 +13225,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -13409,7 +13409,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -13593,7 +13593,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -13763,7 +13763,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -13933,7 +13933,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -14102,7 +14102,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -14271,7 +14271,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -14440,7 +14440,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -14616,7 +14616,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -14794,7 +14794,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -14969,7 +14969,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -15138,7 +15138,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -15307,7 +15307,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -15476,7 +15476,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -15639,7 +15639,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -15803,7 +15803,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -15968,7 +15968,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -16133,7 +16133,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -16298,7 +16298,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -16479,7 +16479,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -16663,7 +16663,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -16833,7 +16833,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -17003,7 +17003,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -17172,7 +17172,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -17341,7 +17341,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -17510,7 +17510,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -17686,7 +17686,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -17864,7 +17864,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -18039,7 +18039,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -18208,7 +18208,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -18377,7 +18377,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -18546,7 +18546,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -18709,7 +18709,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -18873,7 +18873,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -19038,7 +19038,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -19203,7 +19203,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -19368,7 +19368,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -19550,7 +19550,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -19729,7 +19729,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -19905,7 +19905,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -20073,7 +20073,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -20238,7 +20238,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -20402,7 +20402,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -20566,7 +20566,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -20730,7 +20730,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -20903,7 +20903,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -21075,7 +21075,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -21248,7 +21248,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -21412,7 +21412,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -21576,7 +21576,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -21740,7 +21740,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -21900,7 +21900,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -22061,7 +22061,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -22223,7 +22223,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -22385,7 +22385,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -22547,7 +22547,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -22723,7 +22723,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -22899,7 +22899,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -23067,7 +23067,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -23232,7 +23232,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -23396,7 +23396,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -23560,7 +23560,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -23724,7 +23724,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -23897,7 +23897,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -24069,7 +24069,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -24242,7 +24242,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -24406,7 +24406,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -24570,7 +24570,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -24734,7 +24734,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -24894,7 +24894,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -25055,7 +25055,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -25217,7 +25217,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -25379,7 +25379,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -25541,7 +25541,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -25723,7 +25723,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -25903,7 +25903,7 @@ ShallowWrapper {
                                     },
                                   },
                                   "editLevel0": Object {
-                                    "key": "l",
+                                    "key": "v",
                                     "label": Object {
                                       "defaultMessage": "Edit in Level0",
                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -26077,7 +26077,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -26246,7 +26246,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -26421,7 +26421,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -26595,7 +26595,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -26764,7 +26764,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -26944,7 +26944,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -27123,7 +27123,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -27299,7 +27299,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -27467,7 +27467,7 @@ ShallowWrapper {
                                   },
                                 },
                                 "editLevel0": Object {
-                                  "key": "l",
+                                  "key": "v",
                                   "label": Object {
                                     "defaultMessage": "Edit in Level0",
                                     "id": "KeyMapping.openEditor.editLevel0",
@@ -27632,7 +27632,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -27796,7 +27796,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -27960,7 +27960,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -28124,7 +28124,7 @@ ShallowWrapper {
                                             },
                                           },
                                           "editLevel0": Object {
-                                            "key": "l",
+                                            "key": "v",
                                             "label": Object {
                                               "defaultMessage": "Edit in Level0",
                                               "id": "KeyMapping.openEditor.editLevel0",
@@ -28297,7 +28297,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -28469,7 +28469,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -28642,7 +28642,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -28806,7 +28806,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -28970,7 +28970,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -29134,7 +29134,7 @@ ShallowWrapper {
                                               },
                                             },
                                             "editLevel0": Object {
-                                              "key": "l",
+                                              "key": "v",
                                               "label": Object {
                                                 "defaultMessage": "Edit in Level0",
                                                 "id": "KeyMapping.openEditor.editLevel0",
@@ -29294,7 +29294,7 @@ ShallowWrapper {
                 },
               },
               "editLevel0": Object {
-                "key": "l",
+                "key": "v",
                 "label": Object {
                   "defaultMessage": "Edit in Level0",
                   "id": "KeyMapping.openEditor.editLevel0",
@@ -29455,7 +29455,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -29617,7 +29617,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -29779,7 +29779,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -29941,7 +29941,7 @@ ShallowWrapper {
                     },
                   },
                   "editLevel0": Object {
-                    "key": "l",
+                    "key": "v",
                     "label": Object {
                       "defaultMessage": "Edit in Level0",
                       "id": "KeyMapping.openEditor.editLevel0",
@@ -30117,7 +30117,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -30293,7 +30293,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -30461,7 +30461,7 @@ ShallowWrapper {
                                         },
                                       },
                                       "editLevel0": Object {
-                                        "key": "l",
+                                        "key": "v",
                                         "label": Object {
                                           "defaultMessage": "Edit in Level0",
                                           "id": "KeyMapping.openEditor.editLevel0",
@@ -30626,7 +30626,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -30790,7 +30790,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -30954,7 +30954,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -31118,7 +31118,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -31291,7 +31291,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -31463,7 +31463,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -31636,7 +31636,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -31800,7 +31800,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -31964,7 +31964,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -32128,7 +32128,7 @@ ShallowWrapper {
                                                     },
                                                   },
                                                   "editLevel0": Object {
-                                                    "key": "l",
+                                                    "key": "v",
                                                     "label": Object {
                                                       "defaultMessage": "Edit in Level0",
                                                       "id": "KeyMapping.openEditor.editLevel0",
@@ -32288,7 +32288,7 @@ ShallowWrapper {
                   },
                 },
                 "editLevel0": Object {
-                  "key": "l",
+                  "key": "v",
                   "label": Object {
                     "defaultMessage": "Edit in Level0",
                     "id": "KeyMapping.openEditor.editLevel0",
@@ -32449,7 +32449,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -32611,7 +32611,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -32773,7 +32773,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",
@@ -32935,7 +32935,7 @@ ShallowWrapper {
                       },
                     },
                     "editLevel0": Object {
-                      "key": "l",
+                      "key": "v",
                       "label": Object {
                         "defaultMessage": "Edit in Level0",
                         "id": "KeyMapping.openEditor.editLevel0",

--- a/src/services/KeyboardShortcuts/KeyMappings.js
+++ b/src/services/KeyboardShortcuts/KeyMappings.js
@@ -9,7 +9,7 @@ import messages from './Messages'
  * (e.g. 'ESC' instead of 'Escape') is desired, in which case it too should
  * point to an internationalized message.
  *
- * > Note: `key` values should match keypress event
+ * > Note: `key` values should correspond to keyboard event
  * > [key values](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)
  */
 export default {
@@ -18,7 +18,7 @@ export default {
     editJosm: {key: 'r', label: messages.editJosm},
     editJosmLayer: {key: 't', label: messages.editJosmLayer},
     editJosmFeatures: {key: 'y', label: messages.editJosmFeatures},
-    editLevel0: {key: 'l', label: messages.editLevel0},
+    editLevel0: {key: 'v', label: messages.editLevel0},
   },
   taskEditing: {
     cancel: {key: 'Escape', label: messages.cancel, keyLabel: messages.escapeLabel},


### PR DESCRIPTION
* Change keyboard shortcut for opening Level0 editor from `l` to `v` to
avoid a potential conflict with the next-task keyboard shortcut

* Change FitBoundsControl to use keydown instead of keypress event