### PR TITLE
Fix admin challenge leaderboard showing global results

### DIFF
--- a/src/components/AdminPane/AdminPane.js
+++ b/src/components/AdminPane/AdminPane.js
@@ -32,7 +32,8 @@ const MetricsSummary = WithChallenges(MetricsOverview)
  */
 export class AdminPane extends Component {
   componentDidUpdate(prevProps) {
-    if (this.props.location !== prevProps.location) {
+    if (this.props.location.pathname !== prevProps.location.pathname &&
+        this.props.location.search !== prevProps.location.search) {
       window.scrollTo(0, 0)
     }
   }

--- a/src/components/AdminPane/Manage/Widgets/LeaderboardWidget/LeaderboardWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/LeaderboardWidget/LeaderboardWidget.js
@@ -3,7 +3,7 @@ import { FormattedMessage } from 'react-intl'
 import { WidgetDataTarget, registerWidgetType }
        from '../../../../../services/Widget/Widget'
 import WithLeaderboard
-from '../../../../../components/HOCs/WithLeaderboard/WithLeaderboard'
+       from '../../../../../components/HOCs/WithLeaderboard/WithLeaderboard'
 import ChallengeOwnerLeaderboard
        from '../../ChallengeOwnerLeaderboard/ChallengeOwnerLeaderboard'
 import PastDurationSelector
@@ -35,6 +35,10 @@ export default class LeaderboardWidget extends Component {
     }
   }
 
+  componentDidMount() {
+    this.props.setMonthsPast(this.props.widgetConfiguration.monthsPast, true)
+  }
+
   render() {
     const monthsPast = this.props.widgetConfiguration.monthsPast || 1
 
@@ -58,4 +62,5 @@ export default class LeaderboardWidget extends Component {
   }
 }
 
-registerWidgetType(WithLeaderboard(LeaderboardWidget, INITIAL_MONTHS_PAST), descriptor)
+registerWidgetType(WithLeaderboard(LeaderboardWidget, INITIAL_MONTHS_PAST,
+                                   {ignoreUser: true, filterChallenges: true}), descriptor)

--- a/src/components/TaskPane/TaskPane.js
+++ b/src/components/TaskPane/TaskPane.js
@@ -82,7 +82,8 @@ export class TaskPane extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.location !== prevProps.location) {
+    if (this.props.location.pathname !== prevProps.location.pathname &&
+        this.props.location.search !== prevProps.location.search) {
       window.scrollTo(0, 0)
     }
   }


### PR DESCRIPTION
Fix Admin challenge leaderboard widget:
- Not showing challenge specific results (only global)
- Scrolling to top of screen when changing months selector
- Reload of page would show same months selected but would not match results 