### PR TITLE
Add support for 'current month' duration on leaderboard

### DIFF
--- a/src/components/AdminPane/Manage/Widgets/LeaderboardWidget/LeaderboardWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/LeaderboardWidget/LeaderboardWidget.js
@@ -8,6 +8,8 @@ import ChallengeOwnerLeaderboard
        from '../../ChallengeOwnerLeaderboard/ChallengeOwnerLeaderboard'
 import PastDurationSelector
        from '../../../../PastDurationSelector/PastDurationSelector'
+import { CURRENT_MONTH }
+       from '../../../../PastDurationSelector/PastDurationSelector'
 import QuickWidget from '../../../../QuickWidget/QuickWidget'
 import messages from './Messages'
 import './LeaderboardWidget.scss'
@@ -40,12 +42,12 @@ export default class LeaderboardWidget extends Component {
   }
 
   render() {
-    const monthsPast = this.props.widgetConfiguration.monthsPast || 1
+    const monthsPast = this.props.widgetConfiguration.monthsPast
 
     const selector =
       <PastDurationSelector
         className="mr-button mr-button--blue mr-mr-8"
-        pastMonthsOptions={[1, 3, 6, 12]}
+        pastMonthsOptions={[CURRENT_MONTH, 1, 3, 6, 12]}
         currentMonthsPast={monthsPast}
         selectDuration={this.setMonthsPast}
       />

--- a/src/components/PastDurationSelector/Messages.js
+++ b/src/components/PastDurationSelector/Messages.js
@@ -8,7 +8,12 @@ export default defineMessages({
     id: "PastDurationSelector.pastMonths.selectOption",
     defaultMessage: "Past {months, plural, one {Month} =12 {Year} other {# Months}}",
   },
-  
+
+  currentMonthOption: {
+    id: "PastDurationSelector.currentMonth.selectOption",
+    defaultMessage: "Current Month",
+  },
+
   allTimeOption: {
     id: "PastDurationSelector.allTime.selectOption",
     defaultMessage: "All Time",

--- a/src/components/PastDurationSelector/PastDurationSelector.js
+++ b/src/components/PastDurationSelector/PastDurationSelector.js
@@ -8,6 +8,7 @@ import messages from './Messages'
 import './PastDurationSelector.scss'
 
 export const ALL_TIME = -1
+export const CURRENT_MONTH = 0
 
 /**
  * PastDurationSelector renders an unmanaged dropdown button that can be used
@@ -51,10 +52,13 @@ const DurationButton = function(props) {
     >
       <span className="mr-flex">
         <span className="mr-mr-2">
-          {props.currentMonthsPast >= 0 &&
+          {props.currentMonthsPast > CURRENT_MONTH &&
                  <FormattedMessage {...messages.pastMonthsOption}
                             values={{months: props.currentMonthsPast}} />}
-          {props.currentMonthsPast < 0 &&
+          {props.currentMonthsPast === CURRENT_MONTH &&
+                 <FormattedMessage {...messages.currentMonthOption}
+                            values={{months: props.currentMonthsPast}} />}
+          {props.currentMonthsPast <= ALL_TIME &&
                  <FormattedMessage {...messages.allTimeOption}
                             values={{months: props.currentMonthsPast}} />}
         </span>
@@ -73,8 +77,9 @@ const ListDurationItems = function(props) {
     <li key={months}>
       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
       <a onClick={() => props.pickDuration(months, props.closeDropdown)}>
-        {months >= 0  && <FormattedMessage {...messages.pastMonthsOption} values={{months}} />}
-        {months < 0  && <FormattedMessage {...messages.allTimeOption} />}
+        {months > CURRENT_MONTH  && <FormattedMessage {...messages.pastMonthsOption} values={{months}} />}
+        {months === CURRENT_MONTH  && <FormattedMessage {...messages.currentMonthOption} />}
+        {months <= ALL_TIME  && <FormattedMessage {...messages.allTimeOption} />}
       </a>
     </li>
   ))

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -551,6 +551,7 @@
   "PageNotFound.message": "Oops! The page you’re looking for is lost.",
   "PageNotFound.homePage": "Take me home",
   "PastDurationSelector.pastMonths.selectOption": "Past {months, plural, one {Month} =12 {Year} other {# Months}}",
+  "PastDurationSelector.currentMonth.selectOption": "Current Month",
   "PastDurationSelector.allTime.selectOption": "All Time",
   "PointsTicker.label": "My Points",
   "PopularChallenges.header": "Popular Challenges",

--- a/src/pages/Leaderboard/Leaderboard.js
+++ b/src/pages/Leaderboard/Leaderboard.js
@@ -11,7 +11,7 @@ import WithCurrentUser
        from '../../components/HOCs/WithCurrentUser/WithCurrentUser'
 import PastDurationSelector
        from '../../components/PastDurationSelector/PastDurationSelector'
-import {ALL_TIME}
+import {ALL_TIME, CURRENT_MONTH}
        from '../../components/PastDurationSelector/PastDurationSelector'
 import CountrySelector
        from '../../components/CountrySelector/CountrySelector'
@@ -86,7 +86,7 @@ class Leaderboard extends Component {
             <div className="mr-flex mr-justify-center mr-mb-2">
               <PastDurationSelector
                 className="mr-button mr-mr-8"
-                pastMonthsOptions={[ALL_TIME, 1, 3, 6, 12]}
+                pastMonthsOptions={[ALL_TIME, CURRENT_MONTH, 1, 3, 6, 12]}
                 currentMonthsPast={this.props.monthsPast}
                 selectDuration={this.props.setMonthsPast}
               />

--- a/src/pages/Metrics/blocks/ReviewStats.js
+++ b/src/pages/Metrics/blocks/ReviewStats.js
@@ -3,7 +3,8 @@ import { FormattedMessage } from 'react-intl'
 import messages from '../Messages'
 import QuickWidget from '../../../components/QuickWidget/QuickWidget'
 import PastDurationSelector from '../../../components/PastDurationSelector/PastDurationSelector'
-import {ALL_TIME} from '../../../components/PastDurationSelector/PastDurationSelector'
+import {ALL_TIME, CURRENT_MONTH}
+       from '../../../components/PastDurationSelector/PastDurationSelector'
 import _get from 'lodash/get'
 
 export default class ReviewStats extends Component {
@@ -46,7 +47,7 @@ export default class ReviewStats extends Component {
         rightHeaderControls={
           <PastDurationSelector
             className="mr-button mr-button--small"
-            pastMonthsOptions={[1, 3, 6, 9, 12, ALL_TIME]}
+            pastMonthsOptions={[1, 3, 6, 9, 12, CURRENT_MONTH, ALL_TIME]}
             currentMonthsPast={this.props.tasksReviewedMonthsPast}
             selectDuration={this.props.setTasksReviewedMonthsPast}
           />

--- a/src/pages/Metrics/blocks/TaskStats.js
+++ b/src/pages/Metrics/blocks/TaskStats.js
@@ -4,7 +4,8 @@ import messages from '../Messages'
 import QuickWidget from '../../../components/QuickWidget/QuickWidget'
 import ChallengeProgress from '../../../components/ChallengeProgress/ChallengeProgress'
 import PastDurationSelector from '../../../components/PastDurationSelector/PastDurationSelector'
-import {ALL_TIME} from '../../../components/PastDurationSelector/PastDurationSelector'
+import {ALL_TIME, CURRENT_MONTH}
+       from '../../../components/PastDurationSelector/PastDurationSelector'
 
 export default class TaskStats extends Component {
   render() {
@@ -18,7 +19,7 @@ export default class TaskStats extends Component {
         rightHeaderControls={
           <PastDurationSelector
             className="mr-button mr-button--small"
-            pastMonthsOptions={[1, 3, 6, 9, 12, ALL_TIME]}
+            pastMonthsOptions={[1, 3, 6, 9, 12, CURRENT_MONTH, ALL_TIME]}
             currentMonthsPast={this.props.tasksCompletedMonthsPast}
             selectDuration={this.props.setTasksCompletedMonthsPast}
           />

--- a/src/services/Leaderboard/Leaderboard.js
+++ b/src/services/Leaderboard/Leaderboard.js
@@ -1,10 +1,13 @@
 import { defaultRoutes as api } from '../Server/Server'
 import _isArray from 'lodash/isArray'
 import Endpoint from '../Server/Endpoint'
+import startOfMonth from 'date-fns/start_of_month'
 
 // Default leaderboard count
 export const DEFAULT_LEADERBOARD_COUNT = 10
 
+// Current Month duration
+export const CURRENT_MONTH = 0
 
 /**
  * Retrieve leaderboard data from the server for the given date range and
@@ -46,7 +49,13 @@ export const fetchLeaderboardForUser = function(userId, bracket=0, numberMonths=
 const initializeLeaderboardParams = function (params, numberMonths,
                                               forProjects, forChallenges,
                                               forUsers, forCountries) {
-  params.monthDuration = numberMonths
+  if (numberMonths === CURRENT_MONTH) {
+    params.start = startOfMonth(new Date()).toISOString()
+    params.end = new Date().toISOString()
+  }
+  else {
+    params.monthDuration = numberMonths
+  }
 
   if (_isArray(forProjects)) {
     params.projectIds = forProjects.join(',')


### PR DESCRIPTION
* When current month is chosen a start and end date is passed
  to server where start date is start of month and end date is
  today.

* Add to leaderboard, admin challenge leaderboard widget,
  user metrics page review stats, user metrics page task stats