### PR TITLE
Fix 'owned' filter not always showing owned projects

### DIFF
--- a/src/components/AdminPane/HOCs/WithDashboardEntityFilter/WithDashboardEntityFilter.js
+++ b/src/components/AdminPane/HOCs/WithDashboardEntityFilter/WithDashboardEntityFilter.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import _filter from 'lodash/filter'
-import _clone from 'lodash/clone'
+import _cloneDeep from 'lodash/cloneDeep'
 import _get from 'lodash/get'
 import _set from 'lodash/set'
 import _camelCase from 'lodash/camelCase'
@@ -33,7 +33,7 @@ const WithDashboardEntityFilter = function(WrappedComponent,
      * the dashboard configuration.
      */
     setDashboardEntityFilter = (filterName, filterValue) => {
-      const updatedFilters = _clone(this.props.currentConfiguration.filters) || {}
+      const updatedFilters = _cloneDeep(this.props.currentConfiguration.filters) || {}
       _set(updatedFilters, `${this.filterFieldName()}.${filterName}`, filterValue)
 
       this.props.saveWorkspaceConfiguration(Object.assign(

--- a/src/components/AdminPane/Manage/ProjectsDashboard/ProjectsDashboard.js
+++ b/src/components/AdminPane/Manage/ProjectsDashboard/ProjectsDashboard.js
@@ -101,21 +101,19 @@ ProjectsDashboard.defaultProps = {
 }
 
 export default
-WithManageableProjects(
-  WithPinned(
-    WithWidgetWorkspaces(
-      WithDashboardEntityFilter(
-        ProjectsDashboard,
-        'project',
-        'projects',
-        'pinnedProjects',
-        'filteredProjects',
-        projectPassesFilters
-      ),
-      WidgetDataTarget.projects,
-      DASHBOARD_NAME,
-      defaultDashboardSetup
-    )
+WithWidgetWorkspaces(
+  WithManageableProjects(
+    WithDashboardEntityFilter(
+      WithPinned(ProjectsDashboard),
+      'project',
+      'projects',
+      'pinnedProjects',
+      'filteredProjects',
+      projectPassesFilters
+    ),
+    true // include challenges
   ),
-  true // include challenges
+  WidgetDataTarget.projects,
+  DASHBOARD_NAME,
+  defaultDashboardSetup
 )

--- a/src/components/HOCs/WithPagedProjects/WithPagedProjects.js
+++ b/src/components/HOCs/WithPagedProjects/WithPagedProjects.js
@@ -50,7 +50,7 @@ export default function(WrappedComponent,
          // challenges (and their project parents) up toward the top of the results.
         _each(this.props.filteredChallenges, (c) => {
           const parent = _find(pagedProjects, (p) => p.id === (_isObject(c.parent) ? c.parent.id : c.parent))
-          if (!parent.score || c.score < parent.score) {
+          if (parent && (!parent.score || c.score < parent.score)) {
             parent.score = c.score
           }
         })

--- a/src/services/Project/Project.js
+++ b/src/services/Project/Project.js
@@ -75,12 +75,15 @@ export const fetchProjects = function(limit=50) {
  * Fetch data on projects the current user has permission to manage (up to the
  * given limit).
  */
-export const fetchManageableProjects = function(page = null, limit = RESULTS_PER_PAGE) {
+export const fetchManageableProjects = function(page = null, limit = RESULTS_PER_PAGE, onlyOwned = false, onlyEnabled = false) {
   const pageToFetch = _isFinite(page) ? page : 0
 
   return function(dispatch) {
     return new Endpoint(
-      api.projects.managed, {schema: [ projectSchema() ], params: {limit: limit, page: (pageToFetch * limit)}}
+      api.projects.managed, {
+        schema: [ projectSchema() ],
+        params: {limit: limit, page: (pageToFetch * limit), onlyOwned, onlyEnabled}
+      }
     ).execute().then(normalizedResults => {
       dispatch(receiveProjects(normalizedResults.entities))
       return normalizedResults


### PR DESCRIPTION
- Add re-fetch of projects when 'owned' or 'visible' is toggled
  to ensure results are in redux