### PR TITLE
Fix decommissioned widget pruning

### DIFF
--- a/src/components/HOCs/WithFeaturedChallenges/WithFeaturedChallenges.js
+++ b/src/components/HOCs/WithFeaturedChallenges/WithFeaturedChallenges.js
@@ -23,7 +23,7 @@ const WithFeaturedChallenges = WrappedComponent => {
 
     async componentDidMount() {
       const normalizedResults = await this.props.fetchFeaturedChallenges()
-      if (!_isEmpty(normalizedResults.entities)) {
+      if (normalizedResults && !_isEmpty(normalizedResults.entities)) {
         this.setState({
           featuredChallenges: _filter(_values(normalizedResults.entities.challenges),
                                       challenge => isUsableChallengeStatus(challenge))

--- a/src/components/WidgetGrid/WidgetGrid.js
+++ b/src/components/WidgetGrid/WidgetGrid.js
@@ -33,6 +33,10 @@ export class WidgetGrid extends Component {
     const widgetInstances =
       _map(this.props.workspace.widgets, (widgetConfiguration, index) => {
         const WidgetComponent = widgetComponent(widgetConfiguration)
+        if (!WidgetComponent) {
+          throw new Error(`Missing component for widget: ${widgetConfiguration.widgetKey}`)
+        }
+
         const widgetY = this.props.workspace.layout[index].y
         return (
           <div

--- a/src/services/Widget/Widget.js
+++ b/src/services/Widget/Widget.js
@@ -197,7 +197,7 @@ export const pruneDecommissionedWidgets = gridConfiguration => {
   const decommissioned = decommissionedWidgets(gridConfiguration)
 
   return decommissioned.length > 0 ?
-         pruneWidgets(gridConfiguration, decommissionedWidgets) :
+         pruneWidgets(gridConfiguration, decommissioned) :
          gridConfiguration
 }
 


### PR DESCRIPTION
* Fix typo that caused decommissioned widgets to not be properly pruned
from existing workspaces

* Explicitly throw exception if an attempt is made to render a missing
widget