### PR TITLE
Load comments when user navigates directly to task

### DIFF
--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
@@ -8,6 +8,8 @@ import _isString from 'lodash/isString'
 import _isPlainObject from 'lodash/isPlainObject'
 import { taskDenormalizationSchema,
          fetchTask,
+         fetchTaskComments,
+         fetchTaskPlace,
          loadRandomTaskFromChallenge,
          loadRandomTaskFromVirtualChallenge,
          addTaskComment,
@@ -129,6 +131,10 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
             }
           })
         }
+
+        // Fetch the task comments and location data, but don't wait for them
+        dispatch(fetchTaskComments(taskId))
+        dispatch(fetchTaskPlace(loadedTask))
 
         return normalizedResults
       })

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -329,7 +329,7 @@ const updateTaskStatus = function(dispatch, taskId, newStatus) {
  * > Note that if the results contain multiple tasks, only the
  * > place description of the first result is retrieved.
  */
-const fetchTaskPlace = function(task) {
+export const fetchTaskPlace = function(task) {
   return function(dispatch) {
     return dispatch(
       fetchPlace(_get(task, 'location.coordinates[1]', 0),


### PR DESCRIPTION
Ensure task comments and location data get loaded when a user navigates
directly to a task from an external link