### PR TITLE
Remove heatmap from project dashboard

### DIFF
--- a/src/components/AdminPane/HOCs/WithChallengeMetrics/WithChallengeMetrics.js
+++ b/src/components/AdminPane/HOCs/WithChallengeMetrics/WithChallengeMetrics.js
@@ -75,7 +75,7 @@ const WithChallengeMetrics = function(WrappedComponent) {
 }
 
 export const includeChallengeInMetrics = function(challenge, manager, tallied, challengeFilters, props) {
-  const tallyMarks = tallied(props.project.id)
+  const tallyMarks = tallied(_get(props.project, 'id'))
   if (tallyMarks && tallyMarks.length > 0 && tallyMarks.indexOf(challenge.id) === -1) {
     return false
   }

--- a/src/components/AdminPane/Manage/Widgets/CalendarHeatmapWidget/CalendarHeatmapWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/CalendarHeatmapWidget/CalendarHeatmapWidget.js
@@ -14,7 +14,7 @@ import './CalendarHeatmapWidget.scss'
 const descriptor = {
   widgetKey: 'CalendarHeatmapWidget',
   label: messages.label,
-  targets: [WidgetDataTarget.challenges, WidgetDataTarget.challenge],
+  targets: [WidgetDataTarget.challenge],
   defaultWidth: 8,
   defaultHeight: 7,
   minWidth: 5,


### PR DESCRIPTION
Currently server only returns activity for public challenges when
supplying a project id.