### PR TITLE
Add support for filtering metrics by admin tasks table

### DIFF
--- a/src/components/AdminPane/HOCs/WithCurrentChallenge/WithCurrentChallenge.js
+++ b/src/components/AdminPane/HOCs/WithCurrentChallenge/WithCurrentChallenge.js
@@ -138,8 +138,9 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   fetchChallengeActivity: (challengeId, startDate, endDate) =>
     dispatch(fetchChallengeActivity(challengeId, startDate, endDate)),
 
-  fetchChallengeActions: challengeId =>
-    dispatch(fetchChallengeActions(challengeId)),
+  fetchChallengeActions: (challengeId, suppressReceive, criteria) => {
+    return dispatch(fetchChallengeActions(challengeId, suppressReceive, criteria))
+  },
 })
 
 export default (WrappedComponent, includeTasks) =>

--- a/src/components/Widgets/CompletionProgressWidget/CompletionProgressWidget.js
+++ b/src/components/Widgets/CompletionProgressWidget/CompletionProgressWidget.js
@@ -22,7 +22,7 @@ const descriptor = {
   defaultHeight: 7,
 }
 
-const ChallengeProgressWithMetrics = WithChallengeMetrics(ChallengeProgress)
+const ChallengeProgressWithMetrics = WithChallengeMetrics(ChallengeProgress, true)
 
 export default class CompletionProgressWidget extends Component {
   render() {

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -309,11 +309,24 @@ export const extendedFind = function(criteria, limit=RESULTS_PER_PAGE) {
  * Fetch action metrics for the given challenge (or all challenges
  * if none is given).
  */
-export const fetchChallengeActions = function(challengeId = null, suppressReceive = false) {
+export const fetchChallengeActions = function(challengeId = null, suppressReceive = false, criteria) {
+  const searchParameters = {}
+  if (criteria) {
+    if (criteria.status) {
+      searchParameters.tStatus = criteria.status
+    }
+    if (criteria.reviewStatus) {
+      searchParameters.trStatus = criteria.reviewStatus
+    }
+    if (criteria.priorities) {
+      searchParameters.priority = criteria.priorities
+    }
+  }
+
   return function(dispatch) {
     const challengeActionsEndpoint = new Endpoint(
       _isFinite(challengeId) ? api.challenge.actions : api.challenges.actions,
-      {schema: [ challengeSchema() ], variables: {id: challengeId}}
+      {schema: [ challengeSchema() ], variables: {id: challengeId}, params:{...searchParameters}}
     )
 
     return challengeActionsEndpoint.execute().then(normalizedResults => {

--- a/src/services/Task/TaskReview/TaskReview.js
+++ b/src/services/Task/TaskReview/TaskReview.js
@@ -96,7 +96,7 @@ export const receiveReviewClusters = function(clusters, status=RequestStatus.suc
         dispatch(receiveReviewMetrics(normalizedResults[0], RequestStatus.success))
       }
 
-      return normalizedResults
+      return normalizedResults[0]
     }).catch((error) => {
       console.log(error.response || error)
     })
@@ -247,6 +247,9 @@ export const setupFilterSearchParameters = (filters, boundingBox, savedChallenge
   }
   if (filters.status && filters.status !== "all") {
     searchParameters.tStatus = filters.status
+  }
+  if (filters.priorities && filters.priorities !== "all") {
+    searchParameters.priorities = filters.priorities
   }
   if (filters.reviewStatus && filters.reviewStatus !== "all") {
     searchParameters.trStatus = filters.reviewStatus


### PR DESCRIPTION
Admin task tables filters by priority, taskStatus and taskReview Status. Adds support to filter the review metrics and the challenge completion progress to match what's in the admin tasks table.