### PR TITLE
Fix reviewer and mapper showing as ids in admin tasks table

### DIFF
--- a/src/services/Task/ClusteredTask.js
+++ b/src/services/Task/ClusteredTask.js
@@ -13,6 +13,7 @@ import _uniqueId from 'lodash/uniqueId'
 import _uniqBy from 'lodash/uniqBy'
 import _cloneDeep from 'lodash/cloneDeep'
 import _set from 'lodash/set'
+import _omit from 'lodash/omit'
 import { fetchBoundedTasks } from './BoundedTask'
 
 // redux actions
@@ -73,10 +74,10 @@ export const fetchClusteredTasks = function(challengeId, isVirtualChallenge=fals
       }
     ).execute().then(normalizedResults => {
       // Add parent field, and copy pointReview fields to top-level for
-      // backward compatibility
+      // backward compatibility (except reviewRequestedBy and reviewedBy)
       let tasks = _values(_get(normalizedResults, 'entities.tasks', {}))
       tasks = _map(tasks, task =>
-        Object.assign(task, {parent: challengeId}, task.pointReview)
+        Object.assign(task, {parent: challengeId}, _omit(task.pointReview, ["reviewRequestedBy", "reviewedBy"]))
       )
 
       dispatch(receiveClusteredTasks(


### PR DESCRIPTION
As backend started passing through new 'pointReview' field
we were copying these fields to top level for backward
compatability but reviewRequestedBy and reviewedBy were
already at top-level as objects instead of ids. Change
to not copy/overwrite these fields at top-level.