### PR TITLE
Don't offer disallowed statuses in task completion

### DIFF
--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -1,10 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { injectIntl } from 'react-intl'
+import { FormattedMessage, injectIntl } from 'react-intl'
 import _get from 'lodash/get'
-import { allowedStatusProgressions,
-         isFinalStatus }
+import { allowedStatusProgressions, isCompletionStatus, messagesByStatus }
        from '../../../../services/Task/TaskStatus/TaskStatus'
 import TaskCommentInput from '../../../TaskCommentInput/TaskCommentInput'
 import SignInButton from '../../../SignInButton/SignInButton'
@@ -15,6 +14,7 @@ import BusySpinner from '../../../BusySpinner/BusySpinner'
 import TaskCompletionStep1 from './TaskCompletionStep1/TaskCompletionStep1'
 import TaskCompletionStep2 from './TaskCompletionStep2/TaskCompletionStep2'
 import TaskNextControl from './TaskNextControl/TaskNextControl'
+import messages from './Messages'
 import './ActiveTaskControls.scss'
 
 /**
@@ -86,6 +86,7 @@ export class ActiveTaskControls extends Component {
     else {
       const allowedProgressions =
         allowedStatusProgressions(this.props.task.status)
+      const isComplete = isCompletionStatus(this.props.task.status)
 
       return (
         <div className={this.props.className}>
@@ -96,7 +97,7 @@ export class ActiveTaskControls extends Component {
             commentChanged={this.setComment}
           />
 
-          {!isEditingTask &&
+          {!isEditingTask && !isComplete &&
            <TaskCompletionStep1
              {...this.props}
              allowedProgressions={allowedProgressions}
@@ -106,8 +107,17 @@ export class ActiveTaskControls extends Component {
            />
           }
 
-          {(!isEditingTask && isFinalStatus(this.props.task.status)) &&
-           <TaskNextControl {...this.props} nextTask={this.next} />
+          {(!isEditingTask && isComplete) &&
+           <div className="mr-text-white mr-text-md mr-mt-4">
+             <div className="mr-mb-2">
+               <FormattedMessage
+                 {...messages.markedAs}
+               /> <FormattedMessage
+                 {...messagesByStatus[this.props.task.status]}
+               />
+             </div>
+             <TaskNextControl {...this.props} nextTask={this.next} />
+           </div>
           }
 
           {isEditingTask &&

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/Messages.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/Messages.js
@@ -1,0 +1,11 @@
+import { defineMessages } from 'react-intl'
+
+/**
+ * Internationalized messages for use with ActiveTaskControls
+ */
+export default defineMessages({
+  markedAs: {
+    id: 'Task.markedAs.label',
+    defaultMessage: "Task marked as",
+  },
+})

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep1/TaskCompletionStep1.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep1/TaskCompletionStep1.js
@@ -51,15 +51,19 @@ export default class TaskCompletionStep1 extends Component {
            <TaskSkipControl {...this.props} />
           }
 
-          <Dropdown
-            className="mr-dropdown--fixed mr-w-full"
-            dropdownButton={dropdown =>
-              <MoreOptionsButton toggleDropdownVisible={dropdown.toggleDropdownVisible} />
-            }
-            dropdownContent={dropdown =>
-              <ListMoreOptionsItems {...this.props} />
-            }
-          />
+          {(this.props.allowedProgressions.has(TaskStatus.fixed) ||
+            this.props.allowedProgressions.has(TaskStatus.tooHard) ||
+            this.props.allowedProgressions.has(TaskStatus.alreadyFixed)) &&
+           <Dropdown
+             className="mr-dropdown--fixed mr-w-full"
+             dropdownButton={dropdown =>
+               <MoreOptionsButton toggleDropdownVisible={dropdown.toggleDropdownVisible} />
+             }
+             dropdownContent={dropdown =>
+               <ListMoreOptionsItems {...this.props} />
+             }
+           />
+          }
         </div>
       </div>
     )
@@ -80,15 +84,21 @@ const MoreOptionsButton = function(props) {
 const ListMoreOptionsItems = function(props) {
   return (
     <ol className="mr-list-dropdown">
-      <li>
-        <TaskFixedControl {...props} asLink />
-      </li>
-      <li>
-        <TaskTooHardControl {...props} asLink />
-      </li>
-      <li>
-        <TaskAlreadyFixedControl {...props} asLink />
-      </li>
+      {props.allowedProgressions.has(TaskStatus.fixed) &&
+       <li>
+         <TaskFixedControl {...props} asLink />
+       </li>
+      }
+      {props.allowedProgressions.has(TaskStatus.tooHard) &&
+       <li>
+         <TaskTooHardControl {...props} asLink />
+       </li>
+      }
+      {props.allowedProgressions.has(TaskStatus.alreadyFixed) &&
+       <li>
+         <TaskAlreadyFixedControl {...props} asLink />
+       </li>
+      }
     </ol>
   )
 }

--- a/src/components/WidgetGrid/WidgetGrid.js
+++ b/src/components/WidgetGrid/WidgetGrid.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import _get from 'lodash/get'
 import _map from 'lodash/map'
-import _compact from 'lodash/compact'
 import ReactGridLayout, { WidthProvider } from 'react-grid-layout'
 import { widgetComponent } from '../../services/Widget/Widget'
 import WithWidgetManagement
@@ -17,19 +16,35 @@ const GridLayout = WidthProvider(ReactGridLayout)
 
 export class WidgetGrid extends Component {
   render() {
-    const GridFilters = this.props.filterComponent
+    // Setup each widget. Note that we assign a z-index to each widget so that
+    // widgets closer to the top of the page have a higher z-index than widgets
+    // closer to the bottom of the page. This is so that an open dropdown menu
+    // in a widget can extend below it and overlap the widget immediately
+    // below. The z-index is necessary because react-grid-layout starts a new
+    // stacking context for each widget, so by default widgets lower on the
+    // page would be rendered on top of widgets higher on the page since they
+    // appear lower in the DOM, thus breaking drop-down menus that extend below
+    // a widget
+    const highestY = Math.max(
+      ..._map(this.props.workspace.widgets, (w, i) => this.props.workspace.layout[i].y)
+    )
 
+    const GridFilters = this.props.filterComponent
     const widgetInstances =
-      _compact(_map(this.props.workspace.widgets, (widgetConfiguration, index) => {
+      _map(this.props.workspace.widgets, (widgetConfiguration, index) => {
         const WidgetComponent = widgetComponent(widgetConfiguration)
+        const widgetY = this.props.workspace.layout[index].y
         return (
           <div
             key={this.props.workspace.layout[index].i}
             className={classNames(
               "mr-card-widget", {
                 'mr-card-widget--editing': this.props.isEditing,
-                'mr-card-widget--top-row': this.props.workspace.layout[index].y === 0,
+                'mr-card-widget--top-row': widgetY === 0,
               })}
+            style={{
+              "zIndex": (highestY - widgetY), // higher values towards top of page
+            }}
           >
             <WidgetComponent {...this.props}
                             widgetLayout={this.props.workspace.layout[index]}
@@ -38,7 +53,7 @@ export class WidgetGrid extends Component {
                             removeWidget={() => this.props.removeWidget(index)} />
           </div>
         )
-      }))
+      })
 
     return (
       <div className={classNames("widget-grid", {"widget-grid--editing": this.props.isEditing})}>

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -505,6 +505,7 @@
   "SignIn.control.longLabel": "Sign in to get started",
   "Task.controls.completionComment.placeholder": "Your comment",
   "Task.comments.comment.controls.submit.label": "Submit",
+  "Task.markedAs.label": "Task marked as",
   "Task.controls.moreOptions.label": "More Options",
   "Task.controls.alreadyFixed.label": "Already fixed",
   "Task.controls.alreadyFixed.tooltip": "Already fixed",


### PR DESCRIPTION
* Don't offer statuses in the "other" status dropdown on step 1 of task
completion that would represent disallowed progressions from the task's
present status

* Don't even display the "other" status dropdown if none of the
additional statuses should be offered

* When viewing a task where no task-completion controls will be on offer
due to the task's present status, display an explanatory message

* Assign explicit z-index values to widgets based on their grid row to
ensure dropdown menus are fully interactive when extending below one
widget onto another