### PR TITLE
Make JOSM attic layer policy no upload/download

### DIFF
--- a/src/services/Overpass/Overpass.js
+++ b/src/services/Overpass/Overpass.js
@@ -25,7 +25,7 @@ export const viewAtticOverpass = (selectedEditor, actionDate, bounds, ignoreAtti
   if (isJosmEditor(selectedEditor)) {
     const overpassApiURL = 'https://overpass-api.de/api/interpreter?data=' + encodeURIComponent(query)
     sendJOSMCommand('http://127.0.0.1:8111/import?new_layer=true&layer_name=' +
-                     adjustedDateString + '&layer_locked=true&url=' +
+                     adjustedDateString + '&upload_policy=never&download_policy=never&url=' +
                      encodeURIComponent(overpassApiURL))
   }
   else {


### PR DESCRIPTION
* Change the JOSM layer policy for attic queries from locked to no
uploads and no downloads