### PR TITLE
Move suggested-fix tag diff into its own widget

### DIFF
--- a/src/components/HOCs/WithWidgetManagement/WithWidgetManagement.js
+++ b/src/components/HOCs/WithWidgetManagement/WithWidgetManagement.js
@@ -1,12 +1,10 @@
 import React, { Component } from 'react';
 import _clone from 'lodash/clone'
 import _cloneDeep from 'lodash/cloneDeep'
-import _each from 'lodash/each'
 import _differenceBy from 'lodash/differenceBy'
 import _find from 'lodash/find'
-import _findIndex from 'lodash/findIndex'
 import _map from 'lodash/map'
-import { generateWidgetId, widgetDescriptor, compatibleWidgetTypes }
+import { compatibleWidgetTypes, addWidgetToGrid }
        from '../../../services/Widget/Widget'
 
 /**
@@ -36,41 +34,13 @@ const WithWidgetManagement = function(WrappedComponent) {
      */
     addWidget = widgetKey => {
       // Make sure the widget is not already added to the workspace
-      if (_findIndex(this.props.workspace.widgets, {widgetKey}) !== -1) {
+      if (_find(this.props.workspace.widgets, {widgetKey})) {
         return
       }
 
-      const descriptor = widgetDescriptor(widgetKey)
-      if (!descriptor) {
-        throw new Error(`Attempt to add unknown widget ${widgetKey} to workspace.`)
-      }
-
-      // For simplicity, we'll add the new widget to the top in its own row.
-      const updatedWidgets = _clone(this.props.workspace.widgets)
-      updatedWidgets.unshift(descriptor)
-
-      const updatedLayout = _cloneDeep(this.props.workspace.layout)
-      // Push everything down to make room for the new widget
-      _each(updatedLayout, row => row.y += (descriptor.defaultHeight))
-
-      updatedLayout.unshift({
-        i: generateWidgetId(),
-        x: 0,
-        y: 0,
-        w: descriptor.defaultWidth,
-        minW: descriptor.minWidth,
-        maxW: descriptor.maxWidth,
-        h: descriptor.defaultHeight,
-        minH: descriptor.minHeight,
-        maxH: descriptor.maxHeight,
-      })
-
       this.props.saveWorkspaceConfiguration(
-        Object.assign(
-          {},
-          this.props.workspace,
-          {widgets: updatedWidgets, layout: updatedLayout}
-        ))
+        addWidgetToGrid(this.props.workspace, widgetKey)
+      )
     }
 
     /**

--- a/src/components/HOCs/WithWidgetWorkspaces/WithWidgetWorkspaces.js
+++ b/src/components/HOCs/WithWidgetWorkspaces/WithWidgetWorkspaces.js
@@ -15,6 +15,7 @@ import {
   pruneWidgets,
   exportWorkspaceConfiguration,
   importWorkspaceConfiguration,
+  ensurePermanentWidgetsAdded,
 } from '../../../services/Widget/Widget'
 import WithCurrentUser from '../WithCurrentUser/WithCurrentUser'
 import WithStatus from '../WithStatus/WithStatus'
@@ -150,6 +151,13 @@ export const WithWidgetWorkspaces = function(WrappedComponent,
       if (configuration.excludeWidgets && configuration.excludeWidgets.length > 0) {
         configuration = pruneWidgets(configuration, configuration.excludeWidgets)
       }
+
+      // Make sure any new permanent widgets are added into the configuration
+      configuration.permanentWidgets = defaultConfiguration().permanentWidgets
+      configuration = ensurePermanentWidgetsAdded(configuration, defaultConfiguration())
+
+      // Make sure conditionalWidgets reflect the latest from default configuration
+      configuration.conditionalWidgets = defaultConfiguration().conditionalWidgets
 
       return configuration
     }

--- a/src/components/QuickWidget/QuickWidget.js
+++ b/src/components/QuickWidget/QuickWidget.js
@@ -15,6 +15,10 @@ import classNames from 'classnames'
  */
 export default class QuickWidget extends Component {
   render() {
+    if (this.props.widgetHidden) {
+      return null
+    }
+
     return (
       <section className={classNames("mr-flex mr-flex-col mr-h-full", this.props.className, {"mr-mb-4": this.props.isEditing})}>
         {this.props.isEditing && !this.props.permanent &&

--- a/src/components/TagDiffVisualization/TagDiffVisualization.js
+++ b/src/components/TagDiffVisualization/TagDiffVisualization.js
@@ -159,7 +159,7 @@ export class TagDiffVisualization extends Component {
       tagChanges = justChanges(tagChanges)
     }
 
-    const toolbar = (
+    const toolbar = this.props.suppressToolbar ? null : (
       <div className="mr-flex mr-mb-1 mr-px-4">
         <div className="mr-text-base mr-text-yellow mr-mr-4">
           {this.props.onlyChanges ?

--- a/src/components/TaskPane/TaskPane.js
+++ b/src/components/TaskPane/TaskPane.js
@@ -36,19 +36,29 @@ export const defaultWorkspaceSetup = function() {
     label: "Task Completion",
     widgets: [
       widgetDescriptor('TaskInstructionsWidget'),
+      widgetDescriptor('TagDiffWidget'),
       widgetDescriptor('TaskMapWidget'),
       widgetDescriptor('TaskCompletionWidget'),
       widgetDescriptor('TaskLocationWidget'),
     ],
     layout: [
       {i: generateWidgetId(), x: 0, y: 0, w: 4, h: 4},
-      {i: generateWidgetId(), x: 4, y: 0, w: 8, h: 19},
+      {i: generateWidgetId(), x: 4, y: 0, w: 8, h: 5},
+      {i: generateWidgetId(), x: 4, y: 5, w: 8, h: 19},
       {i: generateWidgetId(), x: 0, y: 4, w: 4, h: 7},
       {i: generateWidgetId(), x: 0, y: 11, w: 4, h: 8},
     ],
-    excludeWidgets: [
+    permanentWidgets: [ // Cannot be removed from workspace
+      'TaskMapWidget',
+      'TaskCompletionWidget',
+      'TagDiffWidget',
+    ],
+    excludeWidgets: [ // Cannot be added to workspace
       'TaskReviewWidget',
-    ]
+    ],
+    conditionalWidgets: [ // conditionally displayed
+      'TagDiffWidget',
+    ],
   }
 }
 

--- a/src/components/Widgets/TagDiffWidget/Messages.js
+++ b/src/components/Widgets/TagDiffWidget/Messages.js
@@ -1,0 +1,17 @@
+import { defineMessages } from 'react-intl'
+
+/**
+ * Internationalized messages for use with TagDiffWidget
+ */
+export default defineMessages({
+  label: {
+    id: "Widgets.TagDiffWidget.label",
+    defaultMessage: "Suggested Fixes",
+  },
+
+  title: {
+    id: "Widgets.TagDiffWidget.title",
+    defaultMessage: "Proposed OSM Tag Changes",
+  },
+})
+

--- a/src/components/Widgets/TagDiffWidget/TagDiffWidget.js
+++ b/src/components/Widgets/TagDiffWidget/TagDiffWidget.js
@@ -1,0 +1,103 @@
+import React, { Component } from 'react'
+import { FormattedMessage } from 'react-intl'
+import _get from 'lodash/get'
+import { WidgetDataTarget, registerWidgetType }
+       from '../../../services/Widget/Widget'
+import { isFinalStatus }
+       from '../../../services/Task/TaskStatus/TaskStatus'
+import { TaskReviewStatus }
+      from '../../../services/Task/TaskReview/TaskReviewStatus'
+import QuickWidget from '../../QuickWidget/QuickWidget'
+import TagDiffVisualization from '../../TagDiffVisualization/TagDiffVisualization'
+import TagDiffModal from '../../TagDiffVisualization/TagDiffModal'
+import SvgSymbol from '../../SvgSymbol/SvgSymbol'
+import BusySpinner from '../../BusySpinner/BusySpinner'
+import messages from './Messages'
+
+const descriptor = {
+  widgetKey: 'TagDiffWidget',
+  label: messages.label,
+  targets: [WidgetDataTarget.task],
+  minWidth: 4,
+  defaultWidth: 8,
+  minHeight: 4,
+  defaultHeight: 5,
+}
+
+export default class TagDiffWidget extends Component {
+  state = {
+    showDiffModal: false,
+  }
+
+  render() {
+    return (
+      <QuickWidget
+        {...this.props}
+        className="mr-bg-transparent"
+        noMain
+        permanent
+        widgetTitle={
+          <div className="mr-flex">
+            <FormattedMessage {...messages.title} />
+            <button
+              className="mr-text-green-lighter mr-ml-4"
+              onClick={() => this.setState({showDiffModal: true})}
+            >
+              <SvgSymbol
+                sym="expand-icon"
+                viewBox="0 0 32 32"
+                className="mr-transition mr-fill-current mr-w-4 mr-h-4"
+              />
+            </button>
+          </div>
+        }
+      >
+        <TagDiff {...this.props} />
+
+        {this.state.showDiffModal &&
+         <TagDiffModal
+           {...this.props}
+           onClose={() => this.setState({showDiffModal: false})}
+         />
+        }
+      </QuickWidget>
+    )
+  }
+}
+
+export const TagDiff = props => {
+  const needsRevised = props.task.reviewStatus === TaskReviewStatus.rejected
+  if (props.task.suggestedFix && (!isFinalStatus(props.task.status) || needsRevised)) {
+    if (props.loadingOSMData) {
+      return (
+        <div className="mr-mb-4">
+          <BusySpinner />
+        </div>
+      )
+    }
+
+    return (
+      <div className="mr-mb-4">
+        <TagDiffVisualization
+          {...props}
+          compact
+          suppressToolbar
+          onlyChanges
+          tagDiff={_get(props, 'tagDiffs[0]')}
+        />
+      </div>
+    )
+  }
+
+  return null
+}
+
+/**
+ * Allow this widget to be treated as a conditional widget, returning true or
+ * false as to whether it should be hidden given the current workspace props
+ */
+TagDiffWidget.hideWidget = function(props) {
+  return !_get(props, 'task.suggestedFix', false)
+}
+
+registerWidgetType(TagDiffWidget, descriptor)

--- a/src/components/Widgets/TaskMapWidget/TaskMapWidget.js
+++ b/src/components/Widgets/TaskMapWidget/TaskMapWidget.js
@@ -1,15 +1,8 @@
 import React, { Component } from 'react'
-import _get from 'lodash/get'
 import { WidgetDataTarget, registerWidgetType }
        from '../../../services/Widget/Widget'
-import { isFinalStatus } from '../../../services/Task/TaskStatus/TaskStatus'
-import { TaskReviewStatus }
-       from '../../../services/Task/TaskReview/TaskReviewStatus'
 import MapPane from '../../EnhancedMap/MapPane/MapPane'
 import TaskMap from '../../TaskPane/TaskMap/TaskMap'
-import TagDiffVisualization from '../../TagDiffVisualization/TagDiffVisualization'
-import TagDiffModal from '../../TagDiffVisualization/TagDiffModal'
-import BusySpinner from '../../BusySpinner/BusySpinner'
 import QuickWidget from '../../QuickWidget/QuickWidget'
 import messages from './Messages'
 
@@ -24,10 +17,6 @@ const descriptor = {
 }
 
 export default class TaskMapWidget extends Component {
-  state = {
-    showDiffModal: false,
-  }
-
   render() {
     return (
       <QuickWidget
@@ -36,50 +25,12 @@ export default class TaskMapWidget extends Component {
         noMain
         permanent
       >
-        <TagDiff
-          {...this.props}
-          showDiffModal={() => this.setState({showDiffModal: true})}
-        />
-
         <MapPane {...this.props}>
           <TaskMap {...this.props} challenge={this.props.task.parent} />
         </MapPane>
-
-        {this.state.showDiffModal &&
-         <TagDiffModal
-           {...this.props}
-           onClose={() => this.setState({showDiffModal: false})}
-         />
-        }
       </QuickWidget>
     )
   }
-}
-
-export const TagDiff = props => {
-  const needsRevised = props.task.reviewStatus === TaskReviewStatus.rejected
-  if (props.task.suggestedFix && (!isFinalStatus(props.task.status) || needsRevised)) {
-    if (props.loadingOSMData) {
-      return (
-        <div className="mr-mb-4">
-          <BusySpinner />
-        </div>
-      )
-    }
-
-    return (
-      <div className="mr-mb-4">
-        <TagDiffVisualization
-          {...props}
-          compact
-          onlyChanges
-          tagDiff={_get(props, 'tagDiffs[0]')}
-        />
-      </div>
-    )
-  }
-
-  return null
 }
 
 registerWidgetType(TaskMapWidget, descriptor)

--- a/src/components/Widgets/widget_registry.js
+++ b/src/components/Widgets/widget_registry.js
@@ -5,6 +5,8 @@
  */
 
 // Import first-party widgets shipped with MapRoulette
+export { default as TagDiffWidget }
+       from './TagDiffWidget/TagDiffWidget'
 export { default as TaskMapWidget }
        from './TaskMapWidget/TaskMapWidget'
 export { default as TaskInstructionsWidget }

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -697,6 +697,8 @@
   "Widgets.ReviewTableWidget.label": "Review Table",
   "Widgets.ReviewTaskMetricsWidget.label": "Review Task Metrics",
   "Widgets.ReviewTaskMetricsWidget.title": "Task Status",
+  "Widgets.TagDiffWidget.label": "Suggested Fixes",
+  "Widgets.TagDiffWidget.title": "Proposed OSM Tag Changes",
   "Widgets.TaskCompletionWidget.label": "Completion",
   "Widgets.TaskCompletionWidget.title": "Completion",
   "Widgets.TaskCompletionWidget.inspectTitle": "Inspect",


### PR DESCRIPTION
* Move tag diff from the TaskMapWidget into its own TagDiffWidget

* Make TagDiffWidget permanent in task completion, but its display
conditional on whether the current task has a suggested fix

* Add basic support for conditional rendering of widgets based on a
function the widget provides

* Widgets that are to be hidden receive a new `widgetHidden=true`
prop and are temporarily assigned a height of zero

* Ensure new permanent widgets are automatically added into existing
workspaces on first subsequent use