### PR TITLE
Ensure modals render above widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maproulette3",
-  "version": "3.2",
+  "version": "3.2.0",
   "private": true,
   "dependencies": {
     "@mapbox/geojsonhint": "^2.0.1",

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -90,7 +90,7 @@ $layer-topnav: $layer-top + $intralayer-bump;
 $layer-dropdown: $layer-top;
 $dropdown-content-z: $layer-dropdown;
 $layer-popout: $layer-top;
-$layer-modal: $layer-max;
+$layer-modal: 100;
 
 // Modal
 $modal-background-background-color: rgba($green, 0.7);


### PR DESCRIPTION
Bump z-index of modals to ensure they always render above widgets