### PR TITLE
Reverse lat lon label

### DIFF
--- a/src/components/TaskPane/TaskLatLon/TaskLatLon.js
+++ b/src/components/TaskPane/TaskLatLon/TaskLatLon.js
@@ -24,11 +24,11 @@ export default class TaskLatLon extends Component {
 
     return (
       <div className={classNames('task-lat-lon', this.props.className)}>
-        <span className='task-lat-lon__label'>Lat/Lon:</span>
-        <span className='task-lat-lon__latitude'>
-          {this.rounded(centerpoint.lat)}
-        </span>, <span className='task-lat-lon__longitude'>
+        <span className='task-lat-lon__label'>Lon/Lat:</span>
+        <span className='task-lat-lon__longitude'>
           {this.rounded(centerpoint.lng)}
+        </span>, <span className='task-lat-lon__latitude'>
+          {this.rounded(centerpoint.lat)}
         </span>
 
         <CopyToClipboard text={`${this.rounded(centerpoint.lat)}, ${this.rounded(centerpoint.lng)}`}>


### PR DESCRIPTION
Map moving by centerpoint (m/ in search box) currently uses lon,lat -- so reverse lat/lon label on the TaskPane to make copy/paste work as expected.