### PR TITLE
Add 'awaiting review' message to ActiveTaskControls

### DIFF
--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -180,6 +180,12 @@ export class ActiveTaskControls extends Component {
              /> <FormattedMessage
                {...messagesByStatus[this.props.task.status]}
              />
+             {(this.props.task.reviewStatus === TaskReviewStatus.needed ||
+               this.props.task.reviewStatus === TaskReviewStatus.disputed) &&
+                <div className="mr-text-yellow mr-text-sd mr-my-4">
+                  <FormattedMessage {...messages.awaitingReview} />
+                </div>
+             }
            </div>
           }
 

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/Messages.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/Messages.js
@@ -13,4 +13,9 @@ export default defineMessages({
     id: 'Task.requestReview.label',
     defaultMessage: "request review?",
   },
+
+  awaitingReview: {
+    id: 'Task.awaitingReview.label',
+    defaultMessage: "Task is awaiting review.",
+  },
 })

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -551,6 +551,7 @@
   "TaskHistory.controls.viewAttic.label": "View Attic",
   "Task.markedAs.label": "Task marked as",
   "Task.requestReview.label": "request review?",
+  "Task.awaitingReview.label": "Task is awaiting review.",
   "Task.controls.moreOptions.label": "More Options",
   "Task.controls.alreadyFixed.label": "Already fixed",
   "Task.controls.alreadyFixed.tooltip": "Already fixed",


### PR DESCRIPTION
When viewing a task that has already been completed (or fixed after a revision needed) a message will show indicating the "task is awaiting review" (for review/re-review and disputed) if appropriate.