### PR TITLE
Restore created-status color on Challenge Progress

### DIFF
--- a/src/components/ChallengeProgress/ChallengeProgress.js
+++ b/src/components/ChallengeProgress/ChallengeProgress.js
@@ -86,7 +86,7 @@ export class ChallengeProgress extends Component {
       [localizedStatuses.falsePositive]: TaskStatusColors[TaskStatus.falsePositive],
       [localizedStatuses.skipped]: TaskStatusColors[TaskStatus.skipped],
       [localizedStatuses.tooHard]: TaskStatusColors[TaskStatus.tooHard],
-      [availableLabel]: TaskStatusColors[TaskStatus.created],
+      [availableLabel]: 'rgba(0, 0, 0, .25)',
     }
 
     const completionData = {


### PR DESCRIPTION
* Restore inadvertently modified translucent black color to represent
tasks in created status on Challenge Progress bars