### PR TITLE
Basic project search for mappers

### DIFF
--- a/src/components/HOCs/WithFilteredChallenges/WithFilteredChallenges.js
+++ b/src/components/HOCs/WithFilteredChallenges/WithFilteredChallenges.js
@@ -9,11 +9,14 @@ import { challengePassesKeywordFilter }
        from '../../../services/Challenge/ChallengeKeywords/ChallengeKeywords'
 import { challengePassesLocationFilter }
        from '../../../services/Challenge/ChallengeLocation/ChallengeLocation'
+import { challengePassesProjectFilter }
+       from '../../../services/Challenge/ChallengeProject/ChallengeProject'
 
 const allFilters = [
   challengePassesDifficultyFilter,
   challengePassesKeywordFilter,
   challengePassesLocationFilter,
+  challengePassesProjectFilter,
 ]
 
 /**

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -225,7 +225,7 @@ export const performChallengeSearch = function(searchObject, limit=RESULTS_PER_P
  * @param {object} criteria - criteria to include in search. Can include keys:
  *                            'searchQuery', 'filters', 'onlyEnabled', 'bounds'
  *                            'sortCriteria.sortBy', 'sortCrtiera.direction',
-                              'page','challengeStatus'
+                              'page', 'challengeStatus'
  * @param {number} limit
  */
 export const extendedFind = function(criteria, limit=RESULTS_PER_PAGE) {
@@ -247,6 +247,7 @@ export const extendedFind = function(criteria, limit=RESULTS_PER_PAGE) {
     // setup query parameters desired by server.
     // ce: limit to enabled challenges
     // pe: limit to enabled projects
+    // ps: limit to projects matching name search
     // cs: query string
     // cd: challenge difficulty
     // ct: keywords/tags (comma-separated string)
@@ -258,6 +259,10 @@ export const extendedFind = function(criteria, limit=RESULTS_PER_PAGE) {
 
     if (_isFinite(filters.difficulty)) {
       queryParams.cd = filters.difficulty
+    }
+
+    if (_isString(filters.project)) {
+      queryParams.ps = filters.project
     }
 
     // Keywords/tags can come from both the the query and the filter, so we need to

--- a/src/services/Challenge/ChallengeProject/ChallengeProject.js
+++ b/src/services/Challenge/ChallengeProject/ChallengeProject.js
@@ -1,0 +1,27 @@
+import _get from 'lodash/get'
+import _includes from 'lodash/includes'
+import _isEmpty from 'lodash/isEmpty'
+
+/**
+ * Returns true if the given challenge passes the project-name filter in the
+ * given challenge filters
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
+export const challengePassesProjectFilter = function(challengeFilters,
+                                                     challenge,
+                                                     searchCriteria) {
+  if (!_isEmpty(challengeFilters.project)) {
+    if (!_get(challenge, 'parent.displayName')) {
+      return false
+    }
+
+    // Just look for a basic case-insensitive substring
+    if (!_includes(challenge.parent.displayName.toLowerCase(),
+                   challengeFilters.project.toLowerCase())) {
+      return false
+    }
+  }
+
+  return true
+}


### PR DESCRIPTION
* Support `p/` command in challenge search box to execute a project-name
search

* Allow optional execution of search-box commands while search is still
being typed/constructed