### PR TITLE
Don't let widget scrollbar cover up content

### DIFF
--- a/src/components/AdminPane/Manage/Widgets/ProjectManagersWidget/ProjectManagersWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/ProjectManagersWidget/ProjectManagersWidget.js
@@ -117,7 +117,7 @@ export default class ProjectManagersWidget extends Component {
       const isLastAdmin = managerRole === GroupType.admin && adminManagers.length < 2
 
       return (
-        <div key={manager.osmId} className="project-managers__manager mr-pr-4">
+        <div key={manager.osmId} className="project-managers__manager">
           <div className="project-managers__manager__about">
             <figure className="image is-24x24 project-managers__manager__profile-pic">
               <img src={manager.avatarURL} alt={manager.displayName} />

--- a/src/components/CommentList/CommentList.js
+++ b/src/components/CommentList/CommentList.js
@@ -37,7 +37,7 @@ export default class CommentList extends Component {
 
     const commentItems = _map(sortedComments, comment =>
       !_isObject(comment) ? null : (
-        <article key={comment.id} className="mr-pr-4 mr-mb-4">
+        <article key={comment.id} className="mr-mb-4">
           <div className="mr-list-reset mr-mb-2 mr-text-xs">
             <span className="mr-font-medium">
               <FormattedTime

--- a/src/styles/components/cards/widget.css
+++ b/src/styles/components/cards/widget.css
@@ -63,7 +63,7 @@
   }
 
   &__content {
-    @apply mr-text-sm mr-h-full mr-rounded mr-overflow-scroll mr-scrolling-touch;
+    @apply mr-text-sm mr-h-full mr-rounded mr-overflow-scroll mr-scrolling-touch mr-pr-4;
 
     p,
     ol,


### PR DESCRIPTION
Add padding to scrollable area of widgets to prevent content from being
covered up by the scrollbar when displayed