### PR TITLE
Show busy spinner while tag-diff data loading

### DIFF
--- a/src/components/TagDiffVisualization/TagDiffVisualization.js
+++ b/src/components/TagDiffVisualization/TagDiffVisualization.js
@@ -8,6 +8,7 @@ import highlightColors from 'react-syntax-highlighter/dist/styles/hljs/agate'
 import vkbeautify from 'vkbeautify'
 import _values from 'lodash/values'
 import SvgSymbol from '../SvgSymbol/SvgSymbol'
+import BusySpinner from '../BusySpinner/BusySpinner'
 import messages from './Messages'
 
 SyntaxHighlighter.registerLanguage('xml', xmlLang)
@@ -37,6 +38,14 @@ export class TagDiffVisualization extends Component {
   }
 
   render() {
+    if (this.props.loadingOSMData || this.props.loadingChangeset) {
+      return (
+        <div className="mr-bg-blue-dark mr-p-4 mr-rounded-sm mr-flex mr-justify-center mr-items-center">
+          <BusySpinner />
+        </div>
+      )
+    }
+
     const tagChanges = _values(this.props.tagDiff)
     if (this.props.hasTagChanges === false || tagChanges.length === 0) {
       return (

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/SuggestedFixControls/SuggestedFixControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/SuggestedFixControls/SuggestedFixControls.js
@@ -21,6 +21,7 @@ import TaskFalsePositiveControl
 import TaskAlreadyFixedControl
        from '../../../../TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskAlreadyFixedControl/TaskAlreadyFixedControl'
 import SvgSymbol from '../../../../SvgSymbol/SvgSymbol'
+import BusySpinner from '../../../../BusySpinner/BusySpinner'
 import TagDiffModal from '../../../../TagDiffVisualization/TagDiffModal'
 import messages from './Messages'
 
@@ -51,6 +52,7 @@ export class SuggestedFixControls extends Component {
             />
           </button>
         </div>
+        {this.props.loadingOSMData && <BusySpinner />}
         {_get(this.props, 'tagDiffs.length', 0) > 0 &&
          <TagDiffVisualization {...this.props} tagDiff={this.props.tagDiffs[0]} />
         }


### PR DESCRIPTION
* Show busy spinner when loading OSM or changeset data for display in a
tag diff for a suggested-fix task