### PR TITLE
Don't hide task completion step2 on revision

### DIFF
--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -194,12 +194,13 @@ export class ActiveTaskControls extends Component {
            />
           }
 
-          {isEditingTask && !needsRevised &&
+          {isEditingTask &&
            <TaskCompletionStep2
              {...this.props}
              allowedProgressions={allowedProgressions}
              complete={this.initiateCompletion}
              cancelEditing={this.cancelEditing}
+             needsRevised={needsRevised}
            />
           }
 

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep2/TaskCompletionStep2.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCompletionStep2/TaskCompletionStep2.js
@@ -6,6 +6,7 @@ import TaskTooHardControl from '../TaskTooHardControl/TaskTooHardControl'
 import TaskAlreadyFixedControl from '../TaskAlreadyFixedControl/TaskAlreadyFixedControl'
 import TaskSkipControl from '../TaskSkipControl/TaskSkipControl'
 import TaskFalsePositiveControl from '../TaskFalsePositiveControl/TaskFalsePositiveControl'
+import TaskRevisedControl from '../TaskRevisedControl/TaskRevisedControl'
 import TaskCancelEditingControl from '../TaskCancelEditingControl/TaskCancelEditingControl'
 import Dropdown from '../../../../Dropdown/Dropdown'
 import './TaskCompletionStep2.scss'
@@ -52,6 +53,10 @@ export default class TaskCompletionStep2 extends Component {
            />
           }
         </div>
+
+        {this.props.needsRevised &&
+          <TaskRevisedControl {...this.props} className="mr-mb-4" />
+        }
 
         <TaskCancelEditingControl {...this.props} />
       </div>

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskRevisedControl/TaskRevisedControl.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskRevisedControl/TaskRevisedControl.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import classNames from 'classnames'
 import { FormattedMessage } from 'react-intl'
 import { TaskReviewStatus }
        from '../../../../../services/Task/TaskReview/TaskReviewStatus'
@@ -24,7 +25,7 @@ export default class TaskRevisedControl extends Component {
     else {
       return (
         <Dropdown
-          className="mr-dropdown--fixed mr-w-full"
+          className={classNames("mr-dropdown--fixed mr-w-full", this.props.className)}
           dropdownButton={dropdown =>
             <MoreOptionsButton toggleDropdownVisible={dropdown.toggleDropdownVisible} {...this.props}/>
           }


### PR DESCRIPTION
* When revising a task after rejection from review, don't hide step 2 of
task completion after clicking Edit

* Add revision-complete controls on step 2 when revising a task