### PR TITLE
Change nav Create link label to Create & Manage

### DIFF
--- a/src/components/Navbar/Messages.js
+++ b/src/components/Navbar/Messages.js
@@ -16,7 +16,7 @@ export default defineMessages({
 
   adminCreate: {
     id: 'Navbar.links.admin',
-    defaultMessage: "Create",
+    defaultMessage: "Create & Manage",
   },
 
   help: {

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -305,7 +305,7 @@
   "Navbar.links.signout": "Sign out",
   "Navbar.links.challengeResults": "Challenges",
   "Navbar.links.leaderboard": "Leaderboard",
-  "Navbar.links.admin": "Create",
+  "Navbar.links.admin": "Create & Manage",
   "Navbar.links.help": "Help",
   "Navbar.links.mobile.userProfile": "User Profile",
   "Navbar.mobile.links.signout": "Sign out",


### PR DESCRIPTION
Change top-nav `Create` link to `Create & Manage` to be a bit clearer
that it should also be used to manage existing challenges