### PR TITLE
Fix two-column user settings form in Chrome

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step1Schema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step1Schema.js
@@ -92,7 +92,6 @@ export const jsSchema = (intl, user, challengeData) => {
   if (AsManager(user).isSuperUser()) {
     schemaFields.properties.featured = {
       title: intl.formatMessage(messages.featuredLabel),
-      description: intl.formatMessage(messages.featuredDescription),
       type: "boolean",
       default: false,
     }
@@ -105,7 +104,6 @@ export const jsSchema = (intl, user, challengeData) => {
   if (AsEditableChallenge(challengeData).isNew()) {
     schemaFields.properties.includeCheckinHashtag = {
       title: " ", // blank title
-      description: intl.formatMessage(messages.includeCheckinHashtagDescription),
       type: "boolean",
       enum: [true, false],
       enumNames: [intl.formatMessage(messages.includeCheckinHashtagTrueLabel),
@@ -136,6 +134,7 @@ export const uiSchema = (intl, user, challengeData) => {
     ],
     featured: {
       "ui:widget": "radio",
+      "ui:help": intl.formatMessage(messages.featuredDescription),
     },
     enabled: {
       "ui:widget": "radio",
@@ -177,6 +176,7 @@ export const uiSchema = (intl, user, challengeData) => {
     },
     includeCheckinHashtag: {
       "ui:widget": "radio",
+      "ui:help": intl.formatMessage(messages.includeCheckinHashtagDescription),
     },
   }
 

--- a/src/components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
+++ b/src/components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
@@ -53,6 +53,42 @@ export const CustomFieldTemplate = props => {
   }
 }
 
+/**
+ * fieldset tags can't be styled using flexbox or grid in Chrome, so this
+ * template attempts to render the fields the same way as the default but using
+ * a div with class "fieldset" instead of a fieldset. To use it, set
+ * `ObjectFieldTemplate={NoFieldsetObjectFieldTemplate}` in your Form
+ *
+ * > CAUTION: Support for expandable fields that would normally be rendered
+ * > with an Add button has been removed, but it could be added back with a
+ * > little work
+ *
+ * See: https://github.com/mozilla-services/react-jsonschema-form/issues/762
+ */
+export const NoFieldsetObjectFieldTemplate = function(props) {
+  const { TitleField, DescriptionField } = props
+  return (
+    <div className="fieldset" id={props.idSchema.$id}>
+      {(props.uiSchema['ui:title'] || props.title) && (
+        <TitleField
+          id={`${props.idSchema.$id}__title`}
+          title={props.title || props.uiSchema['ui:title']}
+          required={props.required}
+          formContext={props.formContext}
+        />
+      )}
+      {props.description && (
+        <DescriptionField
+          id={`${props.idSchema.$id}__description`}
+          description={props.description}
+          formContext={props.formContext}
+        />
+      )}
+      {props.properties.map(prop => prop.content)}
+    </div>
+  )
+}
+
 export const CustomArrayFieldTemplate = props => {
   const itemFields = _map(props.items, element =>
     <div

--- a/src/components/Navbar/Messages.js
+++ b/src/components/Navbar/Messages.js
@@ -31,7 +31,7 @@ export default defineMessages({
 
   profile: {
     id: 'Navbar.links.userProfile',
-    defaultMessage: "User Profile",
+    defaultMessage: "User Settings",
   },
 
   signout: {

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -488,7 +488,7 @@
   "Navbar.links.leaderboard": "Leaderboard",
   "Navbar.links.admin": "Create & Manage",
   "Navbar.links.help": "Learn",
-  "Navbar.links.userProfile": "User Profile",
+  "Navbar.links.userProfile": "User Settings",
   "Navbar.links.signout": "Sign out",
   "PageNotFound.message": "Sorry, nothing here but open ocean.",
   "PageNotFound.returnTo": "Return to",

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -17,7 +17,7 @@ import SignInButton from '../../components/SignInButton/SignInButton'
 import BusySpinner from '../../components/BusySpinner/BusySpinner'
 import SvgSymbol from '../../components/SvgSymbol/SvgSymbol'
 import ApiKey from './ApiKey'
-import { CustomSelectWidget }
+import { CustomSelectWidget, NoFieldsetObjectFieldTemplate }
        from '../../components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter'
 import { jsSchema, uiSchema } from './ProfileSchema'
 import messages from './Messages'
@@ -134,15 +134,18 @@ class Profile extends Component {
               {saveIndicator}
             </header>
 
-            <Form schema={jsSchema(this.props.intl)}
-                  uiSchema={uiSchema(this.props.intl)}
-                  widgets={{SelectWidget: CustomSelectWidget}}
-                  className="form form--2-col"
-                  liveValidate
-                  noHtml5Validate
-                  showErrorList={false}
-                  formData={userSettings}
-                  onChange={this.changeHandler}>
+            <Form
+              schema={jsSchema(this.props.intl)}
+              uiSchema={uiSchema(this.props.intl)}
+              widgets={{SelectWidget: CustomSelectWidget}}
+              className="form form--2-col"
+              liveValidate
+              noHtml5Validate
+              showErrorList={false}
+              formData={userSettings}
+              onChange={this.changeHandler}
+              ObjectFieldTemplate={NoFieldsetObjectFieldTemplate}
+            >
               <div className="form-controls" />
             </Form>
           </section>

--- a/src/styles/components/forms.css
+++ b/src/styles/components/forms.css
@@ -22,7 +22,7 @@
     @apply mr-mb-8;
   }
 
-  &--2-col fieldset {
+  &--2-col .fieldset {
     @screen md {
       @apply mr-grid mr-grid-columns-2 mr-grid-gap-8;
 


### PR DESCRIPTION
Use alternative rendering of RJSF object field template that uses
a div instead of a fieldset to allow flexbox and grid styling to be
properly applied to the user settings form in Chrome