### PR TITLE
Change skipping task to do nothing if status already set.

### DIFF
--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.test.js
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.test.js
@@ -91,7 +91,7 @@ test("mapDispatchToProps completeTask calls completeTask", () => {
 
   const mappedProps = mapDispatchToProps(dispatch, {history})
 
-  mappedProps.completeTask(task.id, challenge.id, completionStatus)
+  mappedProps.completeTask(task, challenge.id, completionStatus)
   expect(dispatch).toBeCalled()
   expect(completeTask).toBeCalledWith(task.id, challenge.id, completionStatus)
 })
@@ -105,8 +105,8 @@ test("completeTask calls addComment if comment present",  async () => {
 
   const mappedProps = mapDispatchToProps(dispatch, {history})
 
-  await mappedProps.completeTask(task.id, challenge.id, completionStatus, comment)
-  expect(addTaskComment).toHaveBeenLastCalledWith(task.id, comment, completionStatus)
+  await mappedProps.completeTask(task, challenge.id, completionStatus, comment)
+  expect(addTaskComment).toHaveBeenLastCalledWith(task, comment, completionStatus)
 })
 
 test("completeTask does not call addComment if no comment", async () => {
@@ -119,7 +119,7 @@ test("completeTask does not call addComment if no comment", async () => {
 
   const mappedProps = mapDispatchToProps(dispatch, {history})
 
-  await mappedProps.completeTask(task.id, challenge.id, completionStatus)
+  await mappedProps.completeTask(task, challenge.id, completionStatus)
   expect(addTaskComment).not.toHaveBeenCalled()
 })
 
@@ -131,7 +131,7 @@ test("completeTask calls loadRandomTaskFromChallenge without proximate task by d
 
   const mappedProps = mapDispatchToProps(dispatch, {history, challengeId: challenge.id})
 
-  await mappedProps.completeTask(task.id, challenge.id, completionStatus)
+  await mappedProps.completeTask(task, challenge.id, completionStatus)
   expect(loadRandomTaskFromChallenge).toBeCalledWith(challenge.id, undefined)
 })
 
@@ -143,7 +143,7 @@ test("completeTask calls loadRandomTaskFromChallenge with task if proximate load
 
   const mappedProps = mapDispatchToProps(dispatch, {history, challengeId: challenge.id})
 
-  await mappedProps.completeTask(task.id, challenge.id,
+  await mappedProps.completeTask(task, challenge.id,
                            completionStatus, "", TaskLoadMethod.proximity)
   expect(loadRandomTaskFromChallenge).toBeCalledWith(challenge.id, task.id)
 })
@@ -155,7 +155,7 @@ test("completeTask calls fetchChallengeActions", () => {
   }
 
   const mappedProps = mapDispatchToProps(dispatch, {history})
-  mappedProps.completeTask(task.id, challenge.id, completionStatus)
+  mappedProps.completeTask(task, challenge.id, completionStatus)
   jest.runOnlyPendingTimers()
 
   expect(fetchChallengeActions).toBeCalledWith(challenge.id)
@@ -173,7 +173,7 @@ test("completeTask routes the user to the new task if there is one", async () =>
 
   const mappedProps = mapDispatchToProps(dispatch, {history, challengeId: challenge.id})
 
-  await mappedProps.completeTask(task.id, challenge.id, completionStatus)
+  await mappedProps.completeTask(task, challenge.id, completionStatus)
   expect(history.push).toBeCalledWith(`/challenge/${challenge.id}/task/${nextTask.id}`)
 })
 
@@ -190,7 +190,7 @@ test("completeTask routes the user to the new task in a virtual challenge", asyn
   const mappedProps =
     mapDispatchToProps(dispatch, {history, virtualChallengeId: virtualChallenge.id})
 
-  await mappedProps.completeTask(task.id, challenge.id, completionStatus)
+  await mappedProps.completeTask(task, challenge.id, completionStatus)
   expect(history.push).toBeCalledWith(`/virtual/${virtualChallenge.id}/task/${nextTask.id}`)
 })
 
@@ -206,7 +206,7 @@ test("completeTask routes the user home if the next task isn't new", async () =>
 
   const mappedProps = mapDispatchToProps(dispatch, {history})
 
-  await mappedProps.completeTask(task.id, challenge.id, completionStatus)
+  await mappedProps.completeTask(task, challenge.id, completionStatus)
   expect(history.push).toBeCalledWith('/browse/challenges', {congratulate: true})
 })
 
@@ -220,6 +220,6 @@ test("completeTask routes the user home if there is no next task", async () => {
 
   const mappedProps = mapDispatchToProps(dispatch, {history})
 
-  await mappedProps.completeTask(task.id, challenge.id, completionStatus)
+  await mappedProps.completeTask(task, challenge.id, completionStatus)
   expect(history.push).toBeCalledWith('/browse/challenges', {congratulate: true})
 })

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -88,7 +88,7 @@ export class ActiveTaskControls extends Component {
                                         this.props.history)
     }
     else {
-      this.props.completeTask(this.props.task.id, this.props.task.parent.id,
+      this.props.completeTask(this.props.task, this.props.task.parent.id,
                               taskStatus, this.state.comment,
                               revisionSubmission? null : this.props.taskLoadBy,
                               this.props.user.id,

--- a/src/components/TaskPane/TaskPane.js
+++ b/src/components/TaskPane/TaskPane.js
@@ -73,9 +73,9 @@ export class TaskPane extends Component {
    * WithCurrentTask, but we intercept the call so that we can manage our
    * transition animation as the task prepares to complete.
    */
-  completeTask = (taskId, challengeId, taskStatus, comment, taskLoadBy, userId, needsReview) => {
-    this.setState({completingTask: taskId})
-    this.props.completeTask(taskId, challengeId, taskStatus, comment, taskLoadBy, userId, needsReview)
+  completeTask = (task, challengeId, taskStatus, comment, taskLoadBy, userId, needsReview) => {
+    this.setState({completingTask: task.id})
+    this.props.completeTask(task, challengeId, taskStatus, comment, taskLoadBy, userId, needsReview)
   }
 
   clearCompletingTask = () => {


### PR DESCRIPTION
When skipping a task, if the status has already been set then it will just go on to the next task. Comments will be saved.