### PR TITLE
Show bounding box on review browse map return

### DIFF
--- a/src/pages/Review/ReviewBrowseMap/ReviewBrowseMap.js
+++ b/src/pages/Review/ReviewBrowseMap/ReviewBrowseMap.js
@@ -148,7 +148,7 @@ export class ReviewBrowseMap extends Component {
     )
 
     if (!this.currentBounds && _get(this.props, 'reviewCriteria.boundingBox')) {
-      const bbox = _get(this.props, 'reviewCriteria.boundingBox').split(',')
+      const bbox = this.props.reviewCriteria.boundingBox.split(',')
       this.currentBounds = toLatLngBounds(bbox)
     }
 

--- a/src/pages/Review/ReviewBrowseMap/ReviewBrowseMap.js
+++ b/src/pages/Review/ReviewBrowseMap/ReviewBrowseMap.js
@@ -147,6 +147,11 @@ export class ReviewBrowseMap extends Component {
       <SourcedTileLayer key={layerId} source={layerSourceWithId(layerId)} zIndex={index + 2} />
     )
 
+    if (!this.currentBounds && _get(this.props, 'reviewCriteria.boundingBox')) {
+      const bbox = _get(this.props, 'reviewCriteria.boundingBox').split(',')
+      this.currentBounds = toLatLngBounds(bbox)
+    }
+
     const map =
       <EnhancedMap className="mr-z-0"
                    center={latLng(0, 0)}


### PR DESCRIPTION
When returning to the review browse map it will now set the map to the boundingBox parameter if there is one.