### PR TITLE
OSM tags in TaskPropertiesWidget for quick fixes

### DIFF
--- a/src/components/Widgets/TaskPropertiesWidget/TaskPropertiesWidget.js
+++ b/src/components/Widgets/TaskPropertiesWidget/TaskPropertiesWidget.js
@@ -23,7 +23,7 @@ export default class TaskPropertiesWidget extends Component {
   render() {
     const taskList = _get(this.props.taskBundle, 'tasks') || [this.props.task]
     const propertyLists = _map(taskList, (task) => {
-      const properties = AsMappableTask(task).allFeatureProperties()
+      const properties = AsMappableTask(task).osmFeatureProperties(this.props.osmElements)
       return (
         <div key={task.id} className="mr-mb-6">
           <div className="mr-text-yellow">

--- a/src/interactions/Task/AsMappableTask.js
+++ b/src/interactions/Task/AsMappableTask.js
@@ -10,6 +10,7 @@ import _pick from 'lodash/pick'
 import _cloneDeep from 'lodash/cloneDeep'
 import { latLng } from 'leaflet'
 import AsIdentifiableFeature from '../TaskFeature/AsIdentifiableFeature'
+import { supportedSimplestyles } from '../TaskFeature/AsSimpleStyleableFeature'
 
 /**
  * AsMappableTask adds functionality to a Task related to mapping.
@@ -43,20 +44,43 @@ export class AsMappableTask {
    * task's geometries. Later properties will overwrite earlier properties with
    * the same name.
    */
-  allFeatureProperties() {
+  allFeatureProperties(features) {
     if (!this.hasGeometries()) {
       return []
     }
 
+    if (!features) {
+      features = this.geometries.features
+    }
+
     let allProperties = {}
 
-    this.geometries.features.forEach(feature => {
+    features.forEach(feature => {
       if (feature && feature.properties) {
         allProperties = Object.assign(allProperties, feature.properties)
       }
     })
 
     return allProperties
+  }
+
+  /**
+   * Similar to allFeatureProperties, but uses current OSM tags for the feature
+   * properties. If OSM data isn't available, falls back to default behavior of
+   * allFeatureProperties
+   */
+  osmFeatureProperties(osmElements) {
+    if (!this.hasGeometries()) {
+      return []
+    }
+
+    if (!osmElements || osmElements.size === 0) {
+      return this.allFeatureProperties()
+    }
+
+    return this.allFeatureProperties(
+      this.featuresWithTags(this.geometries.features, osmElements, true, supportedSimplestyles)
+    )
   }
 
   /**

--- a/src/interactions/TaskFeature/AsIdentifiableFeature.js
+++ b/src/interactions/TaskFeature/AsIdentifiableFeature.js
@@ -4,7 +4,7 @@ import _find from 'lodash/find'
  * The names of feature and property fields that may be used to identify a
  * feature representing an OSM element
  */
-export const featureIdFields = ['@id', 'osmid', 'osmId', 'osmIdentifier', 'id']
+export const featureIdFields = ['@id', 'osmid', 'osmIdentifier', 'id']
 
 /**
  * AsIdentifiableFeature adds functionality to a Task feature related to


### PR DESCRIPTION
* Show current OSM tags for task properties in TaskPropertiesWidget for
quick-fix tasks, just as we do on the properties popup if a user were to
click the task on the task map