### PR TITLE
Seed redux with preferred challenges at startup

### DIFF
--- a/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.js
+++ b/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.js
@@ -10,7 +10,6 @@ import WithSortedChallenges from '../../HOCs/WithSortedChallenges/WithSortedChal
 import WithPagedChallenges from '../../HOCs/WithPagedChallenges/WithPagedChallenges'
 import ChallengeResultItem from '../ChallengeResultItem/ChallengeResultItem'
 import PageResultsButton from './PageResultsButton'
-import BusySpinner from '../../BusySpinner/BusySpinner'
 import StartVirtualChallenge from './StartVirtualChallenge'
 import messages from './Messages'
 import './ChallengeResultList.scss'
@@ -54,14 +53,13 @@ export class ChallengeResultList extends Component {
 
     let results = null
     if (challengeResults.length === 0) {
-      results = (
-        <div className="mr-text-white mr-text-lg mr-pt-4">
-          {isFetching ?
-           <BusySpinner /> :
-           <span><FormattedMessage {...messages.noResults} /></span>
-          }
-        </div>
-      )
+      if (!isFetching) {
+        results = (
+          <div className="mr-text-white mr-text-lg mr-pt-4">
+            <span><FormattedMessage {...messages.noResults} /></span>
+          </div>
+        )
+      }
     }
     else {
       results = _map(challengeResults, challenge => (

--- a/src/components/ChallengeProgress/ChallengeProgress.js
+++ b/src/components/ChallengeProgress/ChallengeProgress.js
@@ -111,10 +111,17 @@ export class ChallengeProgress extends Component {
         }
         {taskActions.total > 0 && taskActions.available !== 0 &&
           <div className="challenge-task-progress__tasks-remaining">
-            <FormattedMessage {...messages.tasksRemaining} values={{taskCount: taskActions.available}}/>
-            {// eslint-disable-next-line react/style-prop-object
-            } (<FormattedNumber style="percent" value={taskActions.available/taskActions.total} />)  
-            <FormattedMessage {...messages.outOfTotal} values={{totalCount: taskActions.total}}/>
+            <FormattedMessage
+              {...messages.tasksRemaining}
+              values={{taskCount: taskActions.available}}
+            />
+            {/* eslint-disable-next-line react/style-prop-object */}
+            (<FormattedNumber style="percent"
+                value={taskActions.available/taskActions.total}
+            />) <FormattedMessage
+              {...messages.outOfTotal}
+              values={{totalCount: taskActions.total}}
+            />
           </div>
         }
       </div>

--- a/src/components/HOCs/WithSearch/WithChallengeSearch.js
+++ b/src/components/HOCs/WithSearch/WithChallengeSearch.js
@@ -1,39 +1,14 @@
-import _get from 'lodash/get'
-import _isUndefined from 'lodash/isUndefined'
+import { performChallengeSearch }
+       from '../../../services/Challenge/Challenge'
 import WithSearch from '../WithSearch/WithSearch'
-import { extendedFind } from '../../../services/Challenge/Challenge'
-import { ChallengeStatus } from '../../../services/Challenge/ChallengeStatus/ChallengeStatus'
 import WithSearchRoute from '../WithSearchRoute/WithSearchRoute'
 
 const SEARCH_GROUP = 'challenges'
 
-/**
- * Adapts the query object passed from WithSearch to the object
- * expected by extendedFind functions
- */
-const buildCriteria = query => {
-  const sortCriteria = _get(query, "sort", {})
-  const filters = _get(query, "filters", {})
-  const queryString = _get(query, "query")
-  const page = _get(query, "page.currentPage")
-  let bounds = null
-
-  if (filters && !_isUndefined(filters.location)) {
-    bounds = _get(query, "mapBounds.bounds")
-  }
-
-  const challengeStatus = [ChallengeStatus.ready,
-                           ChallengeStatus.partiallyLoaded,
-                           ChallengeStatus.none,
-                           ChallengeStatus.empty]
-
-  return {searchQuery: queryString, filters, sortCriteria, bounds, page, challengeStatus}
-}
-
-const performChallengeSearch = (query, limit) => {
-  return extendedFind(buildCriteria(query), limit)
-}
-
-export default (WrappedComponent) => {
-  return WithSearch(WithSearchRoute(WrappedComponent, SEARCH_GROUP), SEARCH_GROUP, performChallengeSearch)
+export default WrappedComponent => {
+  return WithSearch(
+    WithSearchRoute(WrappedComponent, SEARCH_GROUP),
+    SEARCH_GROUP,
+    performChallengeSearch
+  )
 }

--- a/src/components/HOCs/WithSortedChallenges/WithSortedChallenges.js
+++ b/src/components/HOCs/WithSortedChallenges/WithSortedChallenges.js
@@ -31,7 +31,7 @@ export const sortChallenges = function(props, challengesProp='challenges') {
       c => _isFinite(c.popularity) ? c.popularity : 0))
   }
   else {
-    // default "smart" sort. Prioritizes featured and user-saved challenges,
+    // default sort. Prioritizes featured and user-saved challenges,
     // followed by popular challenges
     const savedChallenges = _get(props, 'user.savedChallenges', [])
 

--- a/src/components/LoadMoreButton/LoadMoreButton.js
+++ b/src/components/LoadMoreButton/LoadMoreButton.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
+import BusySpinner from '../BusySpinner/BusySpinner'
 import './LoadMoreButton.scss'
 
 
@@ -12,19 +13,21 @@ import './LoadMoreButton.scss'
  */
 export default class LoadMoreButton extends Component {
   render() {
-    if (!this.props.hasMoreResults && !this.props.isLoading) {
+    if (this.props.isLoading) {
+      return <BusySpinner />
+    }
+    else if (!this.props.hasMoreResults) {
       return null
     }
 
     return (
-      <button className={classNames("mr-button",
-                                    this.props.className,
-                                    {"is-loading": this.props.isLoading,
-                                     "no-focus": !this.props.isLoading})}
-              onClick={(e) => {
-                e.preventDefault()
-                this.props.loadMore()
-              }}>
+      <button
+        className={classNames("mr-button", this.props.className)}
+        onClick={e => {
+          e.preventDefault()
+          this.props.loadMore()
+        }}
+      >
         {this.props.children}
       </button>
     )

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -27,10 +27,12 @@ import { ensureUserLoggedIn } from '../User/User'
 import { toLatLngBounds } from '../MapBounds/MapBounds'
 import { addError, addServerError } from '../Error/Error'
 import AppErrors from '../Error/AppErrors'
-import { RECEIVE_CHALLENGES,
-         REMOVE_CHALLENGE } from './ChallengeActions'
+import { RECEIVE_CHALLENGES, REMOVE_CHALLENGE }
+       from './ChallengeActions'
+import { ChallengeStatus } from './ChallengeStatus/ChallengeStatus'
 import { zeroTaskActions } from '../Task/TaskAction/TaskAction'
-import { parseQueryString, RESULTS_PER_PAGE } from '../Search/Search'
+import { parseQueryString, RESULTS_PER_PAGE, SortOptions }
+       from '../Search/Search'
 import startOfDay from 'date-fns/start_of_day'
 
 // normalizr schema
@@ -186,6 +188,36 @@ export const fetchProjectChallengeListing = function(projectIds, onlyEnabled=fal
 }
 
 /**
+ * Execute a challenge search, using extendedFind, from the given challenges
+ * search object
+ */
+export const performChallengeSearch = function(searchObject, limit=RESULTS_PER_PAGE) {
+  const sortCriteria = _get(searchObject, "sort", {})
+  const filters = _get(searchObject, "filters", {})
+  const queryString = _get(searchObject, "query")
+  const page = _get(searchObject, "page.currentPage")
+  let bounds = null
+
+  if (filters && !_isUndefined(filters.location)) {
+    bounds = _get(searchObject, "mapBounds.bounds")
+  }
+
+  const challengeStatus = [ChallengeStatus.ready,
+                           ChallengeStatus.partiallyLoaded,
+                           ChallengeStatus.none,
+                           ChallengeStatus.empty]
+
+  return extendedFind({
+    searchQuery: queryString,
+    filters,
+    sortCriteria,
+    bounds,
+    page,
+    challengeStatus
+  }, limit)
+}
+
+/**
  * Fetches challenges that contain any of the given criteria
  * (including: keywords/tags, column to sort results by, filters),
  * up to the given limit.
@@ -203,7 +235,7 @@ export const extendedFind = function(criteria, limit=RESULTS_PER_PAGE) {
                           true : criteria.onlyEnabled
 
   const bounds = criteria.bounds
-  const sortBy = _get(criteria, 'sortCriteria.sortBy')
+  const sortBy = _get(criteria, 'sortCriteria.sortBy', SortOptions.popular)
   const direction = (_get(criteria, 'sortCriteria.direction') || 'DESC').toUpperCase()
   const sort = sortBy ? `${sortBy}` : null
   const page = _isFinite(criteria.page) ? criteria.page : 0

--- a/src/services/Search/Search.js
+++ b/src/services/Search/Search.js
@@ -12,6 +12,7 @@ import { fromLatLngBounds } from '../MapBounds/MapBounds'
 
 // redux actions
 export const SET_SEARCH = 'SET_SEARCH'
+export const SET_COMPLETE_SEARCH = 'SET_COMPLETE_SEARCH'
 export const CLEAR_SEARCH = 'CLEAR_SEARCH'
 export const FETCHING_RESULTS = 'FETCHING_RESULTS'
 export const RECEIVED_RESULTS = 'RECEIVED_RESULTS'
@@ -98,6 +99,14 @@ export const parseQueryString = function(rawQueryText) {
 }
 
 // redux action creators
+export const setCompleteSearch = function(searchName, searchObject) {
+  return {
+    type: SET_COMPLETE_SEARCH,
+    searchName,
+    searchObject,
+  }
+}
+
 export const setSearch = function(searchName, query) {
   return {
     type: SET_SEARCH,
@@ -312,6 +321,10 @@ export const currentSearch = function(state={}, action) {
   let mergedState = null
 
   switch(action.type) {
+    case SET_COMPLETE_SEARCH:
+      mergedState = _cloneDeep(state)
+      _set(mergedState, action.searchName, action.searchObject)
+      return mergedState
     case SET_SEARCH:
       mergedState = _cloneDeep(state)
       _set(mergedState, `${action.searchName}.query`, action.query)


### PR DESCRIPTION
* Use the new preferred challenges API to seed redux with a set of new, popular,
and featured challenges

* Setup a default challenge search at app startup so that users can
easily 'load more' results if desired

* Change the challenge search to default to sorting by popular if no
sort option is specified

* Change the LoadMoreButton to display a busy spinner if results are
still loading

* Add missing space to ChallengeProgress task count