### PR TITLE
Fix mustache tags help for challenge instructions

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Messages.js
@@ -86,6 +86,9 @@ export default defineMessages({
     defaultMessage: "Instructions",
   },
 
+  // Note: dummy variable included to workaround react-intl
+  // [bug 1158](https://github.com/yahoo/react-intl/issues/1158)
+  // Just pass in an empty string for its value
   instructionDescription: {
     id: 'Admin.EditChallenge.form.instruction.description',
     defaultMessage: "The instruction tells a mapper how to resolve a Task in " +
@@ -96,7 +99,7 @@ export default defineMessages({
       "this field supports Markdown. You can also reference feature properties " +
       "from your GeoJSON with simple mustache tags: e.g. `\\{\\{address\\}\\}` would be " +
       "replaced with the value of the `address` property, allowing for basic " +
-      "customization of instructions for each task. This field is required.",
+      "customization of instructions for each task. This field is required. {dummy}",
   },
 
   checkinCommentLabel: {

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step1Schema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step1Schema.js
@@ -153,7 +153,7 @@ export const uiSchema = (intl, user, challengeData) => {
     },
     instruction: {
       "ui:field": "markdown",
-      "ui:help": intl.formatMessage(messages.instructionDescription),
+      "ui:help": intl.formatMessage(messages.instructionDescription, {dummy: ''}),
     },
     difficulty: {
       "ui:widget": "select",

--- a/src/components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
+++ b/src/components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
@@ -15,45 +15,6 @@ import 'react-tagsinput/react-tagsinput.css'
 import './RJSFFormFieldAdapter.scss'
 
 /**
- * CustomFieldTemplate returns an appropriate input field template for the
- * given react-jsonschema-form field data that is structured in a mostly
- * Bulma-compliant manner using Bulma classes. We don't have complete control
- * over the markup, so in some cases it's an approximation and we rely on the
- * css styling to fix things up.
- *
- * @see See [react-jsonschema-form](https://github.com/mozilla-services/react-jsonschema-form)
- */
-export const CustomFieldTemplate = props => {
-  // If the field has errors, mark the form context to let it know the
-  // form is not valid. This is necessary because, even though RJSF performs
-  // field-level validation at initialization, it does not inform any top-level
-  // handlers of these errors until the data is actually modified by the user.
-  if (_get(props, 'rawErrors.length', 0) > 0) {
-    props.formContext.isValid = false
-  }
-
-  // RJSF starts with an artificial 'root' field. We basically ignore it,
-  // just rendering the children within a wrapper div.
-  if (props.id === 'root') {
-    return <div className="form-fields-wrapper">{props.children}</div>
-  }
-
-  // Decide which template to render based on the ui:widget field in the
-  // given uiSchema. It's recommended that an explicit widget type is set
-  // in the uiSchema for anything other than a basic text input in order
-  // to ensure the proper template is used.
-  switch(_get(props, 'uiSchema.ui:widget')) {
-    case 'select':
-      return SelectField(props)
-    case 'checkbox':
-    case 'radio':
-      return CheckboxField(props)
-    default:
-      return InputField(props)
-  }
-}
-
-/**
  * fieldset tags can't be styled using flexbox or grid in Chrome, so this
  * template attempts to render the fields the same way as the default but using
  * a div with class "fieldset" instead of a fieldset. To use it, set
@@ -145,28 +106,6 @@ export const CustomSelectWidget = function(props) {
 }
 
 /**
- * SelectField is a Bulma template for RJSF select fields
- */
-export const SelectField = ({id, label, required, rawDescription, children}) => (
-  <div className="field is-horizontal">
-    <div className="field-label">
-      <label className="label">
-        {label}
-        {required ? <span className='required'>*</span> : null}
-      </label>
-    </div>
-    <div className="field-body">
-      <div className="field">
-        <div className="control">
-          <div className="select">{children}</div>
-          <MarkdownContent className="help" markdown={rawDescription} />
-        </div>
-      </div>
-    </div>
-  </div>
-)
-
-/**
  * MarkdownEditField renders a textarea and markdown preview side-by-side.
  */
 export class MarkdownEditField extends Component {
@@ -190,36 +129,6 @@ export class MarkdownEditField extends Component {
   }
 }
 
-/**
- * InputField is a Bulma template for RJSF text input fields. It's also compatible
- * with textarea fields with some css tweaks.
- */
-export const InputField = ({id, label, required, rawDescription, rawErrors, children}) => (
-  <div className="field is-horizontal">
-    <div className="field-label">
-      <label className="label">
-        {label}
-        {required ? <span className='required'>*</span> : null}
-      </label>
-    </div>
-    <div className="field-body">
-      <div className="field">
-        <div className="control">
-          {_get(rawErrors, 'length', 0) > 0 &&
-            <div className="errors">
-              {_map(rawErrors, (error, index) =>
-                <div className="error" key={index}>{error}</div>
-              )}
-            </div>
-          }
-          {children}
-          <MarkdownContent className="help" markdown={rawDescription} />
-        </div>
-      </div>
-    </div>
-  </div>
-)
-
 export const TagsInputField = props => {
   return (
     <div className="tags-field">
@@ -231,29 +140,6 @@ export const TagsInputField = props => {
     </div>
   )
 }
-
-/**
- * CheckboxField is a Bulma template for RJSF checkbox fields. It's also compatible
- * with radio group fields with some css tweaks.
- */
-export const CheckboxField = ({id, label, required, rawDescription, children}) => (
-  <div className="field is-horizontal">
-    <div className="field-label">
-      <label className="label">
-        {label}
-        {required ? <span className='required'>*</span> : null}
-      </label>
-    </div>
-    <div className="field-body">
-      <div className="field">
-        <div className="control">
-          {children}
-          <MarkdownContent className="help" markdown={rawDescription} />
-        </div>
-      </div>
-    </div>
-  </div>
-)
 
 /**
  * Provides a custom Dropzone widget for extracting *text* content (like


### PR DESCRIPTION
* Work around react-intl bug so that mustache tags example in the form
help for challenge instructions renders properly in production

* Remove old custom Bulma form fields from RJSFFormFieldAdapter that are
no longer in use