### PR TITLE
Skipping task was not setting task status to skipped

### DIFF
--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
@@ -199,7 +199,7 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
         }
       }
 
-      if (taskStatus === TaskStatus.skipped && task.taskStatus !== TaskStatus.created) {
+      if (taskStatus === TaskStatus.skipped && task.status !== TaskStatus.created) {
         // Skipping task that already has a status
         return doAfter()
       }


### PR DESCRIPTION
Due to a typo, when skipping a task the backend was not calling setTaskStatus to actually set the status to skipped