### PR TITLE
Use new prioritizedTasks API for random tasks

### DIFF
--- a/src/components/TaskPane/TaskRandomnessControl/TaskRandomnessControl.js
+++ b/src/components/TaskPane/TaskRandomnessControl/TaskRandomnessControl.js
@@ -22,7 +22,7 @@ export default class TaskRandomnessControl extends Component {
   }
 
   render() {
-    if (!this.props.user || !this.props.task) {
+    if (!this.props.user || !this.props.task || !_isFinite(this.props.challengeId)) {
       return null
     }
 
@@ -59,9 +59,9 @@ TaskRandomnessControl.propTypes = {
   /** The current user */
   user: PropTypes.object,
   /** The current active challenge */
-  challengeId: PropTypes.number.isRequired,
+  challengeId: PropTypes.number,
   /** Current setting of whether to load tasks randomly or by proximity */
-  taskLoadBy: PropTypes.string.isRequired,
+  taskLoadBy: PropTypes.string,
   /** Invoked if the user alters the load-by setting  */
   setTaskLoadBy: PropTypes.func.isRequired,
 }

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -48,6 +48,7 @@ const apiRoutes = factory => {
       'tasks': factory.get('/challenge/:id/tasks'),
       'clusteredTasks': factory.get('/challenge/clustered/:id'),
       'randomTask': factory.get('/challenge/:id/tasks/randomTasks', {noCache: true}),
+      'prioritizedTask': factory.get('/challenge/:id/tasks/prioritizedTasks', {noCache: true}),
       'previousSequentialTask': factory.get('/challenge/:challengeId/previousTask/:taskId'),
       'nextSequentialTask': factory.get('/challenge/:challengeId/nextTask/:taskId'),
       'actions': factory.get('/data/challenge/:id'),

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -199,17 +199,25 @@ export const loadRandomTaskFromChallenge = function(challengeId,
                                                     priorTaskId,
                                                     includeMapillary=false) {
   return function(dispatch) {
-    return retrieveChallengeTask(dispatch, new Endpoint(
-      api.challenge.randomTask,
-      {
+    // We use different API endpoints depending on whether a priorTaskId is
+    // given (indicating that a proximate/nearby task is desired)
+    let endpoint = null
+    if (_isFinite(priorTaskId)) {
+      endpoint = new Endpoint(api.challenge.randomTask, {
         schema: [ taskSchema() ],
         variables: {id: challengeId},
-        params: {
-          proximity: _isFinite(priorTaskId) ? priorTaskId : undefined,
-          mapillary: includeMapillary,
-        }
-      }
-    ))
+        params: {proximity: priorTaskId, mapillary: includeMapillary},
+      })
+    }
+    else {
+      endpoint = new Endpoint(api.challenge.prioritizedTask, {
+        schema: [ taskSchema() ],
+        variables: {id: challengeId},
+        params: {mapillary: includeMapillary},
+      })
+    }
+
+    return retrieveChallengeTask(dispatch, endpoint)
   }
 }
 


### PR DESCRIPTION
When retrieving tasks by random (as opposed to by proximity), use the
new prioritizedTasks API to ensure tasks are retrieved by priority
instead of purely at random