### PR TITLE
Fix primary task marker not always showing in multi-task map

### DIFF
--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -70,9 +70,7 @@ export default class TaskBundleWidget extends Component {
     // If the nearby tasks loaded, update bounds
     if (_get(this.props, 'nearbyTasks.tasks.length', 0) > 0 &&
         !_isEqual(this.props.nearbyTasks, prevProps.nearbyTasks)) {
-      const taskList = _get(this.props, 'nearbyTasks.tasks')
-      taskList.push(AsMappableTask(this.props.task))
-      this.setBoundsToNearbyTask(taskList)
+      this.setBoundsToNearbyTask()
     }
   }
 
@@ -100,7 +98,15 @@ export default class TaskBundleWidget extends Component {
     this.props.augmentClusteredTasks(challengeId, false, {boundingBox: bounds})
   }
 
-  setBoundsToNearbyTask = (taskList) => {
+  setBoundsToNearbyTask = () => {
+    const taskList = _get(this.props, 'nearbyTasks.tasks')
+
+    // Add the current task to the task list so that it always shows
+    // up in the bounds.
+    const mappableTask = AsMappableTask(this.props.task)
+    mappableTask.point = mappableTask.calculateCenterPoint()
+    taskList.push(mappableTask)
+
     if (taskList.length === 0) {
       return
     }

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -20,6 +20,7 @@ import WithClusteredTasks from '../../HOCs/WithClusteredTasks/WithClusteredTasks
 import WithBoundedTasks from '../../HOCs/WithBoundedTasks/WithBoundedTasks'
 import WithFilteredClusteredTasks
        from '../../HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks'
+import AsMappableTask from '../../../interactions/Task/AsMappableTask'
 import ChallengeTaskMap from '../../ChallengeTaskMap/ChallengeTaskMap'
 import QuickWidget from '../../QuickWidget/QuickWidget'
 import SvgSymbol from '../../SvgSymbol/SvgSymbol'
@@ -69,7 +70,9 @@ export default class TaskBundleWidget extends Component {
     // If the nearby tasks loaded, update bounds
     if (_get(this.props, 'nearbyTasks.tasks.length', 0) > 0 &&
         !_isEqual(this.props.nearbyTasks, prevProps.nearbyTasks)) {
-      this.setBoundsToNearbyTask()
+      const taskList = _get(this.props, 'nearbyTasks.tasks')
+      taskList.push(AsMappableTask(this.props.task))
+      this.setBoundsToNearbyTask(taskList)
     }
   }
 
@@ -97,13 +100,13 @@ export default class TaskBundleWidget extends Component {
     this.props.augmentClusteredTasks(challengeId, false, {boundingBox: bounds})
   }
 
-  setBoundsToNearbyTask = () => {
-    if (_get(this.props, 'nearbyTasks.tasks.length', 0) === 0) {
+  setBoundsToNearbyTask = (taskList) => {
+    if (taskList.length === 0) {
       return
     }
 
     const nearbyBounds = bbox(featureCollection(
-      this.props.nearbyTasks.tasks.map(t => point([t.point.lng, t.point.lat]))
+      taskList.map(t => point([t.point.lng, t.point.lat]))
     ))
 
     this.updateBounds(

--- a/src/interactions/Task/AsMappableTask.js
+++ b/src/interactions/Task/AsMappableTask.js
@@ -12,7 +12,6 @@ import { latLng } from 'leaflet'
 export class AsMappableTask {
   constructor(task) {
     Object.assign(this, task)
-    this.point = this.calculateCenterPoint()
   }
 
   /**

--- a/src/interactions/Task/AsMappableTask.js
+++ b/src/interactions/Task/AsMappableTask.js
@@ -12,6 +12,7 @@ import { latLng } from 'leaflet'
 export class AsMappableTask {
   constructor(task) {
     Object.assign(this, task)
+    this.point = this.calculateCenterPoint()
   }
 
   /**


### PR DESCRIPTION
Add primary task to the list of nearby tasks before calculating bounding box in TaskBundleWidget.