### PR TITLE
Remove excluded widgets from workspaces

### DIFF
--- a/src/components/HOCs/WithWidgetManagement/WithWidgetManagement.js
+++ b/src/components/HOCs/WithWidgetManagement/WithWidgetManagement.js
@@ -5,6 +5,7 @@ import _each from 'lodash/each'
 import _differenceBy from 'lodash/differenceBy'
 import _find from 'lodash/find'
 import _findIndex from 'lodash/findIndex'
+import _map from 'lodash/map'
 import { generateWidgetId, widgetDescriptor, compatibleWidgetTypes }
        from '../../../services/Widget/Widget'
 
@@ -25,7 +26,9 @@ const WithWidgetManagement = function(WrappedComponent) {
     availableWidgets = () => {
       const compatibleWidgets = compatibleWidgetTypes(this.props.workspace.targets)
       const unusedWidgets = _differenceBy(compatibleWidgets, this.props.workspace.widgets, 'widgetKey')
-      return _differenceBy(unusedWidgets, this.props.workspace.excludeWidgets, 'widgetKey')
+      return _differenceBy(unusedWidgets,
+                           _map(this.props.workspace.excludeWidgets, key => ({widgetKey: key})),
+                           'widgetKey')
     }
 
     /**

--- a/src/components/ReviewTaskPane/ReviewTaskPane.js
+++ b/src/components/ReviewTaskPane/ReviewTaskPane.js
@@ -42,7 +42,7 @@ export const defaultWorkspaceSetup = function() {
       {i: generateWidgetId(), x: 4, y: 0, w: 8, h: 18},
     ],
     excludeWidgets: [
-      widgetDescriptor('TaskCompletionWidget'),
+      'TaskCompletionWidget',
     ]
   }
 }

--- a/src/components/TaskPane/TaskPane.js
+++ b/src/components/TaskPane/TaskPane.js
@@ -46,7 +46,7 @@ export const defaultWorkspaceSetup = function() {
       {i: generateWidgetId(), x: 0, y: 11, w: 4, h: 8},
     ],
     excludeWidgets: [
-      widgetDescriptor('TaskReviewWidget'),
+      'TaskReviewWidget',
     ]
   }
 }


### PR DESCRIPTION
* Remove newly excluded widgets from workspaces when loaded

* Change workspace `excludeWidgets` to simply reference widget key names
instead of complete widget descriptors