### PR TITLE
Ignore keyboard shortcuts if modifier keys used

### DIFF
--- a/src/components/HOCs/WithKeyboardShortcuts/WithKeyboardShortcuts.js
+++ b/src/components/HOCs/WithKeyboardShortcuts/WithKeyboardShortcuts.js
@@ -49,9 +49,13 @@ const mapDispatchToProps = dispatch => {
       dispatch(removeKeyboardShortcut(groupName, shortcutName))
     },
     textInputActive: textInputActive,
-    quickKeyHandler: (key, handler) => (event => {
+    quickKeyHandler: (key, handler, allowModifierKeys=false) => (event => {
       if (textInputActive(event)) {
         return // ignore typing in inputs
+      }
+
+      if (!allowModifierKeys && (event.metaKey || event.altKey || event.ctrlKey)) {
+        return
       }
 
       if (event.key === key) {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskEditControl/TaskEditControl.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskEditControl/TaskEditControl.js
@@ -23,6 +23,11 @@ export default class TaskEditControl extends Component {
       return
     }
 
+    // Ignore if modifier keys were pressed
+    if (event.metaKey || event.altKey || event.ctrlKey) {
+      return
+    }
+
     const editShortcuts = this.props.keyboardShortcutGroups.openEditor
 
     switch(event.key) {


### PR DESCRIPTION
* Ignore keyboard shortcuts if a modifier key was in use, e.g. don't
treat cmd-r or ctrl-r as `r`