### PR TITLE
Don't try to simplestyle point features

### DIFF
--- a/src/interactions/TaskFeature/AsSimpleStyleableFeature.js
+++ b/src/interactions/TaskFeature/AsSimpleStyleableFeature.js
@@ -31,7 +31,7 @@ export class AsSimpleStyleableFeature {
   styleLeafletLayer(layer) {
     if (this.properties) {
       _each(simplestyleLeafletMapping, (leafletStyle, simplestyleProperty) => {
-        if (!_isUndefined(this.properties[simplestyleProperty])) {
+        if (!_isUndefined(this.properties[simplestyleProperty]) && layer.setStyle) {
           layer.setStyle({[leafletStyle]: this.properties[simplestyleProperty]})
         }
       })


### PR DESCRIPTION
* Check to make sure a leaflet layer can be styled before trying to
apply simplestyle property styling, as we don't currently support
styling of point/node features