### PR TITLE
Fix bug with paging on inbox

### DIFF
--- a/src/services/User/User.js
+++ b/src/services/User/User.js
@@ -337,6 +337,7 @@ export const fetchUserNotifications = function(userId) {
   return function(dispatch) {
     return new Endpoint(api.user.notifications, {
       variables: {userId},
+      params: {limit: -1}
     }).execute().then(response => {
       const user = {id: userId}
       user.notifications = response


### PR DESCRIPTION
Only 10 notifications returned by default from server, so
change call to server to return limit "-1" and fetch all.