### PR TITLE
Fetch project when browsing challenge

### DIFF
--- a/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.js
+++ b/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.js
@@ -1,13 +1,16 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { denormalize } from 'normalizr'
 import _get from 'lodash/get'
 import _isObject from 'lodash/isObject'
 import _isFinite from 'lodash/isFinite'
 import _debounce from 'lodash/debounce'
 import _omit from 'lodash/omit'
-import { fetchChallenge }
+import { fetchChallenge, challengeDenormalizationSchema }
        from '../../../services/Challenge/Challenge'
+import { fetchProject }
+       from '../../../services/Project/Project'
 import { addError } from '../../../services/Error/Error'
 import AppErrors from '../../../services/Error/AppErrors'
 
@@ -76,8 +79,11 @@ export const WithBrowsedChallenge = function(WrappedComponent) {
         if (_get(this.state, 'browsedChallenge.id') !== challengeId ||
             this.state.isVirtual !== isVirtual ||
             _isFinite(this.state.loadingBrowsedChallenge)) {
-          let challenge = isVirtual ? props.virtualChallenge :
-                            _get(props.entities, `challenges.${challengeId}`)
+          let challenge = isVirtual ?
+                          props.virtualChallenge :
+                          denormalize(_get(this.props.entities, `challenges.${challengeId}`),
+                                      challengeDenormalizationSchema(),
+                                      this.props.entities)
 
           if (_isObject(challenge)) {
             // If our challenge data is stale, refresh it.
@@ -197,6 +203,13 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
                    `entities.challenges.${normalizedResults.result}.deleted`)) {
             dispatch(addError(AppErrors.challenge.doesNotExist))
             ownProps.history.push('/browse/challenges')
+          }
+          else {
+            const projectId =
+              _get(normalizedResults, `entities.challenges.${normalizedResults.result}.parent`)
+            if (_isFinite(projectId)) {
+              dispatch(fetchProject(projectId))
+            }
           }
         })
       },


### PR DESCRIPTION
* When fetching a challenge as a result of browsing, also fetch the
parent project so that it'll be available for denormalization

* Denormalize browsed challenge so that parent project is available for
permission checks, used for example to determine whether to display a
Manage option