### PR TITLE
Swap all-tags icon for text label in TagDiffWidget

### DIFF
--- a/src/components/Widgets/TagDiffWidget/Messages.js
+++ b/src/components/Widgets/TagDiffWidget/Messages.js
@@ -13,5 +13,10 @@ export default defineMessages({
     id: "Widgets.TagDiffWidget.title",
     defaultMessage: "Proposed OSM Tag Changes",
   },
+
+  viewAllTagsLabel: {
+    id: "Widgets.TagDiffWidget.controls.viewAllTags.label",
+    defaultMessage: "Show all Tags",
+  },
 })
 

--- a/src/components/Widgets/TagDiffWidget/TagDiffWidget.js
+++ b/src/components/Widgets/TagDiffWidget/TagDiffWidget.js
@@ -10,7 +10,6 @@ import { TaskReviewStatus }
 import QuickWidget from '../../QuickWidget/QuickWidget'
 import TagDiffVisualization from '../../TagDiffVisualization/TagDiffVisualization'
 import TagDiffModal from '../../TagDiffVisualization/TagDiffModal'
-import SvgSymbol from '../../SvgSymbol/SvgSymbol'
 import BusySpinner from '../../BusySpinner/BusySpinner'
 import messages from './Messages'
 
@@ -37,19 +36,15 @@ export default class TagDiffWidget extends Component {
         noMain
         permanent
         widgetTitle={
-          <div className="mr-flex">
-            <FormattedMessage {...messages.title} />
-            <button
-              className="mr-text-green-lighter mr-ml-4"
-              onClick={() => this.setState({showDiffModal: true})}
-            >
-              <SvgSymbol
-                sym="expand-icon"
-                viewBox="0 0 32 32"
-                className="mr-transition mr-fill-current mr-w-4 mr-h-4"
-              />
-            </button>
-          </div>
+          <FormattedMessage {...messages.title} />
+        }
+        rightHeaderControls={
+          <button
+            className="mr-button mr-button--small"
+            onClick={() => this.setState({showDiffModal: true})}
+          >
+            <FormattedMessage {...messages.viewAllTagsLabel} />
+          </button>
         }
       >
         <TagDiff {...this.props} />


### PR DESCRIPTION
* Improve clarity of TagDiffWidget control for viewing all OSM tags by
replacing icon with text label