### PR TITLE
Fix direct project link always showing not manager error

### DIFF
--- a/src/components/AdminPane/HOCs/WithCurrentProject/WithCurrentProject.js
+++ b/src/components/AdminPane/HOCs/WithCurrentProject/WithCurrentProject.js
@@ -75,12 +75,17 @@ const WithCurrentProject = function(WrappedComponent, options={}) {
         return
       }
 
-      const projectId = this.currentProjectId(props)
+      let projectId = this.currentProjectId(props)
 
-      if (_isFinite(this.routedProjectId(props)) && projectId === null) {
+      if (_isFinite(this.routedProjectId(props)) && projectId === null &&
+          !this.state.loadingProject) {
         this.props.notManagerError()
         props.history.push('/admin/projects')
         return
+      }
+
+      if (projectId === null) {
+        projectId = this.routedProjectId(props)
       }
 
       if (_isFinite(projectId)) {


### PR DESCRIPTION
Going directly to a project link would always should the not a manager error even if you were a manager fo that project. Fixes the issue by ensuring the project is loaded before checking permissions.