### PR TITLE
Include virtual project search in p/ searches.

### DIFF
--- a/src/components/AdminPane/HOCs/WithCurrentProject/WithCurrentProject.js
+++ b/src/components/AdminPane/HOCs/WithCurrentProject/WithCurrentProject.js
@@ -3,12 +3,12 @@ import { connect } from 'react-redux'
 import { denormalize } from 'normalizr'
 import _get from 'lodash/get'
 import _isFinite from 'lodash/isFinite'
+import _isObject from 'lodash/isObject'
 import _values from 'lodash/values'
 import _filter from 'lodash/filter'
 import _find from 'lodash/find'
 import _omit from 'lodash/omit'
 import _map from 'lodash/map'
-import _indexOf from 'lodash/indexOf'
 import _sortBy from 'lodash/sortBy'
 import { fetchProject,
          fetchProjectActivity } from '../../../../services/Project/Project'
@@ -75,8 +75,10 @@ const WithCurrentProject = function(WrappedComponent, options={}) {
     challengeProjects = (projectId, props) => {
       const allChallenges = _values(_get(this.props, 'entities.challenges', {}))
       return _filter(allChallenges, (challenge) => {
-                        return challenge.parent === projectId ||
-                          _indexOf(challenge.virtualParents, projectId) !== -1
+                      return challenge.parent === projectId ||
+                        _find(challenge.virtualParents, (vp) => {
+                          return (_isObject(vp) ? vp.id === projectId : vp === projectId)
+                        })
                     })
     }
 

--- a/src/interactions/Project/AsManageableProject.js
+++ b/src/interactions/Project/AsManageableProject.js
@@ -1,6 +1,6 @@
 import _filter from 'lodash/filter'
 import _isObject from 'lodash/isObject'
-import _indexOf from 'lodash/indexOf'
+import _find from 'lodash/find'
 
 /**
  * AsManageable adds functionality to a Project related to management.
@@ -14,7 +14,7 @@ export class AsManageableProject {
     return _filter(challenges, challenge =>
       ((_isObject(challenge.parent) ? challenge.parent.id === this.id :
                                       challenge.parent === this.id) ||
-        _indexOf(challenge.virtualParents, this.id) !== -1)
+        _find(challenge.virtualParents, (vp) => (_isObject(vp) ? vp.id === this.id : vp === this.id)))
     )
   }
 }

--- a/src/interactions/User/AsManager.js
+++ b/src/interactions/User/AsManager.js
@@ -157,14 +157,13 @@ export class AsManager extends AsEndUser {
       }
 
       _each(challenge.virtualParents, (vp) => {
-        if (projectIds.indexOf(vp) !== -1) {
+        if (projectIds.indexOf(_isObject(vp) ? vp.id : vp) !== -1) {
           if (!projectChallenges.has(challenge)) {
             projectChallenges.add(challenge)
           }
         }
       })
     })
-
     return [...projectChallenges]
   }
 }

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -48,6 +48,7 @@ export const challengeDenormalizationSchema = function() {
   return new schema.Entity('challenges', {
     parent: projectSchema(),
     comments: [ commentSchema() ],
+    virtualParents: [ projectSchema() ],
   })
 }
 

--- a/src/services/Challenge/ChallengeProject/ChallengeProject.js
+++ b/src/services/Challenge/ChallengeProject/ChallengeProject.js
@@ -1,6 +1,7 @@
 import _get from 'lodash/get'
 import _includes from 'lodash/includes'
 import _isEmpty from 'lodash/isEmpty'
+import _isObject from 'lodash/isObject'
 
 /**
  * Returns true if the given challenge passes the project-name filter in the
@@ -15,6 +16,18 @@ export const challengePassesProjectFilter = function(challengeFilters,
     if (!_get(challenge, 'parent.displayName')) {
       return false
     }
+
+    const virtualParents = _get(challenge, 'virtualParents', [])
+    for (let i = 0; i < virtualParents.length; i++) {
+      const vp = virtualParents[i]
+      if (_isObject(vp) && vp.enabled) {
+        if (_includes(vp.displayName.toLowerCase(),
+                      challengeFilters.project.toLowerCase())) {
+          return true
+        }
+      }
+    }
+
 
     // Just look for a basic case-insensitive substring
     if (!_includes(challenge.parent.displayName.toLowerCase(),


### PR DESCRIPTION
This relies on back-end PR: Support virtual project search in extendedFind #605. MR2 will now return the same basic information for virtual projects as it does for projects. 
* All places checking for virtual projects ids need to handle the virtual projects as objects. 
* ChallengeProjectFilter needs to also match the searched for name in the virtualParents.