### PR TITLE
Add 'back to inbox' option on review confirm

### DIFF
--- a/src/components/HOCs/WithTaskReview/WithTaskReview.js
+++ b/src/components/HOCs/WithTaskReview/WithTaskReview.js
@@ -29,6 +29,9 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
           if (loadBy === TaskReviewLoadMethod.next) {
             url.push(`/challenge/${task.parentId}/task/${task.id}/review`)
           }
+          else if (loadBy === TaskReviewLoadMethod.inbox) {
+            url.push('/inbox')
+          }
           else {
             url.push('/review')
           }

--- a/src/components/ReviewTaskControls/ReviewTaskControls.js
+++ b/src/components/ReviewTaskControls/ReviewTaskControls.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
+import _get from 'lodash/get'
 import { FormattedMessage } from 'react-intl'
 import { TaskReviewStatus } from '../../services/Task/TaskReview/TaskReviewStatus'
 import { TaskStatus, messagesByStatus }
@@ -14,7 +15,6 @@ import TaskEditControl from '../TaskPane/ActiveTaskDetails/ActiveTaskControls/Ta
 import UserEditorSelector
        from '../UserEditorSelector/UserEditorSelector'
 import TaskConfirmationModal from '../TaskConfirmationModal/TaskConfirmationModal'
-import queryString from 'query-string'
 import messages from './Messages'
 import './ReviewTaskControls.scss'
 
@@ -123,7 +123,7 @@ export class ReviewTaskControls extends Component {
       )
     }
 
-    const fromInbox = queryString.parse(this.props.history.location.search)["fromInbox"]
+    const fromInbox = _get(this.props.history, 'location.state.fromInbox')
 
     return (
       <div className={classNames("review-task-controls", this.props.className)}>

--- a/src/components/ReviewTaskControls/ReviewTaskControls.js
+++ b/src/components/ReviewTaskControls/ReviewTaskControls.js
@@ -14,6 +14,7 @@ import TaskEditControl from '../TaskPane/ActiveTaskDetails/ActiveTaskControls/Ta
 import UserEditorSelector
        from '../UserEditorSelector/UserEditorSelector'
 import TaskConfirmationModal from '../TaskConfirmationModal/TaskConfirmationModal'
+import queryString from 'query-string'
 import messages from './Messages'
 import './ReviewTaskControls.scss'
 
@@ -122,6 +123,8 @@ export class ReviewTaskControls extends Component {
       )
     }
 
+    const fromInbox = queryString.parse(this.props.history.location.search)["fromInbox"]
+
     return (
       <div className={classNames("review-task-controls", this.props.className)}>
         <div className="mr-text-sm mr-text-white mr-mt-4 mr-whitespace-no-wrap">
@@ -178,6 +181,7 @@ export class ReviewTaskControls extends Component {
             chooseLoadBy={this.chooseLoadBy}
             loadBy={this.state.loadBy}
             inReview={true}
+            fromInbox={fromInbox}
           />
         }
       </div>

--- a/src/components/TaskConfirmationModal/TaskConfirmationModal.js
+++ b/src/components/TaskConfirmationModal/TaskConfirmationModal.js
@@ -126,7 +126,48 @@ export class TaskConfirmationModal extends Component {
                   <label className="mr-mr-4">
                     <FormattedMessage {...messagesByReviewLoadMethod[TaskReviewLoadMethod.next]} />
                   </label>
+                  { this.props.fromInbox &&
+                    <React.Fragment>
+                      <input
+                        type="radio"
+                        name="loadReviewPreference"
+                        className="mr-mr-1"
+                        checked={this.props.loadBy === TaskReviewLoadMethod.inbox}
+                        onChange={() => this.props.chooseLoadBy(TaskReviewLoadMethod.inbox)}
+                      />
+                      <label className="mr-mr-4">
+                        <FormattedMessage {...messagesByReviewLoadMethod[TaskReviewLoadMethod.inbox]} />
+                      </label>
+                    </React.Fragment>
+                  }
+                  <input
+                    type="radio"
+                    name="loadReviewPreference"
+                    className="mr-mr-1"
+                    checked={this.props.loadBy === TaskReviewLoadMethod.all}
+                    onChange={() => this.props.chooseLoadBy(TaskReviewLoadMethod.all)}
+                  />
+                  <label>
+                    <FormattedMessage {...messagesByReviewLoadMethod[TaskReviewLoadMethod.all]} />
+                  </label>
+                </div>
+              }
 
+              { reviewConfirmation && this.props.needsRevised && this.props.fromInbox &&
+                <div className="form mr-mt-8 mr-border-grey-lighter-10 mr-border-t mr-border-b mr-py-4">
+                  <span className="mr-mr-4">
+                    <FormattedMessage {...messages.loadNextReviewLabel} />
+                  </span>
+                  <input
+                    type="radio"
+                    name="loadReviewPreference"
+                    className="mr-mr-1"
+                    checked={this.props.loadBy === TaskReviewLoadMethod.inbox}
+                    onChange={() => this.props.chooseLoadBy(TaskReviewLoadMethod.inbox)}
+                  />
+                  <label className="mr-mr-4">
+                    <FormattedMessage {...messagesByReviewLoadMethod[TaskReviewLoadMethod.inbox]} />
+                  </label>
                   <input
                     type="radio"
                     name="loadReviewPreference"

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -5,7 +5,6 @@ import { FormattedMessage, injectIntl } from 'react-intl'
 import _get from 'lodash/get'
 import _isFinite from 'lodash/isFinite'
 import _isUndefined from 'lodash/isUndefined'
-import queryString from 'query-string'
 import { allowedStatusProgressions, isCompletionStatus,
          isFinalStatus, messagesByStatus }
        from '../../../../services/Task/TaskStatus/TaskStatus'
@@ -153,7 +152,7 @@ export class ActiveTaskControls extends Component {
       _get(this.props, 'editor.taskId') !== this.props.task.id &&
            this.state.taskBeingCompleted === this.props.task.id
 
-    const fromInbox = queryString.parse(this.props.history.location.search)["fromInbox"]
+    const fromInbox = _get(this.props.history, 'location.state.fromInbox')
 
     if (editorLoading) {
       return <BusySpinner />

--- a/src/pages/Inbox/Notification.js
+++ b/src/pages/Inbox/Notification.js
@@ -148,7 +148,7 @@ const ViewTask = function(props) {
   return (
     <div className="mr-mt-8">
       <Link to={
-        `challenge/${props.notification.challengeId}/task/${props.notification.taskId}${props.review ? '/review' : ''}`
+        `challenge/${props.notification.challengeId}/task/${props.notification.taskId}${props.review ? '/review' : ''}?fromInbox=true`
       }>
         <FormattedMessage {...messages.viewTaskLabel} />
       </Link>

--- a/src/pages/Inbox/Notification.js
+++ b/src/pages/Inbox/Notification.js
@@ -147,9 +147,10 @@ const ViewTask = function(props) {
 
   return (
     <div className="mr-mt-8">
-      <Link to={
-        `challenge/${props.notification.challengeId}/task/${props.notification.taskId}${props.review ? '/review' : ''}?fromInbox=true`
-      }>
+      <Link to={{
+              pathname: `challenge/${props.notification.challengeId}/task/${props.notification.taskId}`,
+              state: {fromInbox: true}
+            }}>
         <FormattedMessage {...messages.viewTaskLabel} />
       </Link>
     </div>

--- a/src/services/Task/TaskReview/Messages.js
+++ b/src/services/Task/TaskReview/Messages.js
@@ -30,4 +30,9 @@ export default defineMessages({
     id: 'Task.review.loadByMethod.all',
     defaultMessage: "Back to Review All",
   },
+
+  inbox: {
+    id: 'Task.review.loadByMethod.inbox',
+    defaultMessage: "Back to Inbox",
+  },
 })

--- a/src/services/Task/TaskReview/TaskReviewLoadMethod.js
+++ b/src/services/Task/TaskReview/TaskReviewLoadMethod.js
@@ -8,9 +8,13 @@ export const NEXT_LOAD_METHOD = 'next'
 /** Load review page with all review tasks */
 export const ALL_LOAD_METHOD = 'all'
 
+/** Load inbox */
+export const LOAD_INBOX_METHOD = 'inbox'
+
 export const TaskReviewLoadMethod = Object.freeze({
   next: NEXT_LOAD_METHOD,
   all: ALL_LOAD_METHOD,
+  inbox: LOAD_INBOX_METHOD,
 })
 
 /**


### PR DESCRIPTION
* On the review confirmation modal adds a "back to inbox" option if the user came from the inbox along with 'back to review' and 'next task to review'

* On the revision confirmation modal adds a "back to inbox" option and 'back to review' option if the user came from the inbox.