### PR TITLE
Ignore object task properties on properties popup

### DIFF
--- a/src/components/EnhancedMap/PropertyList/Messages.js
+++ b/src/components/EnhancedMap/PropertyList/Messages.js
@@ -1,0 +1,16 @@
+import { defineMessages } from 'react-intl'
+
+/**
+ * Internationalized messages for use with PropertyList
+ */
+export default defineMessages({
+  title: {
+    id: "PropertyList.title",
+    defaultMessage: "Properties",
+  },
+
+  noProperties: {
+    id: "PropertyList.noProperties",
+    defaultMessage: "No Properties",
+  },
+})

--- a/src/components/EnhancedMap/PropertyList/PropertyList.js
+++ b/src/components/EnhancedMap/PropertyList/PropertyList.js
@@ -1,6 +1,10 @@
 import React from 'react'
+import { FormattedMessage } from 'react-intl'
+import _compact from 'lodash/compact'
 import _map from 'lodash/map'
 import _isEmpty from 'lodash/isEmpty'
+import _isObject from 'lodash/isObject'
+import messages from './Messages'
 
 /**
  * Renders a list of properties in a table, intended for use in a map popup
@@ -11,10 +15,19 @@ const PropertyList = props => {
   const tagInfo = process.env.REACT_APP_TAGINFO_SERVER_URL
 
   if (_isEmpty(props.featureProperties)) {
-    return <div className="feature-properties empty">No Properties</div>
+    return (
+      <div className="feature-properties empty">
+        <h3>{props.header ? props.header : <FormattedMessage {...messages.title} />}</h3>
+        <span className="mr-ml-5"><FormattedMessage {...messages.noProperties} /></span>
+      </div>
+    )
   }
 
-  const rows = _map(props.featureProperties, (value, key) => {
+  const rows = _compact(_map(props.featureProperties, (value, key) => {
+    if (_isObject(value)) {
+      return null
+    }
+
     const link =
       !_isEmpty(tagInfo) ?
       <a target="_blank" rel="noopener noreferrer" href={`${tagInfo}/keys/${key}`}>{key}</a> :
@@ -26,11 +39,11 @@ const PropertyList = props => {
         <td className="value">{value}</td>
       </tr>
     )
-  })
+  }))
 
   return (
     <div className="feature-properties">
-      <h3>{props.header || "Properties"}</h3>
+      <h3>{props.header ? props.header : <FormattedMessage {...messages.title} />}</h3>
       <table className="property-list table">
         <tbody>{rows}</tbody>
       </table>

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -502,6 +502,8 @@
   "LayerToggle.controls.moreMapillary.label": "More",
   "LayerToggle.imageCount": "({count, plural, =0 {no images} other {# images}})",
   "LayerToggle.loading": "(loading...)",
+  "PropertyList.title": "Properties",
+  "PropertyList.noProperties": "No Properties",
   "EnhancedMap.SearchControl.searchLabel": "Search",
   "EnhancedMap.SearchControl.noResults": "No Results",
   "FeaturedChallenges.header": "Featured Challenges",


### PR DESCRIPTION
* When displaying a popup of a task's tags/properties, skip any that are
structured as objects

* Use internationalized messages in PropertyList component

* Fix minor display issues when no properties are available