### PR TITLE
Prevent wrapping of challenge results header

### DIFF
--- a/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.scss
+++ b/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.scss
@@ -17,6 +17,7 @@
       font-size: $size-3;
       margin-bottom: 0;
       margin-right: 1em;
+      white-space: nowrap;
     }
 
     &__result-controls {


### PR DESCRIPTION
Don't let challenge results header wrap:

<img width="497" alt="wrapped_header" src="https://user-images.githubusercontent.com/445970/50999700-c5c81f00-14df-11e9-93ad-e779fac8689a.png">
