### PR TITLE
Fix reviewed date picker in Safari

### DIFF
--- a/src/components/IntlDatePicker/IntlDatePicker.js
+++ b/src/components/IntlDatePicker/IntlDatePicker.js
@@ -13,10 +13,10 @@ export default class IntlDatePicker extends Component {
   // This is a funky method to extract the date format to use for the date picker
   // since react intl will not give us the date format directly
   extractDateFormat() {
-    const isoString = '2018-12-31 12:00:00' // example date
+    const isoString = '2018-12-31T12:00:00.000Z' // example date
 
     const intlString = this.props.intl.formatDate(isoString) // generate a formatted date
-    const dateParts = isoString.split(' ')[0].split('-') // prepare to replace with pattern parts
+    const dateParts = isoString.split('T')[0].split('-') // prepare to replace with pattern parts
 
     return intlString
       .replace(dateParts[2], 'dd')


### PR DESCRIPTION
Fix reviewed date picker in Safari. Safari was confused by example date format given.