### PR TITLE
'My Review Tasks' tab to not link to 'review' screen for a contested task

### DIFF
--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -480,12 +480,6 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
                         <FormattedMessage {...messages.fixTaskLabel} /> :
                         <FormattedMessage {...messages.viewTaskLabel} />
 
-      // The mapper needs to rereview a contested task.
-      if (row._original.reviewStatus === TaskReviewStatus.disputed) {
-        linkTo += "/review"
-        message = <FormattedMessage {...messages.resolveTaskLabel} />
-      }
-
       return <div className="row-controls-column">
         <Link to={linkTo}>
           {message}


### PR DESCRIPTION
  Backed out change to send mappers to /review if task was
  contested on the 'my reviewed tasks' tab as mappers
  should not be reviewing their own tasks.