### PR TITLE
Various adjustment to task-completion widgets

### DIFF
--- a/src/components/TaskPane/TaskPane.js
+++ b/src/components/TaskPane/TaskPane.js
@@ -41,10 +41,9 @@ export const defaultWorkspaceSetup = function() {
     ],
     layout: [
       {i: generateWidgetId(), x: 0, y: 0, w: 4, h: 4},
-      {i: generateWidgetId(), x: 4, y: 0, w: 8, h: 18},
+      {i: generateWidgetId(), x: 4, y: 0, w: 8, h: 19},
       {i: generateWidgetId(), x: 0, y: 4, w: 4, h: 7},
-      {i: generateWidgetId(), x: 0, y: 11, w: 4, h: 7},
-      {i: generateWidgetId(), x: 0, y: 18, w: 3, h: 12},
+      {i: generateWidgetId(), x: 0, y: 11, w: 4, h: 8},
     ],
     excludeWidgets: [
       widgetDescriptor('TaskReviewWidget'),

--- a/src/components/TaskPane/TaskTrackControls/TaskTrackControls.js
+++ b/src/components/TaskPane/TaskTrackControls/TaskTrackControls.js
@@ -1,21 +1,21 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import classNames from 'classnames'
 import { FormattedMessage } from 'react-intl'
 import _findIndex from 'lodash/findIndex'
-import SvgSymbol from '../../SvgSymbol/SvgSymbol'
+import _noop from 'lodash/noop'
 import messages from './Messages'
 
 /**
- * TaskTrackControls displays a switch for toggling tracking of the current
- * task, saving/unsaving it into the user's set of saved tasks.
+ * TaskTrackControls displays a checkbox for toggling tracking of the current
+ * task, saving/unsaving it into the user's set of saved tasks
  *
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default class TaskTrackControls extends Component {
-  taskIsTracked = () =>
-    _findIndex(this.props.user.savedTasks,
-               {id: this.props.task.id}) !== -1
+  taskIsTracked = () => {
+    return _findIndex(this.props.user.savedTasks,
+                      {id: this.props.task.id}) !== -1
+  }
 
   toggleSaved = () => {
     if (this.taskIsTracked()) {
@@ -31,55 +31,19 @@ export default class TaskTrackControls extends Component {
       return null
     }
 
-    let control = null
-
-    // Normally we show a switch for toggling, but in minimized mode we show an
-    // icon control.
-    if (this.props.isMinimized) {
-      let label = null
-      let icon = null
-
-      if (this.taskIsTracked()) {
-        label = messages.untrackLabel
-        icon = "bookmark-icon"
-      }
-      else {
-        label = messages.trackLabel
-        icon = "bookmark-add-icon"
-      }
-
-      control = (
-        <button className="button icon-only" onClick={this.toggleSaved}>
-          <span className="control-icon"
-                title={this.props.intl.formatMessage(label)}>
-            <SvgSymbol viewBox='0 0 20 20' sym={icon} />
-          </span>
-          <span className="control-label">
-            <FormattedMessage {...label} />
-          </span>
-        </button>
-      )
-    }
-    else {
-      control = (
-        <div className="has-centered-children">
-          <div className="switch-backdrop">
-            <div className="field" onClick={this.toggleSaved}>
-              <input type="checkbox" className="switch is-rounded short-and-wide"
-                    onChange={() => {}}
-                    checked={this.taskIsTracked()} />
-              <label>
-                <FormattedMessage {...messages.trackLabel } />
-              </label>
-            </div>
-          </div>
-        </div>
-      )
-    }
-
     return (
-      <div className={classNames("task-track-controls", this.props.className)}>
-        {control}
+      <div>
+        <div onClick={this.toggleSaved}>
+          <input
+            type="checkbox"
+            className="mr-mr-2"
+            onChange={() => _noop}
+            checked={this.taskIsTracked()}
+          />
+          <label>
+            <FormattedMessage {...messages.trackLabel } />
+          </label>
+        </div>
       </div>
     )
   }

--- a/src/components/Widgets/TaskHistoryWidget/Messages.js
+++ b/src/components/Widgets/TaskHistoryWidget/Messages.js
@@ -6,7 +6,7 @@ import { defineMessages } from 'react-intl'
 export default defineMessages({
   label: {
     id: "Widgets.TaskHistoryWidget.label",
-    defaultMessage: "History",
+    defaultMessage: "Task History",
   },
 
   title: {

--- a/src/components/Widgets/TaskHistoryWidget/TaskHistoryWidget.js
+++ b/src/components/Widgets/TaskHistoryWidget/TaskHistoryWidget.js
@@ -19,8 +19,8 @@ const descriptor = {
   widgetKey: 'TaskHistoryWidget',
   label: messages.label,
   targets: [WidgetDataTarget.task],
-  minWidth: 4,
-  defaultWidth: 3,
+  minWidth: 3,
+  defaultWidth: 4,
   minHeight: 3,
   defaultHeight: 6,
 }

--- a/src/components/Widgets/TaskLocationWidget/TaskLocationWidget.js
+++ b/src/components/Widgets/TaskLocationWidget/TaskLocationWidget.js
@@ -15,7 +15,7 @@ const descriptor = {
   targets: [WidgetDataTarget.task],
   minWidth: 3,
   defaultWidth: 3,
-  minHeight: 2,
+  minHeight: 6,
   defaultHeight: 8,
 }
 

--- a/src/components/Widgets/TaskMoreOptionsWidget/TaskMoreOptionsWidget.js
+++ b/src/components/Widgets/TaskMoreOptionsWidget/TaskMoreOptionsWidget.js
@@ -3,8 +3,6 @@ import { FormattedMessage } from 'react-intl'
 import { WidgetDataTarget, registerWidgetType }
        from '../../../services/Widget/Widget'
 import TaskTrackControls from '../../TaskPane/TaskTrackControls/TaskTrackControls'
-import TaskRandomnessControl
-       from '../../TaskPane/TaskRandomnessControl/TaskRandomnessControl'
 import QuickWidget from '../../QuickWidget/QuickWidget'
 import messages from './Messages'
 
@@ -15,17 +13,18 @@ const descriptor = {
   minWidth: 3,
   defaultWidth: 3,
   minHeight: 3,
-  defaultHeight: 6,
+  defaultHeight: 3,
 }
 
 export default class TaskMoreOptionsWidget extends Component {
   render() {
     return (
-      <QuickWidget {...this.props}
-                  className="task-more-options-widget"
-                  widgetTitle={<FormattedMessage {...messages.title} />}>
-        <TaskTrackControls {...this.props} className="active-task-controls__track-task" />
-        <TaskRandomnessControl {...this.props} />
+      <QuickWidget
+        {...this.props}
+        className="task-more-options-widget"
+        widgetTitle={<FormattedMessage {...messages.title} />}
+      >
+        <TaskTrackControls {...this.props} />
       </QuickWidget>
     )
   }

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -612,7 +612,7 @@
   "Widgets.TaskCompletionWidget.label": "Completion",
   "Widgets.TaskCompletionWidget.title": "Completion",
   "Widgets.TaskCompletionWidget.inspectTitle": "Inspect",
-  "Widgets.TaskHistoryWidget.label": "History",
+  "Widgets.TaskHistoryWidget.label": "Task History",
   "Widgets.TaskHistoryWidget.title": "History",
   "Widgets.TaskHistoryWidget.control.startDiff": "Start Diff",
   "Widgets.TaskHistoryWidget.control.cancelDiff": "Cancel Diff",


### PR DESCRIPTION
* Remove extraneous entry from TaskPane widget layout and adjust
location widget height to ensure lat/lon are shown by default

* Increase minimum height of task location widget

* Change task history widget label from History to Task History

* Reduce task history minimum width so it can be made narrower

* Remove random/proximity control from task more options widget since
it's now a part of the confirmation step

* Update task track control to use a standard checkbox instead of a
Bulma switch and remove old "minimized" view leftover from the old
sidebar UI