### PR TITLE
Changed default page title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>MapRoulette</title>
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
Avoids seeing `React App` when the page is loading.