### PR TITLE
Various minor visual fixes

### DIFF
--- a/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.js
+++ b/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.js
@@ -73,7 +73,7 @@ export class ChallengeResultList extends Component {
     }
 
     return (
-      <div className="lg:mr-w-sm lg:mr-pr-6 mr-mb-6 lg:mr-mb-0 lg:mr-rounded lg:mr-h-content lg:mr-overflow-auto">
+      <div className="lg:mr-w-sm lg:mr-pr-6 lg:mr-mr-2 mr-mb-6 lg:mr-mb-0 lg:mr-rounded lg:mr-h-content lg:mr-overflow-auto">
         {virtualChallengeOption}
         {results}
 

--- a/src/components/EnhancedMap/MapPane/MapPane.scss
+++ b/src/components/EnhancedMap/MapPane/MapPane.scss
@@ -7,6 +7,7 @@
 
   .leaflet-container {
     height: 100%;
+    border-radius: .25rem;
     .leaflet-pane {
       z-index: $layer-map;
 

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -61,7 +61,9 @@ export default class Navbar extends Component {
         <MediaQuery minWidth={screens.lg}>
           <LoggedInUser {...this.props}>
             <div className="mr-flex mr-items-center">
-              <PointsTicker user={this.props.user} className="mr-mr-8" />
+              <a href="/leaderboard">
+                <PointsTicker user={this.props.user} className="mr-mr-8" />
+              </a>
               <Dropdown
                 className="mr-dropdown--right"
                 dropdownButton={dropdown =>

--- a/src/components/TaskCommentInput/TaskCommentInput.js
+++ b/src/components/TaskCommentInput/TaskCommentInput.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import classNames from 'classnames'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import messages from  './Messages'
 import './TaskCommentInput.scss'
@@ -17,9 +18,9 @@ export class TaskCommentInput extends Component {
 
   render() {
     return (
-      <div className="mr-pr-4 mr-mt-2">
+      <div className="mr-mt-2">
         <textarea
-          className="mr-input mr-input--green-lighter-outline"
+          className={classNames("mr-input mr-input--green-lighter-outline", this.props.className)}
           rows="1"
           cols="1"
           placeholder={this.props.intl.formatMessage(messages.placeholder)}

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -91,7 +91,7 @@ export class ActiveTaskControls extends Component {
         <div className={this.props.className}>
           <TaskCommentInput
             {...this.props}
-            className="active-task-controls__task-comment"
+            className="mr-border-yellow-75"
             value={this.state.comment}
             commentChanged={this.setComment}
           />

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep1/TaskCompletionStep1.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep1/TaskCompletionStep1.js
@@ -4,7 +4,6 @@ import { TaskStatus } from '../../../../../services/Task/TaskStatus/TaskStatus'
 import UserEditorSelector
        from '../../../../UserEditorSelector/UserEditorSelector'
 import Dropdown from '../../../../Dropdown/Dropdown'
-import SvgSymbol from '../../../../SvgSymbol/SvgSymbol'
 import TaskEditControl from '../TaskEditControl/TaskEditControl'
 import TaskFalsePositiveControl from '../TaskFalsePositiveControl/TaskFalsePositiveControl'
 import TaskFixedControl from '../TaskFixedControl/TaskFixedControl'
@@ -70,14 +69,10 @@ export default class TaskCompletionStep1 extends Component {
 const MoreOptionsButton = function(props) {
   return (
     <button
-      className="mr-dropdown__button mr-button mr-w-full"
+      className="mr-dropdown__button mr-button mr-text-green-lighter mr-w-full"
       onClick={props.toggleDropdownVisible}
     >
-      <SvgSymbol
-        sym="navigation-more-icon"
-        viewBox="0 0 20 20"
-        className="mr-fill-green-lighter mr-w-4 mr-h-4"
-      />
+      Other&hellip;
     </button>
   )
 }

--- a/src/components/WidgetGrid/WidgetGrid.js
+++ b/src/components/WidgetGrid/WidgetGrid.js
@@ -48,6 +48,7 @@ export class WidgetGrid extends Component {
            <React.Fragment>
              {this.props.editNameControl}
              <WidgetPicker {...this.props} isRight onWidgetSelected={this.props.addWidget} />
+             {this.props.doneEditingControl}
            </React.Fragment>
           }
         </div>

--- a/src/components/WidgetGrid/WidgetGrid.scss
+++ b/src/components/WidgetGrid/WidgetGrid.scss
@@ -6,6 +6,7 @@
     justify-content: flex-end;
     align-items: center;
     padding-top: 10px;
+    margin-right: 2rem;
 
     .dashboard__filter {
       margin-right: 15px;

--- a/src/components/WidgetPicker/WidgetPicker.js
+++ b/src/components/WidgetPicker/WidgetPicker.js
@@ -40,7 +40,7 @@ export class WidgetPicker extends Component {
     return (
       <Dropdown
         {...this.props}
-        className="mr-dropdown--right mr-widget-picker mr-button mr-mr-8"
+        className="mr-dropdown mr-widget-picker mr-button mr-mr-4"
         dropdownButton={dropdown =>
           <PickerButton toggleDropdownVisible={dropdown.toggleDropdownVisible} />
         }

--- a/src/components/WidgetWorkspace/WidgetWorkspace.js
+++ b/src/components/WidgetWorkspace/WidgetWorkspace.js
@@ -86,18 +86,7 @@ export class WidgetWorkspace extends Component {
   }
 
   headerActions = () => {
-    if (this.isEditing()) {
-      return (
-        <ul className="mr-list-buttons mr-mb-3">
-          <li>
-            <Button className="mr-button--white" onClick={this.doneEditingLayout}>
-              <FormattedMessage {...messages.saveConfigurationLabel} />
-            </Button>
-          </li>
-        </ul>
-      )
-    }
-    else {
+    if (!this.isEditing()) {
       return (
         <React.Fragment>
           <Button onClick={() => this.startEditingLayout()}>
@@ -146,13 +135,13 @@ export class WidgetWorkspace extends Component {
     let editNameBox = null
     if (this.isEditing(this.props.currentConfiguration)) {
       editNameBox = (
-        <div className="mr-flex mr-justify-start mr-items-center">
+        <React.Fragment>
           <label className="mr-text-greener mr-mr-2">Layout Name:</label>
           <QuickTextBox suppressControls
                         text={this.state.newConfigurationName}
                         setText={this.setNewName}
           />
-        </div>
+        </React.Fragment>
       )
     }
 
@@ -168,6 +157,11 @@ export class WidgetWorkspace extends Component {
         <WidgetGrid {...this.props}
                     isEditing={this.isEditing()}
                     editNameControl={editNameBox}
+                    doneEditingControl={
+                      <Button className="mr-button--white" onClick={this.doneEditingLayout}>
+                        <FormattedMessage {...messages.saveConfigurationLabel} />
+                      </Button>
+                    }
                     workspace={this.props.currentConfiguration} />
       </div>
     )

--- a/src/pages/Dashboard/Dashboard.js
+++ b/src/pages/Dashboard/Dashboard.js
@@ -41,7 +41,7 @@ class Dashboard extends Component {
     return (
       <WidgetWorkspace
         {...this.props}
-        className="mr-bg-gradient-r-green-dark-blue mr-text-white mr-px-6 mr-py-8 md:mr-py-12 lg:mr-py-20"
+        className="mr-bg-gradient-r-green-dark-blue mr-text-white mr-px-6 mr-py-8"
         workspaceTitle={
           <h1 className="mr-h2"><FormattedMessage {...messages.header} /></h1>
         }

--- a/src/pages/Home/FeaturedChallenges.js
+++ b/src/pages/Home/FeaturedChallenges.js
@@ -35,7 +35,7 @@ export class FeaturedChallenges extends Component {
       <CardChallenge
         key={challenge.id}
         {...this.props}
-        className="mr-mb-4 md:mr-mb-0"
+        className="mr-card-challenge--featured mr-mb-4"
         challenge={challenge}
         isExpanded
         permanentlyExpanded

--- a/src/pages/Home/Hero.js
+++ b/src/pages/Home/Hero.js
@@ -4,12 +4,12 @@ import { Link } from 'react-router-dom'
 export default class Hero extends Component {
   render() {
     return (
-      <div className="md:mr-h-hero mr-bg-black mr-text-white mr-bg-cover mr-bg-center mr-bg-hero mr-flex mr-items-center mr-pb-10 mr-px-4 mr-min-h-xs">
+      <div className="md:mr-h-hero mr-bg-black mr-text-white mr-bg-cover mr-bg-center mr-bg-hero mr-flex mr-items-center mr-py-10 mr-px-4">
         <div className="mr-flex-grow mr-max-w-lg mr-mx-auto mr-text-center">
-          <h1 className="mr-text-3xl md:mr-text-6xl mr-leading-tight mr-mb-4">
+          <h1 className="mr-text-3xl mr-font-medium md:mr-text-5xl lg:mr-text-6xl lg:mr--mt-40 mr-leading-tight">
             Be an instant contributor to the world’s maps
           </h1>
-          <Link to="/browse/challenges" className="mr-button md:mr-mb-12">
+          <Link to="/browse/challenges" className="mr-button mr-mt-8">
             Get Started
           </Link>
         </div>

--- a/src/tailwind.js
+++ b/src/tailwind.js
@@ -65,6 +65,7 @@ let colors = {
   'blue-dark': '#182841',
   'blue-dark-75': 'rgba(24, 40, 65, .75)',
   yellow: '#FFFD86',
+  'yellow-75': 'rgba(255, 253, 134, .75)',
   turquoise: '#17FFF3',
   pink: '#E87CE0',
   'pink-light': '#FFB2F0',


### PR DESCRIPTION
* link points ticker to leaderboard
* reduce whitespace above dashboard
* put widget layout editing controls on same line
* round corners on challenge map
* adjust task-completion comment input color and margin
* adjust label on task-completion other-statuses button
* add whitespace between challenge results scrollbar and map
* adjust home page hero styling
* adjust home page featured challenges color