### PR TITLE
Use map bounds for attic queries

### DIFF
--- a/src/components/TaskHistoryList/TaskHistoryList.js
+++ b/src/components/TaskHistoryList/TaskHistoryList.js
@@ -135,7 +135,7 @@ export default class TaskHistoryList extends Component {
               </div>
               {!this.props.selectDiffs &&
                 // eslint-disable-next-line jsx-a11y/anchor-is-valid
-                <a onClick={() => viewAtticOverpass(this.props.editor, log.timestamp, this.props.task.calculateBBox())}>
+                <a onClick={() => viewAtticOverpass(this.props.editor, log.timestamp, this.props.mapBounds.bounds)}>
                   <FormattedMessage {...messages.viewAtticLabel} />
                 </a>
               }

--- a/src/components/Widgets/TaskHistoryWidget/TaskHistoryWidget.js
+++ b/src/components/Widgets/TaskHistoryWidget/TaskHistoryWidget.js
@@ -4,6 +4,7 @@ import { WidgetDataTarget, registerWidgetType }
        from '../../../services/Widget/Widget'
 import TaskHistoryList from '../../TaskHistoryList/TaskHistoryList'
 import WithTaskHistory from '../../HOCs/WithTaskHistory/WithTaskHistory'
+import WithSearch from '../../HOCs/WithSearch/WithSearch'
 import AsMappableTask from '../../../interactions/Task/AsMappableTask'
 import QuickWidget from '../../QuickWidget/QuickWidget'
 import { viewDiffOverpass, viewOSMCha } from '../../../services/Overpass/Overpass'
@@ -41,7 +42,7 @@ export default class TaskHistoryWidget extends Component {
     if (diffTimestamps.length >= 2 ) {
       viewDiffOverpass(AsMappableTask(this.props.task).calculateBBox(),
                        ...diffTimestamps.slice(-2))
-      this.setState({selectedTimestamps: []})
+      this.setState({selectedTimestamps: [], diffSelectionActive: false})
     }
     else {
       this.setState({selectedTimestamps: diffTimestamps})
@@ -115,6 +116,7 @@ export default class TaskHistoryWidget extends Component {
           taskHistory={this.props.task.history}
           task={AsMappableTask(this.props.task)}
           editor={this.getEditor()}
+          mapBounds={this.props.mapBounds}
           selectDiffs={this.state.diffSelectionActive}
           toggleSelection={this.toggleSelection}
           selectedTimestamps={this.state.selectedTimestamps}
@@ -127,4 +129,7 @@ export default class TaskHistoryWidget extends Component {
 TaskHistoryWidget.propTypes = {
 }
 
-registerWidgetType(WithTaskHistory(TaskHistoryWidget), descriptor)
+registerWidgetType(
+  WithSearch(WithTaskHistory(TaskHistoryWidget), 'task'),
+  descriptor
+)

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -853,6 +853,7 @@
   "Task.reviewStatus.approvedWithFixes": "Approved with Fixes",
   "Task.review.loadByMethod.next": "Next Task",
   "Task.review.loadByMethod.all": "Back to Review All",
+  "Task.review.loadByMethod.inbox": "Back to Inbox",
   "Task.status.created": "Created",
   "Task.status.fixed": "Fixed",
   "Task.status.falsePositive": "Not an Issue",

--- a/src/services/Overpass/Overpass.js
+++ b/src/services/Overpass/Overpass.js
@@ -2,42 +2,40 @@ import addMinutes from 'date-fns/add_minutes'
 import isAfter from 'date-fns/is_after'
 import format from 'date-fns/format'
 import { isJosmEditor, sendJOSMCommand } from '../Editor/Editor'
+import { fromLatLngBounds } from '../MapBounds/MapBounds'
 import _get from 'lodash/get'
 
 /**
- * View the task AOI as of the given date via Overpass attic query.
- * @param atticDate
+ * View the AOI defined by the given bounds (either LatLngBounds or an array)
+ * as of the given date via Overpass attic query
  */
-export const viewAtticOverpass = (selectedEditor, actionDate, actionBBox) => {
+export const viewAtticOverpass = (selectedEditor, actionDate, bounds) => {
   const adjustedDateString = offsetAtticDateMoment(actionDate).toISOString()
-  const bbox = overpassBBox(actionBBox).join(',');
+  const bbox = overpassBBox(bounds).join(',')
   const query =
-    '[out:xml][timeout:25][bbox:' + bbox + '][date:"' + adjustedDateString + '"];' +
-    '( node(' + bbox + '); <; >; );' +
-    'out meta;';
+    `[out:xml][timeout:25][bbox:${bbox}][date:"${adjustedDateString}"];` +
+    `( node(${bbox}); <; >; );` +
+    'out meta;'
 
   // Try sending to JOSM if it's user's chosen editor, otherwise Overpass Turbo.
-  var overpassApiURL = 'https://overpass-api.de/api/interpreter?data=' + encodeURIComponent(query);
   if (isJosmEditor(selectedEditor)) {
+    const overpassApiURL = 'https://overpass-api.de/api/interpreter?data=' + encodeURIComponent(query)
     sendJOSMCommand('http://127.0.0.1:8111/import?new_layer=true&layer_name=' +
                      adjustedDateString + '&layer_locked=true&url=' +
-                     encodeURIComponent(overpassApiURL)
-    )
+                     encodeURIComponent(overpassApiURL))
   }
   else {
-    const overpassTurboURL = 'https://overpass-turbo.eu/map.html?Q=' + encodeURIComponent(query);
-    window.open(overpassTurboURL);
+    const overpassTurboURL = 'https://overpass-turbo.eu/map.html?Q=' + encodeURIComponent(query)
+    window.open(overpassTurboURL)
   }
 }
 
 /**
- * View augmented diff in achavi of the task AOI for the two given items
- * @param actionBBox
- * @param firstItem
- * @param secondItem
+ * View augmented diff in achavi of the AOI defined by the given bounds (either
+ * LatLngBounds or an array) for the two given dates
  */
- export const viewDiffOverpass = (actionBBox, firstDate, secondDate) => {
-   // order firstItem and secondItem into earlierItem and laterItem
+ export const viewDiffOverpass = (bounds, firstDate, secondDate) => {
+   // order firstDate and secondDate into earlierDate and laterDate
    let earlierDate = new Date(firstDate)
    let laterDate = new Date(secondDate)
 
@@ -46,66 +44,63 @@ export const viewAtticOverpass = (selectedEditor, actionDate, actionBBox) => {
      laterDate = new Date(firstDate)
    }
 
-   const bbox = overpassBBox(actionBBox).join(',');
-   let query =
-     '[out:xml][timeout:25][bbox:' + bbox + ']' +
-     '[adiff:"' + earlierDate.toISOString() + '","' +
-                  offsetAtticDateMoment(laterDate).toISOString() + '"];' +
-     '( node(' + bbox + '); <; >; );' +
-     'out meta geom qt;';
-
+   const bbox = overpassBBox(bounds).join(',')
+   const query =
+     `[out:xml][timeout:25][bbox:${bbox}]` +
+     `[adiff:"${earlierDate.toISOString()}","${offsetAtticDateMoment(laterDate).toISOString()}"];` +
+     `( node(${bbox}); <; >; );` +
+     'out meta geom qt;'
 
    // Send users to achavi for visualization of augmented diff
-   let overpassURL = 'https://overpass-api.de/api/interpreter?data=' + encodeURIComponent(query);
-   let achaviURL = 'https://overpass-api.de/achavi/?url=' + encodeURIComponent(overpassURL);
+   const overpassURL = 'https://overpass-api.de/api/interpreter?data=' + encodeURIComponent(query)
+   const achaviURL = 'https://overpass-api.de/achavi/?url=' + encodeURIComponent(overpassURL)
    window.open(achaviURL)
  }
 
 /**
- * View changesets in OSM Cha. Sets up filters for task bbox, start date of
- * first edit, and participating usernames.
- **/
-export const viewOSMCha = (actionBBox, earliestDate, participantUsernames) => {
+ * View changesets in OSMCha. Sets up filters for given bbox, the given start
+ * date (typically the earliest relevant date in the task history), and
+ * participating usernames
+ */
+export const viewOSMCha = (bboxArray, earliestDate, participantUsernames) => {
   const filterParams = []
   // Setup bbox filter
-  const bbox = actionBBox.join(',')
-  filterParams.push('"in_bbox":[{"label":"' + bbox + '","value":"' + bbox + '"}]')
+  const bbox = bboxArray.join(',')
+  filterParams.push(`"in_bbox":[{"label":"${bbox}","value":"${bbox}"}]`)
 
   if (earliestDate) {
     // Setup start-date filter
     const startDate = format(earliestDate, "YYYY-MM-DD")
-    filterParams.push('"date__gte":[{"label":"' + startDate + '","value":"' + startDate + '"}]')
+    filterParams.push(`"date__gte":[{"label":"${startDate}","value":"${startDate}"}]`)
   }
 
   // Setup user filter
   if (participantUsernames && participantUsernames.length > 0) {
-    const userList = participantUsernames.map((username) => {
-       return '{"label":"' + username + '","value":"' + username + '"}'
-      })
-    filterParams.push('"users":[' + userList.join(',') + ']')
+    const userList =
+      participantUsernames.map(username => `{"label":"${username}","value":"${username}"}`)
+    filterParams.push(`"users":[${userList.join(',')}]`)
   }
 
   window.open('https://osmcha.mapbox.com/?filters=' +
-          encodeURIComponent('{' + filterParams.join(',') + '}'))
+              encodeURIComponent(`{${filterParams.join(',')}}`))
 }
 
 /**
  * Returns a Moment instance representing the action date of the given
  * item. The timestamp is offset by the configured `atticQueryOffsetMinutes`
  * number of minutes.
- *
- * @param actionDate
  */
-const offsetAtticDateMoment = (actionDate) => {
+const offsetAtticDateMoment = actionDate => {
   return addMinutes(actionDate,
-    _get(process.env, 'REACT_APP_ATTIC_QUERY_OFFSET_MINUTES', 10))
+                    _get(process.env, 'REACT_APP_ATTIC_QUERY_OFFSET_MINUTES', 10))
 }
 
 /**
  * Get the task bounding box, transforming to SWNE (min lat, min lon, max lat, max lon) array
  * as preferred by Overpass.
  */
-const overpassBBox = (bbox) => {
+const overpassBBox = bounds => {
+  const bbox = fromLatLngBounds(bounds)
   // Transform WSEN to SWNE that Overpass prefers
-  return [bbox[1], bbox[0], bbox[3], bbox[2]];
+  return [bbox[1], bbox[0], bbox[3], bbox[2]]
 }


### PR DESCRIPTION
* Use map bounds, instead of task bounds, for overpass attic queries

* Use string interpolation for overpass queries

* Treat diff process as complete once the diff is kicked off with two
history entries