### PR TITLE
Add to admin challenge list ability to filter which show in metrics.

### DIFF
--- a/src/components/AdminPane/AdminPane.scss
+++ b/src/components/AdminPane/AdminPane.scss
@@ -38,6 +38,30 @@
     }
   }
 
+  .item-tally-toggle {
+    max-width: 50px;
+    float: right;
+    margin-left: 18px;
+    margin-right: 10px;
+    margin-top: 10px;
+
+    svg.icon {
+      height: 18px;
+      width: auto;
+      fill: $grey-lightest;
+      vertical-align: middle;
+
+      &.turnOff {
+        fill: $blue;
+      }
+
+      &.partialOn {
+        fill: $blue;
+        opacity: 0.5;
+      }
+    }
+  }
+
   .tabs {
     ul {
       border-bottom: 2px solid $grey-lightest-less;
@@ -286,6 +310,21 @@
             fill: $grey-lightest;
             vertical-align: middle;
             transform: rotate(10deg);
+
+            &.enabled {
+              fill: $blue;
+            }
+          }
+        }
+
+        .column.item-tallied {
+          max-width: 50px;
+
+          svg.icon {
+            height: 18px;
+            width: auto;
+            fill: $grey-lightest;
+            vertical-align: middle;
 
             &.enabled {
               fill: $blue;

--- a/src/components/AdminPane/HOCs/WithChallengeMetrics/WithChallengeMetrics.js
+++ b/src/components/AdminPane/HOCs/WithChallengeMetrics/WithChallengeMetrics.js
@@ -14,6 +14,9 @@ import _sortBy from 'lodash/sortBy'
 import _reverse from 'lodash/reverse'
 import parse from 'date-fns/parse'
 import WithComputedMetrics from '../../HOCs/WithComputedMetrics/WithComputedMetrics'
+import WithDashboardEntityFilter
+       from '../../HOCs/WithDashboardEntityFilter/WithDashboardEntityFilter'
+
 import { TaskStatus }
        from '../../../../services/Task/TaskStatus/TaskStatus'
 
@@ -71,5 +74,21 @@ const WithChallengeMetrics = function(WrappedComponent) {
   }
 }
 
+export const includeChallengeInMetrics = function(challenge, manager, tallied, challengeFilters, props) {
+  const tallyMarks = tallied(props.project.id)
+  if (tallyMarks && tallyMarks.length > 0 && tallyMarks.indexOf(challenge.id) === -1) {
+    return false
+  }
+
+  return true
+}
+
 export default WrappedComponent =>
-  WithComputedMetrics(injectIntl(WithChallengeMetrics(WrappedComponent)))
+  WithDashboardEntityFilter(
+    WithComputedMetrics(injectIntl(WithChallengeMetrics(WrappedComponent))),
+    'challenge',
+    'challenges',
+    'talliedChallenges',
+    'challenges',
+    includeChallengeInMetrics
+  )

--- a/src/components/AdminPane/HOCs/WithDashboardEntityFilter/WithDashboardEntityFilter.js
+++ b/src/components/AdminPane/HOCs/WithDashboardEntityFilter/WithDashboardEntityFilter.js
@@ -65,7 +65,7 @@ const WithDashboardEntityFilter = function(WrappedComponent,
         _get(this.props.currentConfiguration.filters, this.filterFieldName(), {})
 
       const filteredDashboardEntities = _filter(this.props[itemsProp], entities =>
-        passesFilterFunction(entities, manager, this.props[pinsProp], filters)
+        passesFilterFunction(entities, manager, this.props[pinsProp], filters, this.props)
       )
 
       // Generate prop names based on filter type.

--- a/src/components/AdminPane/HOCs/WithManageableProjects/WithManageableProjects.js
+++ b/src/components/AdminPane/HOCs/WithManageableProjects/WithManageableProjects.js
@@ -24,6 +24,7 @@ import { fetchProjectChallengeListing }
 import WithCurrentUser from '../../../HOCs/WithCurrentUser/WithCurrentUser'
 import AsManager from '../../../../interactions/User/AsManager'
 import WithPinned from '../../HOCs/WithPinned/WithPinned'
+import WithTallied from '../../HOCs/WithTallied/WithTallied'
 
 /**
  * WithManageableProjects makes available to the WrappedComponent all the
@@ -140,5 +141,8 @@ const mapDispatchToProps = dispatch => {
 
 export default (WrappedComponent, includeChallenges) =>
   connect(mapStateToProps, mapDispatchToProps)(
-    WithCurrentUser(WithPinned(WithManageableProjects(WrappedComponent, includeChallenges)))
+    WithCurrentUser(
+      WithPinned(
+        WithTallied(
+          WithManageableProjects(WrappedComponent, includeChallenges))))
   )

--- a/src/components/AdminPane/HOCs/WithTallied/WithTallied.js
+++ b/src/components/AdminPane/HOCs/WithTallied/WithTallied.js
@@ -1,0 +1,140 @@
+import React, { Component } from 'react'
+
+/**
+ * WithTallied provides the WrappedComponent with challenges that
+ * the managing user has marked as to be "tallied" in the admin area
+ * so they can be included when calculating metrics.
+ *
+ * @author [Kelli Rotstan](https://github.com/krotstan)
+ */
+export const WithTallied = function(WrappedComponent) {
+  return class extends Component {
+    state = {
+      searchActive: false,
+      searchTallies: {}
+    }
+
+    /**
+     * Retrieves all tallied challenges from the user's app settings
+     *
+     * @private
+     */
+    allTalliedEntities = () => {
+      if (this.state.searchActive) {
+          return this.state.searchTallies
+      }
+      return this.props.getUserAppSetting(this.props.user, 'tallied') || {}
+    }
+
+    /**
+     * Retrieves tallied challenges from the given parent
+     *
+     * @private
+     */
+    tallied = (parentId) => {
+      return this.allTalliedEntities()[parentId]
+    }
+
+    /**
+     * Updates the tallyMarks for a parentId.
+     *
+     * @private
+     */
+    updateTallyMarks = (parentId, newTallyMarks) => {
+      const newTallyStore =
+          Object.assign({}, this.allTalliedEntities(), {
+            [parentId]: newTallyMarks,
+          })
+
+      if (this.state.searchActive) {
+        this.setState({searchTallies: newTallyStore})
+      }
+      else {
+        this.props.updateUserAppSetting(this.props.user.id, {
+          'tallied': newTallyStore
+        })
+      }
+    }
+
+    /**
+     * Toggles the tallied status of the given challenge
+     *
+     * @private
+     */
+    toggleTallyMark = (parentId, challengeId) => {
+      const newTallyMarks = new Set(this.tallied(parentId))
+      newTallyMarks.has(challengeId) ? newTallyMarks.delete(challengeId) :
+                                    newTallyMarks.add(challengeId)
+      this.updateTallyMarks(parentId, [...newTallyMarks])
+    }
+
+    /**
+     * Resets all tallyMarks for a project.
+     *
+     * @private
+     */
+    resetTallyMarks = (parentId) => {
+      if (this.state.searchActive) {
+        this.setState({searchTallies: {}})
+      }
+      else {
+        this.updateTallyMarks(parentId, [])
+      }
+    }
+
+    /**
+     * Toggles whether we are in searh mode. When in search
+     * mode we do not want to update the user's app settings.
+     *
+     * @private
+     */
+    toggleSearchTallies = (parentId, updateChallenges = null) => {
+      const newSearchActive = !this.state.searchActive
+      if (updateChallenges) {
+        const newTallyStore =
+            Object.assign({}, this.allTalliedEntities(), {
+              [parentId]: updateChallenges,
+            })
+
+        if (newSearchActive) {
+          this.setState({searchActive: newSearchActive, searchTallies: newTallyStore})
+        }
+        else {
+          this.props.updateUserAppSetting(this.props.user.id, {
+            'tallied': newTallyStore
+          })
+          this.setState({searchActive: newSearchActive})
+        }
+      }
+      else {
+        this.setState({searchActive: newSearchActive})
+      }
+    }
+
+    /**
+     * Returns whether this challenge is marked as tallied.
+     *
+     * @private
+     */
+    showAsTallied = (parentId, challengeId) => {
+      return (this.tallied(parentId) || []).indexOf(challengeId) !== -1
+    }
+
+    render() {
+      // Don't render if we're still fetching user data
+      if (this.props.checkingLoginStatus || !this.props.user.isLoggedIn) {
+        return null
+      }
+
+      return <WrappedComponent
+              {...this.props}
+              talliedChallenges={this.tallied}
+              toggleChallengeTally={this.toggleTallyMark}
+              updateTallyMarks={this.updateTallyMarks}
+              showAsTallied={this.showAsTallied}
+              toggleSearchTallies={this.toggleSearchTallies} />
+    }
+  }
+}
+
+export default WrappedComponent => WithTallied(WrappedComponent)

--- a/src/components/AdminPane/Manage/ChallengeCard/ChallengeCard.js
+++ b/src/components/AdminPane/Manage/ChallengeCard/ChallengeCard.js
@@ -40,6 +40,17 @@ export default class ChallengeCard extends Component {
                           sym='pin-icon' />
             </div>
           </div>
+
+          {!this.props.hideTallyControl &&
+            <div className='column is-narrow item-tallied'>
+              <div className="clickable"
+                   onClick={() => this.props.toggleChallengeTally(this.props.project.id, this.props.challenge.id)}>
+                <SvgSymbol className={classNames('icon', {enabled: this.props.isTallied})}
+                            viewBox='0 0 20 20'
+                            sym='chart-icon' />
+              </div>
+            </div>
+          }
         </div>
       </div>
     )

--- a/src/components/AdminPane/Manage/ChallengeList/ChallengeList.js
+++ b/src/components/AdminPane/Manage/ChallengeList/ChallengeList.js
@@ -33,6 +33,8 @@ export default class ChallengeList extends Component {
                  key={challenge.id}
                  challenge={challenge}
                  isPinned={this.props.pinnedChallenges.indexOf(challenge.id) !== -1}
+                 isTallied={this.props.showAsTallied(this.props.project.id, challenge.id)}
+                 hideTallyControl={this.props.hideTallyControl || this.props.suppressControls}
                  link={link} />
       }),
       challengeCard => !challengeCard.props.isPinned

--- a/src/components/AdminPane/Manage/ProjectCard/ProjectCard.js
+++ b/src/components/AdminPane/Manage/ProjectCard/ProjectCard.js
@@ -46,7 +46,7 @@ export class ProjectCard extends Component {
             <FormattedMessage {...messages.challengePreviewHeader} />
           </div>
 
-          <ChallengeList challenges={matchingChallenges} suppressControls
+          <ChallengeList challenges={matchingChallenges} suppressControls hideTallyControl
                          {..._omit(this.props, 'challenges')} />
         </div>
       )
@@ -55,7 +55,7 @@ export class ProjectCard extends Component {
       projectBody = (
         <div className='project-card__project-content'>
           <ChallengeList challenges={project.childChallenges(this.props.challenges)}
-                         suppressControls={!manager.canWriteProject(project)}
+                         suppressControls={!manager.canWriteProject(project)} hideTallyControl
                          {..._omit(this.props, 'challenges')} />
         </div>
       )

--- a/src/components/AdminPane/Manage/ProjectDashboard/ProjectDashboard.js
+++ b/src/components/AdminPane/Manage/ProjectDashboard/ProjectDashboard.js
@@ -11,8 +11,6 @@ import WithManageableProjects
        from '../../HOCs/WithManageableProjects/WithManageableProjects'
 import WithCurrentProject
        from '../../HOCs/WithCurrentProject/WithCurrentProject'
-import WithChallengeMetrics
-       from '../../HOCs/WithChallengeMetrics/WithChallengeMetrics'
 import WithWidgetWorkspaces
        from '../../../HOCs/WithWidgetWorkspaces/WithWidgetWorkspaces'
 import WithDashboardEntityFilter
@@ -155,9 +153,7 @@ WithManageableProjects(
   WithCurrentProject(
     WithWidgetWorkspaces(
       WithDashboardEntityFilter(
-        WithChallengeMetrics(
-          injectIntl(ProjectDashboard),
-        ),
+        injectIntl(ProjectDashboard),
         'challenge',
         'challenges',
         'pinnedChallenges',

--- a/src/components/AdminPane/Manage/Widgets/BurndownChartWidget/BurndownChartWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/BurndownChartWidget/BurndownChartWidget.js
@@ -4,6 +4,8 @@ import { WidgetDataTarget, registerWidgetType }
        from '../../../../../services/Widget/Widget'
 import BurndownChart from '../../BurndownChart/BurndownChart'
 import QuickWidget from '../../../../QuickWidget/QuickWidget'
+import WithChallengeMetrics
+       from '../../../HOCs/WithChallengeMetrics/WithChallengeMetrics'
 import messages from './Messages'
 import './BurndownChartWidget.scss'
 
@@ -34,4 +36,4 @@ export default class BurndownChartWidget extends Component {
   }
 }
 
-registerWidgetType(BurndownChartWidget, descriptor)
+registerWidgetType(WithChallengeMetrics(BurndownChartWidget), descriptor)

--- a/src/components/AdminPane/Manage/Widgets/CalendarHeatmapWidget/CalendarHeatmapWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/CalendarHeatmapWidget/CalendarHeatmapWidget.js
@@ -6,6 +6,8 @@ import CalendarHeatmap from '../../CalendarHeatmap/CalendarHeatmap'
 import PastDurationSelector
        from '../../../../PastDurationSelector/PastDurationSelector'
 import QuickWidget from '../../../../QuickWidget/QuickWidget'
+import WithChallengeMetrics
+       from '../../../HOCs/WithChallengeMetrics/WithChallengeMetrics'
 import messages from './Messages'
 import './CalendarHeatmapWidget.scss'
 
@@ -50,4 +52,4 @@ export default class CalendarHeatmapWidget extends Component {
   }
 }
 
-registerWidgetType(CalendarHeatmapWidget, descriptor)
+registerWidgetType(WithChallengeMetrics(CalendarHeatmapWidget), descriptor)

--- a/src/components/AdminPane/Manage/Widgets/ChallengeListWidget/ChallengeListWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/ChallengeListWidget/ChallengeListWidget.js
@@ -1,6 +1,10 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage, injectIntl } from 'react-intl'
+import classNames from 'classnames'
+import _get from 'lodash/get'
+import _map from 'lodash/map'
+import _difference from 'lodash/difference'
 import { WidgetDataTarget, registerWidgetType }
        from '../../../../../services/Widget/Widget'
 import { extendedFind } from '../../../../../services/Challenge/Challenge'
@@ -10,6 +14,7 @@ import WithSearch from '../../../../HOCs/WithSearch/WithSearch'
 import SearchBox from '../../../../SearchBox/SearchBox'
 import ChallengeList from '../../ChallengeList/ChallengeList'
 import QuickWidget from '../../../../QuickWidget/QuickWidget'
+import SvgSymbol from '../../../../SvgSymbol/SvgSymbol'
 import messages from './Messages'
 import './ChallengeListWidget.scss'
 
@@ -27,26 +32,77 @@ const descriptor = {
 }
 
 // Setup child components with needed HOCs.
+class ChallengeSearchBox extends Component {
+  componentDidUpdate(prevProps) {
+    if (_get(this.props, 'searchQuery.query') !==
+        _get(prevProps, 'searchQuery.query')) {
+      if (!_get(this.props, 'searchQuery.query')) {
+        this.props.toggleSearchTallies(this.props.projectId)
+      }
+      else if (!_get(prevProps, 'searchQuery.query')) {
+        this.props.toggleSearchTallies(this.props.projectId, _map(this.props.challenges, (c) => c.id))
+      }
+    }
+  }
+
+  render() {
+    return <SearchBox {...this.props} />
+  }
+}
+
 const ChallengeSearch = WithSearch(
-  SearchBox,
+  ChallengeSearchBox,
   'challengeListWidget',
   searchCriteria =>
     extendedFind({searchQuery: searchCriteria.query, onlyEnabled: false}, 1000),
 )
 
 export default class ChallengeListWidget extends Component {
+  componentDidUpdate(prevProps) {
+    if (this.props.challenges && !this.props.talliedChallenges(this.props.project.id)) {
+      this.props.updateTallyMarks(this.props.project.id, _map(this.props.challenges, (c) => c.id))
+    }
+  }
+
+  toggleAllTallies = () => {
+    if ((this.props.talliedChallenges(this.props.project.id) || []).length ===
+        (this.props.challenges || []).length) {
+      this.props.updateTallyMarks(this.props.project.id, [])
+    }
+    else {
+      this.props.updateTallyMarks(this.props.project.id, _map(this.props.challenges, (c) => c.id))
+    }
+  }
+
   render() {
-    const searchControl = this.props.projects.length === 0 ? null : (
-      <ChallengeSearch className="mr-p-2 mr-text-grey-light mr-border mr-border-grey-light mr-rounded-sm"
-                       inputClassName="mr-text-grey mr-leading-normal"
-                       placeholder={this.props.intl.formatMessage(messages.searchPlaceholder)} />
+    const tallied = this.props.talliedChallenges(this.props.project.id) || []
+    const allEnabled = _difference(_map(this.props.challenges, c => c.id), tallied).length === 0
+    const someEnabled = tallied.length !== 0
+
+    const rightHeaderControls = this.props.projects.length === 0 ? null : (
+      <div className=''>
+        <div className='item-tally-toggle'>
+          <div className="clickable" onClick={this.toggleAllTallies}>
+            <SvgSymbol className={classNames('icon', {turnOff: allEnabled, partialOn: someEnabled && !allEnabled})}
+                        viewBox='0 0 20 20'
+                        sym='chart-icon' />
+          </div>
+        </div>
+        <ChallengeSearch className="mr-p-2 mr-text-grey-light mr-border mr-border-grey-light mr-rounded-sm"
+                         inputClassName="mr-text-grey mr-leading-normal"
+                         toggleSearchTallies={this.props.toggleSearchTallies}
+                         challenges={this.props.challenges}
+                         projectId={this.props.project.id}
+                         placeholder={this.props.intl.formatMessage(messages.searchPlaceholder)} />
+
+      </div>
     )
 
     return (
       <QuickWidget {...this.props}
                   className="challenge-list-widget"
                   widgetTitle={<FormattedMessage {...messages.title} />}
-                  rightHeaderControls={searchControl}>
+                  rightHeaderControls={rightHeaderControls}>
         <ChallengeList {...this.props}
                        challenges={this.props.challenges} />
       </QuickWidget>

--- a/src/components/AdminPane/Manage/Widgets/StatusRadarWidget/StatusRadarWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/StatusRadarWidget/StatusRadarWidget.js
@@ -4,6 +4,8 @@ import { WidgetDataTarget, registerWidgetType }
        from '../../../../../services/Widget/Widget'
 import CompletionRadar from '../../CompletionRadar/CompletionRadar'
 import QuickWidget from '../../../../QuickWidget/QuickWidget'
+import WithChallengeMetrics
+       from '../../../HOCs/WithChallengeMetrics/WithChallengeMetrics'
 import messages from './Messages'
 import './StatusRadarWidget.scss'
 
@@ -31,4 +33,4 @@ export default class StatusRadarWidget extends Component {
   }
 }
 
-registerWidgetType(StatusRadarWidget, descriptor)
+registerWidgetType(WithChallengeMetrics(StatusRadarWidget), descriptor)

--- a/src/components/Sprites/Sprites.js
+++ b/src/components/Sprites/Sprites.js
@@ -213,6 +213,9 @@ export default function() {
         <symbol id="layers-icon" viewBox="0 0 20 20">
           <path d="M10 1l10 6-10 6L0 7l10-6zm6.67 10L20 13l-10 6-10-6 3.33-2L10 15l6.67-4z" />
         </symbol>
+        <symbol id="chart-icon" viewBox="0 0 20 20">
+          <path d="M4.13 12H4a2 2 0 1 0 1.8 1.11L7.86 10a2.03 2.03 0 0 0 .65-.07l1.55 1.55a2 2 0 1 0 3.72-.37L15.87 8H16a2 2 0 1 0-1.8-1.11L12.14 10a2.03 2.03 0 0 0-.65.07L9.93 8.52a2 2 0 1 0-3.72.37L4.13 12zM0 4c0-1.1.9-2 2-2h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V4z"/>
+        </symbol>
         <symbol id="home-icon" viewBox="0 0 71 80">
           <g
             id="Challenges"

--- a/src/components/Widgets/CompletionProgressWidget/CompletionProgressWidget.js
+++ b/src/components/Widgets/CompletionProgressWidget/CompletionProgressWidget.js
@@ -4,6 +4,8 @@ import { WidgetDataTarget, registerWidgetType }
        from '../../../services/Widget/Widget'
 import ChallengeProgress from '../../ChallengeProgress/ChallengeProgress'
 import QuickWidget from '../../QuickWidget/QuickWidget'
+import WithChallengeMetrics
+       from '../../AdminPane/HOCs/WithChallengeMetrics/WithChallengeMetrics'
 import messages from './Messages'
 
 const descriptor = {
@@ -35,4 +37,5 @@ export default class CompletionProgressWidget extends Component {
   }
 }
 
-registerWidgetType(CompletionProgressWidget, descriptor)
+registerWidgetType(
+  WithChallengeMetrics(CompletionProgressWidget), descriptor)


### PR DESCRIPTION
Adds a metrics toggle for each challenge in the challenge list of the admin project view. Those challenges toggled to include in metrics will be stored in the user's app settings (except when doing a name search on the challenges).