### PR TITLE
Support task action websocket messages

### DIFF
--- a/src/components/ChallengeTaskMap/ChallengeTaskMap.js
+++ b/src/components/ChallengeTaskMap/ChallengeTaskMap.js
@@ -95,12 +95,13 @@ export class ChallengeTaskMap extends Component {
       return true
     }
 
-    // the clustered tasks themselves change
-    if (_get(nextProps, 'taskInfo.tasks.length') !==
-        _get(this.props, 'taskInfo.tasks.length')) {
+    // the clustered tasks changed
+    if (_get(nextProps, 'taskInfo.fetchId') !==
+        _get(this.props, 'taskInfo.fetchId')) {
       return true
     }
 
+    // the selected tasks changed
     if (_get(nextProps, 'selectedTasks.size', 0) !==
         _get(this.props, 'selectedTasks.size', 0)) {
       return true

--- a/src/components/ChallengeTaskMap/ChallengeTaskMap.js
+++ b/src/components/ChallengeTaskMap/ChallengeTaskMap.js
@@ -95,7 +95,12 @@ export class ChallengeTaskMap extends Component {
       return true
     }
 
-    // the clustered tasks changed
+    // the clustered tasks themselves change
+    if (_get(nextProps, 'taskInfo.tasks.length') !==
+        _get(this.props, 'taskInfo.tasks.length')) {
+      return true
+    }
+
     if (_get(nextProps, 'taskInfo.fetchId') !==
         _get(this.props, 'taskInfo.fetchId')) {
       return true

--- a/src/components/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
+++ b/src/components/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
@@ -32,12 +32,16 @@ import { TaskPriority, keysByPriority }
  */
 export default function WithFilteredClusteredTasks(WrappedComponent,
                                                    tasksProp='clusteredTasks',
-                                                   outputProp) {
+                                                   outputProp,
+                                                   initialFilters) {
   return class extends Component {
     state = {
-      includeStatuses: _fromPairs(_map(TaskStatus, status => [status, true])),
-      includeReviewStatuses: _fromPairs(_map(TaskReviewStatusWithUnset, status => [status, true])),
-      includePriorities: _fromPairs(_map(TaskPriority, priority => [priority, true])),
+      includeStatuses: _get(initialFilters, 'statuses',
+                            _fromPairs(_map(TaskStatus, status => [status, true]))),
+      includeReviewStatuses: _get(initialFilters, 'reviewStatuses',
+                                  _fromPairs(_map(TaskReviewStatusWithUnset, status => [status, true]))),
+      includePriorities: _get(initialFilters, 'priorities',
+                              _fromPairs(_map(TaskPriority, priority => [priority, true]))),
       selectedTasks: new Map(),
       filteredTasks: {tasks: []},
     }
@@ -321,8 +325,7 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
     }
 
     componentDidUpdate(prevProps, prevState) {
-      if (_get(prevProps[tasksProp], 'tasks.length', 0) !==
-          _get(this.props[tasksProp], 'tasks.length', 0)) {
+      if (_get(prevProps[tasksProp], 'fetchId') !== _get(this.props[tasksProp], 'fetchId')) {
         this.setState({
           filteredTasks: this.filterTasks(this.state.includeStatuses,
                                           this.state.includeReviewStatuses,

--- a/src/components/HOCs/WithWebSocketSubscriptions/WithWebSocketSubscriptions.js
+++ b/src/components/HOCs/WithWebSocketSubscriptions/WithWebSocketSubscriptions.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { subscribeToReviewMessages, unsubscribeFromReviewMessages }
+import { subscribeToReviewMessages,
+         unsubscribeFromReviewMessages,
+         subscribeToChallengeTaskMessages,
+         unsubscribeFromChallengeTaskMessages }
        from '../../../services/Task/Task'
 
 /**
@@ -18,6 +21,8 @@ export const WithWebSocketSubscriptions = function(WrappedComponent) {
           {...this.props}
           subscribeToReviewMessages={this.props.subscribeToReviewMessages}
           unsubscribeFromReviewMessages={this.props.unsubscribeFromReviewMessages}
+          subscribeToChallengeTaskMessages={this.props.subscribeToChallengeTaskMessages}
+          unsubscribeFromChallengeTaskMessages={this.props.unsubscribeFromChallengeTaskMessages}
         />
       )
     }
@@ -27,6 +32,8 @@ export const WithWebSocketSubscriptions = function(WrappedComponent) {
 const mapDispatchToProps = dispatch => ({
   subscribeToReviewMessages: () => subscribeToReviewMessages(dispatch),
   unsubscribeFromReviewMessages: () => unsubscribeFromReviewMessages(),
+  subscribeToChallengeTaskMessages: challengeId => subscribeToChallengeTaskMessages(dispatch, challengeId),
+  unsubscribeFromChallengeTaskMessages: challengeId => unsubscribeFromChallengeTaskMessages(challengeId),
 })
 
 export default WrappedComponent =>

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -456,7 +456,8 @@ registerWidgetType(
             [TaskStatus.created]: true,
             [TaskStatus.skipped]: true,
             [TaskStatus.tooHard]: true,
-          }
+          },
+          includeLocked: false,
         }
       )
     )

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -89,31 +89,41 @@ const onReviewMessage = function(dispatch, messageObject) {
 }
 
 const onChallengeTaskMessage = function(dispatch, messageObject) {
-  const task = messageObject.data.task
+  let task = messageObject.data.task
   switch(messageObject.messageType) {
     case "task-claimed":
+      task = Object.assign({}, task, {lockedBy: _get(messageObject, 'data.byUser.userId')})
+      dispatchTaskUpdateNotification(dispatch, task)
+      break
+    case "task-released":
     case "task-update":
-      dispatch(receiveTasks(simulatedEntities(task)))
-      dispatch(receiveClusteredTasks(
-        task.parent,
-        false,
-        [
-          Object.assign({}, _pick(task, ['id', 'created', 'modified', 'priority', 'status', 'difficulty']), {
-            parentId: task.parent,
-            point: {lng: task.location.coordinates[0], lat: task.location.coordinates[1]},
-            title: task.name,
-            type: 2,
-          })
-        ],
-        RequestStatus.success,
-        uuidv1(),
-        true,
-        true
-      ))
+      dispatchTaskUpdateNotification(dispatch, task)
       break
     default:
       break // Ignore
   }
+}
+
+const dispatchTaskUpdateNotification = function(dispatch, task) {
+  dispatch(receiveTasks(simulatedEntities(task)))
+  dispatch(receiveClusteredTasks(
+    task.parent,
+    false,
+    [Object.assign(
+      {},
+      _pick(task, ['id', 'created', 'modified', 'priority', 'status', 'difficulty', 'lockedBy']),
+      {
+        parentId: task.parent,
+        point: {lng: task.location.coordinates[0], lat: task.location.coordinates[1]},
+        title: task.name,
+        type: 2,
+      }
+    )],
+    RequestStatus.success,
+    uuidv1(),
+    true,
+    true
+  ))
 }
 
 

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -1,4 +1,5 @@
 import { schema } from 'normalizr'
+import uuidv1 from 'uuid/v1'
 import _get from 'lodash/get'
 import _pick from 'lodash/pick'
 import _cloneDeep from 'lodash/cloneDeep'
@@ -23,6 +24,7 @@ import AppErrors from '../Error/AppErrors'
 import { generateSearchParametersString } from '../Search/Search'
 import { ensureUserLoggedIn } from '../User/User'
 import { markReviewDataStale } from './TaskReview/TaskReview'
+import { receiveClusteredTasks } from './ClusteredTask'
 import { TaskStatus } from './TaskStatus/TaskStatus'
 
 /** normalizr schema for tasks */
@@ -51,6 +53,17 @@ export const taskDenormalizationSchema = function() {
   })
 }
 
+export const subscribeToChallengeTaskMessages = function(dispatch, challengeId) {
+  websocketClient.addServerSubscription(
+    "challengeTasks", challengeId, "challengeTaskMessageHandler",
+    messageObject => onChallengeTaskMessage(dispatch, messageObject)
+  )
+}
+
+export const unsubscribeFromChallengeTaskMessages = function(challengeId) {
+  websocketClient.removeServerSubscription("challengeTasks", challengeId, "challengeTaskMessageHandler")
+}
+
 export const subscribeToReviewMessages = function(dispatch) {
   websocketClient.addServerSubscription(
     "reviews", null, "reviewMessageHandler",
@@ -69,6 +82,34 @@ const onReviewMessage = function(dispatch, messageObject) {
     case "review-update":
       // For now just mark the existing review data as stale
       dispatch(markReviewDataStale())
+      break
+    default:
+      break // Ignore
+  }
+}
+
+const onChallengeTaskMessage = function(dispatch, messageObject) {
+  const task = messageObject.data.task
+  switch(messageObject.messageType) {
+    case "task-claimed":
+    case "task-update":
+      dispatch(receiveTasks(simulatedEntities(task)))
+      dispatch(receiveClusteredTasks(
+        task.parent,
+        false,
+        [
+          Object.assign({}, _pick(task, ['id', 'created', 'modified', 'priority', 'status', 'difficulty']), {
+            parentId: task.parent,
+            point: {lng: task.location.coordinates[0], lat: task.location.coordinates[1]},
+            title: task.name,
+            type: 2,
+          })
+        ],
+        RequestStatus.success,
+        uuidv1(),
+        true,
+        true
+      ))
       break
     default:
       break // Ignore
@@ -140,15 +181,11 @@ export const fetchTaskTags = function(taskId) {
       {schema: {}, variables: {id: taskId}}
     ).execute().then(normalizedTags => {
       if (_isObject(normalizedTags.result)) {
-        // Inject tags into task.
-        dispatch(receiveTasks({
-          tasks: {
-            [taskId]: {
-              id: taskId,
-              tags: _values(normalizedTags.result),
-            }
-          }
-        }))
+        // Inject tags into task
+        dispatch(receiveTasks(simulatedEntities({
+          id: taskId,
+          tags: _values(normalizedTags.result),
+        })))
       }
       return normalizedTags
     })
@@ -328,16 +365,12 @@ export const fetchTaskComments = function(taskId) {
       dispatch(receiveComments(normalizedComments.entities))
 
       if (_isObject(normalizedComments.entities.comments)) {
-        // Inject comment ids into task.
-        dispatch(receiveTasks({
-          tasks: {
-            [taskId]: {
-              id: taskId,
-              comments: _map(_keys(normalizedComments.entities.comments),
-                             id => parseInt(id, 10)),
-            }
-          }
-        }))
+        // Inject comment ids into task
+        dispatch(receiveTasks(simulatedEntities({
+          id: taskId,
+          comments: _map(_keys(normalizedComments.entities.comments),
+                         id => parseInt(id, 10)),
+        })))
       }
 
       return normalizedComments
@@ -355,15 +388,11 @@ export const fetchTaskHistory = function(taskId) {
       {schema: {}, variables: {id: taskId}}
     ).execute().then(normalizedHistory => {
       if (_isObject(normalizedHistory.result)) {
-        // Inject history into task.
-        dispatch(receiveTasks({
-          tasks: {
-            [taskId]: {
-              id: taskId,
-              history: _values(normalizedHistory.result),
-            }
-          }
-        }))
+        // Inject history into task
+        dispatch(receiveTasks(simulatedEntities({
+          id: taskId,
+          history: _values(normalizedHistory.result),
+        })))
       }
 
       return normalizedHistory
@@ -552,14 +581,10 @@ const updateTaskStatus = function(dispatch, taskId, newStatus, requestReview = n
                                   osmComment = null, completionResponses = null) {
   // Optimistically assume request will succeed. The store will be updated
   // with fresh task data from the server if the save encounters an error.
-  dispatch(receiveTasks({
-    tasks: {
-      [taskId]: {
-        id: taskId,
-        status: newStatus
-      }
-    }
-  }))
+  dispatch(receiveTasks(simulatedEntities({
+    id: taskId,
+    status: newStatus,
+  })))
 
   const params = {}
   if (requestReview != null) {
@@ -675,14 +700,10 @@ export const fetchTaskPlace = function(task) {
     ).then(normalizedPlaceResults => {
       // Tasks have no natural reference to places, so inject the place id into
       // the task so that later denormalization will work properly.
-      return dispatch(receiveTasks({
-        tasks: {
-          [task.id]: {
-            id: task.id,
-            place: _get(normalizedPlaceResults, 'result'),
-          }
-        }
-      }))
+      return dispatch(receiveTasks(simulatedEntities({
+        id: task.id,
+        place: _get(normalizedPlaceResults, 'result'),
+      })))
     })
   }
 }
@@ -699,14 +720,10 @@ export const updateTaskTags = function(taskId, tags) {
     ).execute().then(normalizedTags => {
       if (_isObject(normalizedTags.result)) {
         // Inject tags into task.
-        dispatch(receiveTasks({
-          tasks: {
-            [taskId]: {
-              id: taskId,
-              tags: _values(normalizedTags.result),
-            }
-          }
-        }))
+        dispatch(receiveTasks(simulatedEntities({
+          id: taskId,
+          tags: _values(normalizedTags.result),
+        })))
       }
       return normalizedTags
     })
@@ -874,6 +891,19 @@ export const retrieveChallengeTask = function(dispatch, endpoint) {
     console.log(error.response || error)
     throw error
   })
+}
+
+/**
+ * Builds a simulated normalized entities representation from the given task
+ *
+ * @private
+ */
+export const simulatedEntities = function(task) {
+  return {
+    tasks: {
+      [task.id]: task,
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
> Note this PR is dependent on backend PR maproueltte/maproulette2##618

Support task action websocket messages

* Update redux task and clustered tasks with latest task data and lock
status when a task action websocket message is received

* Add option for filtering out locked tasks to
WithFilteredClusteredTasks HOC

* Subscribe to task action websocket messages in TaskBundleWidget for
the current challenge
