### PR TITLE
Change attic overpass to not adjust date on start entry

### DIFF
--- a/src/components/TaskHistoryList/TaskHistoryList.js
+++ b/src/components/TaskHistoryList/TaskHistoryList.js
@@ -88,6 +88,7 @@ export default class TaskHistoryList extends Component {
 
           if (log.startedAt) {
             startedAtEntry = {timestamp: log.startedAt,
+                              ignoreAtticOffset: true,
                               entry: [
                                 <li className="mr-mb-4" key={"start-" + index}>
                                   <div>
@@ -135,7 +136,8 @@ export default class TaskHistoryList extends Component {
               </div>
               {!this.props.selectDiffs &&
                 // eslint-disable-next-line jsx-a11y/anchor-is-valid
-                <a onClick={() => viewAtticOverpass(this.props.editor, log.timestamp, this.props.mapBounds.bounds)}>
+                <a onClick={() => viewAtticOverpass(this.props.editor, log.timestamp,
+                                    this.props.mapBounds.bounds, log.ignoreAtticOffset)}>
                   <FormattedMessage {...messages.viewAtticLabel} />
                 </a>
               }

--- a/src/services/Overpass/Overpass.js
+++ b/src/services/Overpass/Overpass.js
@@ -9,8 +9,12 @@ import _get from 'lodash/get'
  * View the AOI defined by the given bounds (either LatLngBounds or an array)
  * as of the given date via Overpass attic query
  */
-export const viewAtticOverpass = (selectedEditor, actionDate, bounds) => {
-  const adjustedDateString = offsetAtticDateMoment(actionDate).toISOString()
+export const viewAtticOverpass = (selectedEditor, actionDate, bounds, ignoreAtticOffset = false) => {
+  let adjustedDateString = offsetAtticDateMoment(actionDate).toISOString()
+  if (ignoreAtticOffset) {
+    adjustedDateString = actionDate
+  }
+
   const bbox = overpassBBox(bounds).join(',')
   const query =
     `[out:xml][timeout:25][bbox:${bbox}][date:"${adjustedDateString}"];` +


### PR DESCRIPTION
We add 10 minutes (configurable) to the attic overpass queries to account for overpass time differences. Change the 'task started' entry to not do this adjustment so there is an initial starting view and enough to compare. 