### PR TITLE
Zoom JOSM to task map bbox after loading features

### DIFF
--- a/src/components/UserEditorSelector/UserEditorSelector.js
+++ b/src/components/UserEditorSelector/UserEditorSelector.js
@@ -43,7 +43,7 @@ export default class UserEditorSelector extends Component {
         </span>
         {this.state.isSaving ? <BusySpinner /> :
          <Dropdown
-           className="mr-dropdown"
+           className="mr-dropdown mr-dropdown--fixed"
            dropdownButton={dropdown =>
              <EditorButton
                editorLabels={localizedEditorLabels}


### PR DESCRIPTION
After loading features in JOSM during task completion, send a follow-up
command to zoom JOSM to the task map's bounding box