### PR TITLE
Exclude locked tasks from user-facing clusters

### DIFF
--- a/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.js
+++ b/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.js
@@ -112,7 +112,7 @@ export const WithBrowsedChallenge = function(WrappedComponent) {
 
             if (challenge.id !== _get(props, 'clusteredTasks.challengeId') ||
                 isVirtual !== _get(props, 'clusteredTasks.isVirtualChallenge')) {
-              props.fetchClusteredTasks(challenge.id, isVirtual)
+              props.fetchClusteredTasks(challenge.id, isVirtual, undefined, undefined, undefined, true)
             }
           }
           else if (!isVirtual && !_isFinite(this.state.loadingBrowsedChallenge)) {

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -87,6 +87,7 @@ export default class TaskBundleWidget extends Component {
         false,
         [TaskStatus.created, TaskStatus.skipped, TaskStatus.tooHard],
         15000,
+        true,
         true
       ).then(() => {
         this.setState({loading: false})

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -39,7 +39,7 @@ export const receiveBoundedTasks = function(tasks,
  * criteria, which should at least include a boundingBox field, and may
  * optionally include a filters field with additional constraints
  */
-export const fetchBoundedTasks = function(criteria, limit=50, skipDispatch=false) {
+export const fetchBoundedTasks = function(criteria, limit=50, skipDispatch=false, excludeLocked=true) {
   return function(dispatch) {
     const normalizedBounds = toLatLngBounds(criteria.boundingBox)
     if (!normalizedBounds) {
@@ -63,7 +63,7 @@ export const fetchBoundedTasks = function(criteria, limit=50, skipDispatch=false
           right: normalizedBounds.getEast(),
           top: normalizedBounds.getNorth(),
         },
-        params: {limit, page: (page * limit), ...searchParameters},
+        params: {limit, page: (page * limit), excludeLocked, ...searchParameters},
       }
     ).execute().then(normalizedResults => {
       const tasks = _values(_get(normalizedResults, 'entities.tasks', {}))

--- a/src/services/Task/ClusteredTask.js
+++ b/src/services/Task/ClusteredTask.js
@@ -58,7 +58,8 @@ export const clearClusteredTasks = function() {
 /**
  * Retrieve clustered task data belonging to the given challenge
  */
-export const fetchClusteredTasks = function(challengeId, isVirtualChallenge=false, statuses=[], limit=15000, mergeTasks=false) {
+export const fetchClusteredTasks = function(challengeId, isVirtualChallenge=false, statuses=[], limit=15000, mergeTasks=false,
+                                            excludeLocked=false) {
   return function(dispatch) {
     const fetchId = _uniqueId()
     dispatch(receiveClusteredTasks(
@@ -69,7 +70,7 @@ export const fetchClusteredTasks = function(challengeId, isVirtualChallenge=fals
       (isVirtualChallenge ? api.virtualChallenge : api.challenge).clusteredTasks, {
         schema: [ taskSchema() ],
         variables: {id: challengeId},
-        params: {limit, filter: statuses.join(',')},
+        params: {limit, excludeLocked, filter: statuses.join(',')},
       }
     ).execute().then(normalizedResults => {
       // Add parent field, and copy pointReview fields to top-level for


### PR DESCRIPTION
When presenting mapper with clusters (browsedChallenge and task bundle widget), exclude locked tasks.

This depends on back-end PR: "Add flag to exclude locked tasks from cluster methods #620"