### PR TITLE
Refresh selections after recomputed filtered tasks

### DIFF
--- a/src/components/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
+++ b/src/components/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
@@ -340,12 +340,7 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
     componentDidUpdate(prevProps, prevState) {
       if (_get(prevProps[tasksProp], 'tasks.length', 0) !== _get(this.props[tasksProp], 'tasks.length', 0) ||
           _get(prevProps[tasksProp], 'fetchId') !== _get(this.props[tasksProp], 'fetchId')) {
-        this.setState({
-          filteredTasks: this.filterTasks(this.state.includeStatuses,
-                                          this.state.includeReviewStatuses,
-                                          this.state.includePriorities,
-                                          this.state.includeLocked)
-        })
+        this.refreshSelectedTasks()
       }
 
       if (!_isEqual(this.state.selectedTasks, prevState.selectedTasks)) {


### PR DESCRIPTION
* In WithFilteredClusteredTasks, ensure selected tasks are refreshed
when filtered tasks are recomputed due to a change in the task data