### PR TITLE
Don't syntax-highlight missing task geometry

### DIFF
--- a/src/components/ViewTask/ViewTask.js
+++ b/src/components/ViewTask/ViewTask.js
@@ -4,12 +4,13 @@ import { Light as SyntaxHighlighter } from 'react-syntax-highlighter'
 import jsonLang from 'react-syntax-highlighter/dist/languages/hljs/json'
 import highlightColors from 'react-syntax-highlighter/dist/styles/hljs/github'
 import BusySpinner from '../BusySpinner/BusySpinner'
+import _get from 'lodash/get'
 
 SyntaxHighlighter.registerLanguage('json', jsonLang);
 
 export default class ViewTask extends Component {
   render() {
-    if (!this.props.task) {
+    if (!_get(this.props, 'task.geometries')) {
       return <BusySpinner />
     }
 


### PR DESCRIPTION
* When viewing the GeoJSON for a task in the Create & Manage area, wait
for the task geometry to be fully loaded before trying to display
syntax-highlighted JSON