### PR TITLE
Show OSM tags on quick-fix task popups. Fixes #915

### DIFF
--- a/src/components/TaskPane/TaskMap/TaskMap.js
+++ b/src/components/TaskPane/TaskMap/TaskMap.js
@@ -32,6 +32,9 @@ import WithKeyboardShortcuts
 import WithMapillaryImages from '../../HOCs/WithMapillaryImages/WithMapillaryImages'
 import { MIN_ZOOM, MAX_ZOOM, DEFAULT_ZOOM }
        from '../../../services/Challenge/ChallengeZoom/ChallengeZoom'
+import AsMappableTask from '../../../interactions/Task/AsMappableTask'
+import { supportedSimplestyles }
+       from '../../../interactions/TaskFeature/AsSimpleStyleableFeature'
 import BusySpinner from '../../BusySpinner/BusySpinner'
 import './TaskMap.scss'
 
@@ -221,6 +224,10 @@ export class TaskMap extends Component {
       }
     }
 
+    if (nextProps.loadingOSMData !== this.props.loadingOSMData) {
+      return true
+    }
+
     return false
   }
 
@@ -275,6 +282,18 @@ export class TaskMap extends Component {
         _flatten(_compact(_map(this.props.taskBundle.tasks,
                                task => _get(task, 'geometries.features'))))
       ).features
+    }
+
+    // If current OSM data is available, show the feature's current OSM tags
+    // instead of those bundled with the GeoJSON. We preserve any simplestyle
+    // properties, allowing display colors and what not to be customized
+    if (_get(this.props, 'osmElements.size', 0) > 0) {
+      return AsMappableTask(this.props.task).featuresWithTags(
+        _get(this.props.task, 'geometries.features'),
+        this.props.osmElements,
+        true,
+        supportedSimplestyles,
+      )
     }
 
     return _get(this.props.task, 'geometries.features')

--- a/src/interactions/Task/AsMappableTask.js
+++ b/src/interactions/Task/AsMappableTask.js
@@ -4,7 +4,12 @@ import bbox from '@turf/bbox'
 import _get from 'lodash/get'
 import _isObject from 'lodash/isObject'
 import _isArray from 'lodash/isArray'
+import _map from 'lodash/map'
+import _fromPairs from 'lodash/fromPairs'
+import _pick from 'lodash/pick'
+import _cloneDeep from 'lodash/cloneDeep'
 import { latLng } from 'leaflet'
+import AsIdentifiableFeature from '../TaskFeature/AsIdentifiableFeature'
 
 /**
  * AsMappableTask adds functionality to a Task related to mapping.
@@ -89,6 +94,50 @@ export class AsMappableTask {
       const centerPoint = this.calculateCenterPoint()
       return bbox(point([centerPoint.lng, centerPoint.lat]))
     }
+  }
+
+  /**
+   * Clones the given features, returning a new array of features with their
+   * properties replaced with the tag data from the given osmElements. If
+   * includeId is true then an `@id` property will also be included. Features
+   * with no id or no data in osmElements will be returned with their original
+   * property set. Specific original properties can also be preserved by
+   * including their names in the preserveProperties array
+   */
+  featuresWithTags(features, osmElements, includeId=true, preserveProperties=[]) {
+    return _map(features, originalFeature => {
+      const feature = _cloneDeep(originalFeature)
+      const elementId = AsIdentifiableFeature(feature).rawFeatureId()
+      if (!elementId || !osmElements.has(elementId)) {
+        // No id or no data for id, so return feature as-is
+        return feature
+      }
+
+      feature.properties = Object.assign(
+        includeId ? {'@id': elementId} : {},
+        this.tagsObjectFor(elementId, osmElements),
+        _pick(originalFeature.properties, preserveProperties)
+      )
+
+      return feature
+    })
+  }
+
+  /**
+   * Generates an object representation of the tags for the specified OSM
+   * element id (e.g. "way/123456789") based on the data from osmElements.
+   * Returns null if osmElements does not contain data for the given id
+   *
+   * @private
+   */
+  tagsObjectFor(elementId, osmElements) {
+    if (!osmElements.has(elementId)) {
+      return null
+    }
+
+    return _fromPairs(
+      _map(osmElements.get(elementId).tag, tag => [tag.k, tag.v])
+    )
   }
 }
 

--- a/src/interactions/TaskFeature/AsIdentifiableFeature.js
+++ b/src/interactions/TaskFeature/AsIdentifiableFeature.js
@@ -1,0 +1,56 @@
+import _find from 'lodash/find'
+
+/**
+ * The names of feature and property fields that may be used to identify a
+ * feature representing an OSM element
+ */
+export const featureIdFields = ['@id', 'osmid', 'osmId', 'osmIdentifier', 'id']
+
+/**
+ * AsIdentifiableFeature adds functionality to a Task feature related to
+ * identification, especially identification of the OSM element represented by
+ * the feature
+ */
+export class AsIdentifiableFeature {
+  constructor(feature) {
+    Object.assign(this, feature)
+  }
+
+  /**
+   * Returns the complete id found on the given feature or its properties, or
+   * null if none is found
+   */
+  rawFeatureId() {
+    if (!this.properties) {
+      return null
+    }
+
+    // Look on the feature itself first, then on its properties
+    let idProp = _find(featureIdFields, name => this[name])
+    if (idProp) {
+      return this[idProp]
+    }
+
+    idProp = _find(featureIdFields, name => this.properties[name])
+    return idProp ? this.properties[idProp] : null
+  }
+
+  /**
+   * Extracts the numerical OSM id from the raw feature id, returning null if
+   * the feature isn't identifiable or a numerical id could not be extracted
+   */
+  osmId() {
+    const featureId = this.rawFeatureId()
+    if (!featureId) {
+      return null
+    }
+
+    // feature ids may contain additional information, such as a representation
+    // of the feature type (way, node, etc). We want to return just the the
+    // numerical OSM id
+    const match = /(\d+)/.exec(featureId)
+    return (match && match.length > 1) ? match[1] : null
+  }
+}
+
+export default feature => new AsIdentifiableFeature(feature)

--- a/src/interactions/TaskFeature/AsSimpleStyleableFeature.js
+++ b/src/interactions/TaskFeature/AsSimpleStyleableFeature.js
@@ -1,5 +1,19 @@
 import _isUndefined from 'lodash/isUndefined'
 import _each from 'lodash/each'
+import _keys from 'lodash/keys'
+
+
+// Maps simplestyle property names to corresponding leaflet style option names
+const simplestyleLeafletMapping = {
+  'stroke': 'color',
+  'stroke-width': 'weight',
+  'stroke-opacity': 'opacity',
+  'fill': 'fillColor',
+  'fill-opacity': 'fillOpacity',
+}
+
+// Names of supported simplestyle properties
+export const supportedSimplestyles = _keys(simplestyleLeafletMapping)
 
 /**
  * AsSimpleStylableFeature adds functionality for interpreting
@@ -10,22 +24,13 @@ export class AsSimpleStyleableFeature {
     Object.assign(this, feature)
   }
 
-  // Maps simplestyle propertie names to corresponding leaflet style option names
-  simplestyleLeafletMapping = {
-    'stroke': 'color',
-    'stroke-width': 'weight',
-    'stroke-opacity': 'opacity',
-    'fill': 'fillColor',
-    'fill-opacity': 'fillOpacity',
-  }
-
   /**
    * Styles the given Leaflet layer with any supported simplestyle properties
    * present on this feature
    */
   styleLeafletLayer(layer) {
     if (this.properties) {
-      _each(this.simplestyleLeafletMapping, (leafletStyle, simplestyleProperty) => {
+      _each(simplestyleLeafletMapping, (leafletStyle, simplestyleProperty) => {
         if (!_isUndefined(this.properties[simplestyleProperty])) {
           layer.setStyle({[leafletStyle]: this.properties[simplestyleProperty]})
         }

--- a/src/services/Editor/Editor.js
+++ b/src/services/Editor/Editor.js
@@ -9,6 +9,7 @@ import _isEmpty from 'lodash/isEmpty'
 import RequestStatus from '../Server/RequestStatus'
 import AsMappableTask from '../../interactions/Task/AsMappableTask'
 import AsMappableBundle from '../../interactions/TaskBundle/AsMappableBundle'
+import AsIdentifiableFeature from '../../interactions/TaskFeature/AsIdentifiableFeature'
 import { toLatLngBounds  } from '../MapBounds/MapBounds'
 import { addError } from '../Error/Error'
 import AppErrors from '../Error/AppErrors'
@@ -25,12 +26,6 @@ export const RAPID = 5
 
 // Default editor choice if user has not selected an editor
 export const DEFAULT_EDITOR = ID
-
-/**
- * Supported names of properties used to identify an OSM entity associated with
- * a feature.
- */
-export const osmIdentifierFields = ['osmid', 'id', '@id', 'osmIdentifier']
 
 // Reference to open editor window
 let editorWindowReference = null
@@ -264,7 +259,7 @@ export const osmObjectParams = function(task, abbreviated=false, entitySeparator
   allTasks.forEach(task => {
     if (task.geometries && task.geometries.features) {
       objects = objects.concat(_compact(task.geometries.features.map(feature => {
-        const osmId = featureOSMId(feature)
+        const osmId = AsIdentifiableFeature(feature).osmId()
         if (!osmId) {
           return null
         }
@@ -444,24 +439,6 @@ const openJOSM = function(dispatch, editor, task, mapBounds, josmURIFunction, ta
       return dispatch(editorOpened(editor, task.id, RequestStatus.error))
     }
   })
-}
-
-/**
- * Retrieve an OSM identifier for the given task feature, if available
- */
-export const featureOSMId = function(feature) {
-  // Identifiers can live on the feature itself or as a property
-  const osmId = firstTruthyValue(feature, osmIdentifierFields) ||
-                firstTruthyValue(feature.properties, osmIdentifierFields)
-
-  if (!osmId) {
-    return null
-  }
-
-  // id properties may contain additional information, such as a representation
-  // of the feature type. We want to return just the the numerical OSM id
-  const match = /(\d+)/.exec(osmId)
-  return (match && match.length > 1) ? match[1] : null
 }
 
 /**


### PR DESCRIPTION
* For quick-fix tasks, show latest OSM tag values on the Properties
popup if the user clicks the task on the map, ignoring most properties
originally uploaded with the task (simplestyle properties are preserved)

* Consolidate extraction of OSM ids from task features into new 
AsIdentifiableFeature interaction

* Update Editor service to make use of new AsIdentifiableFeature
interaction