### PR TITLE
Minor withTargetUser and withUserMetrics changes

### DIFF
--- a/src/components/HOCs/WithUserMetrics/WithUserMetrics.js
+++ b/src/components/HOCs/WithUserMetrics/WithUserMetrics.js
@@ -62,7 +62,7 @@ export const WithUserMetrics = function(WrappedComponent) {
 
     componentDidMount() {
       if (this.props.targetUser) {
-        this.updateMetrics(this.props)
+        this.updateAllMetrics(this.props)
       }
     }
 

--- a/src/pages/Metrics/Metrics.js
+++ b/src/pages/Metrics/Metrics.js
@@ -139,4 +139,4 @@ class Metrics extends Component {
   }
 }
 
-export default WithStatus(WithTargetUser(WithUserMetrics(injectIntl(Metrics)), true))
+export default WithStatus(WithTargetUser(WithUserMetrics(injectIntl(Metrics)), false))


### PR DESCRIPTION
rename 'readAll' to limitToSuperUsers,
rename 'targetUserId()' to 'getTargetUserId()',
withUserMetrics calling old method this.updateMetrics,
withUserMetrics lowerCase can be called on null