### PR TITLE
Fix error when no nearby tasks available on last task in challenge

### DIFF
--- a/src/components/TaskPane/TaskNearbyList/Messages.js
+++ b/src/components/TaskPane/TaskNearbyList/Messages.js
@@ -8,4 +8,9 @@ export default defineMessages({
     id: "Widgets.TaskNearbyMap.currentTaskTooltip",
     defaultMessage: "Current Task",
   },
+
+  noTasksAvailableLabel: {
+    id: "Widgets.TaskNearbyMap.noTasksAvailable.label",
+    defaultMessage: "No nearby tasks are available.",
+  },
 })

--- a/src/components/TaskPane/TaskNearbyList/TaskNearbyMap.js
+++ b/src/components/TaskPane/TaskNearbyList/TaskNearbyMap.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { injectIntl } from 'react-intl'
+import { FormattedMessage, injectIntl } from 'react-intl'
 import L from 'leaflet'
 import 'leaflet-vectoricon'
 import { ZoomControl, Marker } from 'react-leaflet'
@@ -127,6 +127,14 @@ export class TaskNearbyMap extends Component {
     const overlayLayers = _map(this.props.visibleOverlays, (layerId, index) =>
       <SourcedTileLayer key={layerId} source={layerSourceWithId(layerId)} zIndex={index + 2} />
     )
+
+    if (!coloredMarkers) {
+      return (
+        <div className="mr-h-full">
+          <FormattedMessage {...messages.noTasksAvailableLabel} />
+        </div>
+      )
+    }
 
     return (
       <div className="mr-h-full">

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -667,6 +667,7 @@
   "Task.management.controls.inspect.label": "Inspect",
   "Task.management.controls.modify.label": "Modify",
   "Widgets.TaskNearbyMap.currentTaskTooltip": "Current Task",
+  "Widgets.TaskNearbyMap.noTasksAvailable.label": "No nearby tasks are available.",
   "Challenge.controls.taskLoadBy.label": "Load tasks by:",
   "Task.controls.track.label": "Track this Task",
   "Task.controls.untrack.label": "Stop tracking this Task",


### PR DESCRIPTION
When on the last task in the challenge, the work on next task 'nearby' option would throw an error. Changed to display a message: "No nearby tasks are available."

