### PR TITLE
Add back loading spinner on review tables

### DIFF
--- a/src/components/HOCs/WithReviewTasks/WithReviewTasks.js
+++ b/src/components/HOCs/WithReviewTasks/WithReviewTasks.js
@@ -19,23 +19,32 @@ const DEFAULT_PAGE_SIZE = 20
  */
 export const WithReviewTasks = function(WrappedComponent, reviewStatus=0) {
   return class extends Component {
+    state = {
+      loading: false
+    }
+
     refresh = (sortBy, direction, filters) => {
       this.update(this.props, sortBy, direction, filters)
     }
 
     update(props, sortBy, direction, filters) {
+      this.setState({loading: true})
+
       if (props.asReviewer) {
         if (props.showReviewedByMe) {
           props.updateUserReviewedTasks({sortCriteria: {sortBy, direction}, filters}).then(() => {
+            this.setState({loading: false})
           })
         }
         else {
           props.updateReviewNeededTasks({sortCriteria: {sortBy, direction}, filters}).then(() => {
+            this.setState({loading: false})
           })
         }
       }
       else {
         props.updateReviewedTasks({sortCriteria: {sortBy, direction}, filters}).then(() => {
+          this.setState({loading: false})
         })
       }
     }
@@ -64,6 +73,7 @@ export const WithReviewTasks = function(WrappedComponent, reviewStatus=0) {
                           defaultPageSize={DEFAULT_PAGE_SIZE}
                           refresh={this.refresh}
                           startReviewing={this.props.startNextReviewTask}
+                          loading={this.state.loading}
                           {..._omit(this.props, ['updateReviewTasks'])} />)
     }
   }

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -147,6 +147,7 @@ export class TaskReviewTable extends Component {
                             this.fetchData()
                           }
                         }}
+                        loading={this.props.loading}
             />
           </div>
         </div>


### PR DESCRIPTION
Loading icon was removed when there was filtering/sorting issues. Those have been fixed. This adds back the loading spinner.