### PR TITLE
Use prioritizedTask API for fetching nearby tasks

### DIFF
--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -279,23 +279,14 @@ export const loadRandomTaskFromChallenge = function(challengeId,
                                                     priorTaskId,
                                                     includeMapillary=false) {
   return function(dispatch) {
-    // We use different API endpoints depending on whether a priorTaskId is
-    // given (indicating that a proximate/nearby task is desired)
-    let endpoint = null
-    if (_isFinite(priorTaskId)) {
-      endpoint = new Endpoint(api.challenge.randomTask, {
-        schema: [ taskSchema() ],
-        variables: {id: challengeId},
-        params: {proximity: priorTaskId, mapillary: includeMapillary},
-      })
-    }
-    else {
-      endpoint = new Endpoint(api.challenge.prioritizedTask, {
-        schema: [ taskSchema() ],
-        variables: {id: challengeId},
-        params: {mapillary: includeMapillary},
-      })
-    }
+    const endpoint = new Endpoint(api.challenge.prioritizedTask, {
+      schema: [ taskSchema() ],
+      variables: { id: challengeId },
+      params: {
+        proximity: _isFinite(priorTaskId) ? priorTaskId : undefined,
+        mapillary: includeMapillary
+      },
+    })
 
     return retrieveChallengeTask(dispatch, endpoint)
   }


### PR DESCRIPTION
> Note: this is dependent on backend PR maproulette/maproulette2#569

* Use prioritizedTask API for fetching nearby tasks so that task
priority will be honored