### PR TITLE
Initial support for OSM element short-codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "redux-thunk": "^2.2.0",
     "remark": "^7.0.1",
     "remark-external-links": "^3.0.0",
-    "remark-react": "^4.0.0",
+    "remark-react": "^6.0.0",
     "route-matcher": "^0.1.0",
     "stale-lru-cache": "^5.1.1",
     "uuid": "^3.3.2",

--- a/src/components/CommentList/CommentList.js
+++ b/src/components/CommentList/CommentList.js
@@ -55,7 +55,7 @@ export default class CommentList extends Component {
           </div>
           <div className={classNames("mr-text-sm mr-rounded-sm mr-p-2",
                                      this.props.lightMode ? "mr-bg-grey-lighter" : "mr-bg-grey-lighter-10")}>
-            <MarkdownContent markdown={comment.comment} />
+            <MarkdownContent allowShortCodes markdown={comment.comment} />
           </div>
 
           {(this.props.includeChallengeNames || this.props.includeTaskLinks) &&

--- a/src/components/HOCs/WithEditor/WithEditor.js
+++ b/src/components/HOCs/WithEditor/WithEditor.js
@@ -1,24 +1,48 @@
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
-import { editTask, closeEditor } from '../../../services/Editor/Editor'
+import _get from 'lodash/get'
+import { editTask, closeEditor, loadObjectsIntoJOSM,
+         josmHost, isJosmEditor, DEFAULT_EDITOR }
+       from '../../../services/Editor/Editor'
+import { addError } from '../../../services/Error/Error'
+import AppErrors from '../../../services/Error/AppErrors'
 
 /**
  * WithEditor provides an editor prop to its WrappedComponent that contains the
- * current open editor (if any) from the redux store, as well as functions for
- * initiating and ending editing of a task.
+ * current open editor (if any) from the redux store and the user's currently
+ * configured editor (or the system default editor if none is configured), as
+ * well as functions for interacting with editors
  *
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 const WithEditor =
   WrappedComponent => connect(mapStateToProps, mapDispatchToProps)(WrappedComponent)
 
-export const mapStateToProps = state => ({
-  editor: state.openEditor,
-})
+export const mapStateToProps = state => {
+  const userId = _get(state, 'currentUser.userId')
+  const userEntity = _get(state, `entities.users.${userId}`)
 
-export const mapDispatchToProps = dispatch => bindActionCreators({
-  editTask,
-  closeEditor,
-}, dispatch)
+  return ({
+    editor: state.openEditor,
+    configuredEditor: _get(userEntity, 'settings.defaultEditor', DEFAULT_EDITOR),
+  })
+}
+
+export const mapDispatchToProps = dispatch => {
+  return Object.assign({
+    loadObjectsIntoJOSM: (objectIds, asNewLayer) => {
+      return loadObjectsIntoJOSM(objectIds, asNewLayer).then(success => {
+        if (!success) {
+          dispatch(addError(AppErrors.josm.noResponse))
+        }
+      })
+    },
+    isJosmEditor,
+    josmHost,
+  }, bindActionCreators({
+    editTask,
+    closeEditor,
+  }, dispatch))
+}
 
 export default WithEditor

--- a/src/components/MarkdownContent/MarkdownContent.js
+++ b/src/components/MarkdownContent/MarkdownContent.js
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import remark from 'remark'
 import externalLinks from 'remark-external-links'
 import reactRenderer from 'remark-react'
+import { expandShortCodesInJSX } from '../../services/ShortCodes/ShortCodes'
 
 /**
  * MarkdownContent normalizes and renders the content of the given markdown
@@ -19,13 +20,17 @@ export default class MarkdownContent extends Component {
 
     // Replace any occurrences of \r\n with newlines.
     const normalizedMarkdown = this.props.markdown.replace(/\r\n/mg, "\n\n")
+    let parsedMarkdown =
+      remark().use(externalLinks, {target: '_blank', rel: ['nofollow']})
+              .use(reactRenderer).processSync(normalizedMarkdown).contents
+
+    if (this.props.allowShortCodes) {
+      parsedMarkdown = expandShortCodesInJSX(parsedMarkdown)
+    }
 
     return (
       <div className={classNames('mr-markdown', this.props.className)}>
-        {
-          remark().use(externalLinks, {target: '_blank', rel: ['nofollow']})
-                  .use(reactRenderer).processSync(normalizedMarkdown).contents
-        }
+        {parsedMarkdown}
       </div>
     )
   }

--- a/src/components/OSMElementReference/OSMElementReference.js
+++ b/src/components/OSMElementReference/OSMElementReference.js
@@ -1,0 +1,66 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import WithEditor from '../HOCs/WithEditor/WithEditor'
+import { Editor } from '../../services/Editor/Editor'
+
+/**
+ * Renders a reference to an OSM element (such as a node or way) as an Overpass
+ * Turbo link, but on click will try to load the data into JOSM if that is the
+ * user's chosen editor -- otherwise will proceed to open Overpass Turbo in a
+ * new browser tab
+ */
+export class OSMElementReference extends PureComponent {
+  overpassQuery() {
+    const elementStatements = this.props.osmElements.map(
+      osmElement => `${osmElement.elementType}(${osmElement.osmId});`
+    ).join('')
+
+    return `(${elementStatements});(._;>;);out;`
+  }
+
+  description() {
+    return this.props.osmElements.map(
+      osmElement => `${osmElement.elementType} ${osmElement.osmId}`
+    ).join(', ')
+  }
+
+  loadInJOSMIfActive(clickEvent) {
+    if (!this.props.isJosmEditor(this.props.configuredEditor)) {
+      return
+    }
+
+    clickEvent.preventDefault()
+    const josmObjectIds = this.props.osmElements.map(
+      osmElement => `${osmElement.elementType[0]}${osmElement.osmId}`
+    )
+    this.props.loadObjectsIntoJOSM(josmObjectIds,
+                                   this.props.configuredEditor === Editor.josmLayer)
+  }
+
+  render() {
+    const overpassUrl =
+      `https://overpass-turbo.eu/map.html?Q=${encodeURIComponent(this.overpassQuery())}`
+
+    return (
+      <a
+        href={overpassUrl}
+        target="_blank"
+        rel="noopener noreferrer nofollow"
+        onClick={e => this.loadInJOSMIfActive(e)}
+      >
+        {this.description()}
+      </a>
+    )
+  }
+}
+
+OSMElementReference.propTypes = {
+  osmElements: PropTypes.arrayOf(
+    PropTypes.shape({
+      elementType: PropTypes.string.isRequired,
+      osmId: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+}
+
+export default WithEditor(OSMElementReference)

--- a/src/components/TaskHistoryList/TaskHistoryList.js
+++ b/src/components/TaskHistoryList/TaskHistoryList.js
@@ -197,7 +197,7 @@ const commentEntry = (entry, props, index) => {
         viewBox="0 0 20 20"
         className="mr-fill-current mr-flex-no-shrink mr-w-4 mr-h-4 mr-mt-3 mr-mr-2"
       />
-      <MarkdownContent markdown={entry.comment} />
+      <MarkdownContent allowShortCodes markdown={entry.comment} />
     </li>
   )
 }

--- a/src/pages/Inbox/Notification.js
+++ b/src/pages/Inbox/Notification.js
@@ -165,7 +165,7 @@ const AttachedComment = function(props) {
       <p className="mr-text-xs">{props.notification.fromUsername}</p>
       <div className="mr-text-sm mr-rounded-sm mr-p-2 mr-bg-grey-lighter-10">
         <div className="mr-markdown mr-markdown--longtext">
-          <Markdown markdown={props.notification.extra} />
+          <Markdown allowShortCodes markdown={props.notification.extra} />
         </div>
       </div>
     </React.Fragment>

--- a/src/services/Editor/Editor.js
+++ b/src/services/Editor/Editor.js
@@ -442,6 +442,19 @@ const openJOSM = function(dispatch, editor, task, mapBounds, josmURIFunction, ta
 }
 
 /**
+ * Load the given objects into JOSM
+ */
+export const loadObjectsIntoJOSM = function(objectIds, asNewLayer) {
+  const objectIdString = objectIds.join(',')
+  let josmURI = `${josmHost()}load_object?objects=${objectIdString}&layer_name=${objectIdString}`
+  if (asNewLayer) {
+    josmURI += "&new_layer=true"
+  }
+
+  return sendJOSMCommand(josmURI)
+}
+
+/**
  * Returns the first truthy value from the given object that is encountered a
  * given acceptable key, which are attempted in order. If no truthy values are
  * found, or if the given object is null/undefined, then undefined is returned.

--- a/src/services/ShortCodes/Handlers/OSMElementHandler.js
+++ b/src/services/ShortCodes/Handlers/OSMElementHandler.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import OSMElementReference
+       from '../../../components/OSMElementReference/OSMElementReference'
+
+
+/**
+ * Expands OSM element reference shortcodes to nodes, ways, and references,
+ * e.g. for way 1234567: `[w/1234567]` or `[w1234567]` or `[w 1234567]` or
+ * `[way/1234567]` or `[way1234567]` or `[way 1234567]`
+ *
+ * Multiple references can be included in a single short-code, separated by
+ * commas: `[n123456789, w987654321]`
+ *
+ * Codes are expanded into links that either pull element data into JOSM (if
+ * active) or else open a new browser tab to display them in Overpass Turbo
+ */
+const OSMElementReferenceCode = {
+  osmElementRegex: "(n|w|r|node|way|rel|relation)[/ ]?(\\d+)[,\\s]*",
+
+  elementTypeMap: {
+    'n': 'node',
+    'node': 'node',
+    'w': 'way',
+    'way': 'way',
+    'r': 'relation',
+    'rel': 'relation',
+    'relation': 'relation',
+  },
+
+  handlesShortCode(shortCode) {
+    return new RegExp(this.osmElementRegex).test(shortCode)
+  },
+
+  expandShortCode(shortCode) {
+    const matchedElements = []
+
+    const regex = RegExp(this.osmElementRegex, 'g')
+    let osmElementMatch = null
+    while ((osmElementMatch = regex.exec(shortCode.slice(1, -1)))) {
+      matchedElements.push({
+        elementType: this.elementTypeMap[osmElementMatch[1]],
+        osmId: osmElementMatch[2],
+      })
+    }
+
+    return matchedElements.length > 0 ?
+           <OSMElementReference osmElements={matchedElements} /> :
+           shortCode
+  }
+}
+
+export default OSMElementReferenceCode

--- a/src/services/ShortCodes/ShortCodes.js
+++ b/src/services/ShortCodes/ShortCodes.js
@@ -1,0 +1,99 @@
+import React from 'react'
+import _find from 'lodash/find'
+import _compact from 'lodash/compact'
+import _isEmpty from 'lodash/isEmpty'
+import _map from 'lodash/map'
+import _isString from 'lodash/isString'
+import _uniqueId from 'lodash/uniqueId'
+
+import OSMElementHandler from './Handlers/OSMElementHandler'
+
+// All available short-code handlers
+const shortCodeHandlers = [OSMElementHandler]
+
+// Short codes are surrounded by brackets, but -- to avoid confusion with
+// Markdown links -- cannot be immediately followed by an open parenthesees
+// (hence the lookahead at the end)
+const shortCodeRegex = /(\[[^\]]+\])(?=[^(]|$)/g
+
+/**
+ * Recursively runs through the given JSX element tree and expands any
+ * short-codes found within the element child content (not props), returning a
+ * cloned copy of the element tree with supported short-codes expanded
+ */
+export const expandShortCodesInJSX = function(jsxNode) {
+  return React.cloneElement(
+    jsxNode,
+    {},
+    _map(jsxNode.props.children, child => {
+      if (_isString(child)) {
+        if (!containsShortCode(child)) {
+          return child
+        }
+
+        return _map(tokenize(child), token => (
+          <span key={_uniqueId('sc-')}>{expandedTokenContent(token)}</span>
+        ))
+      }
+      else {
+        return expandShortCodesInJSX(child)
+      }
+    })
+  )
+}
+
+/**
+ * Determines if the given string content contains one or more short-codes
+ */
+export const containsShortCode = function(content) {
+  return shortCodeRegex.test(content)
+}
+
+/**
+ * Runs through the available short-code handlers to find one that is capable
+ * of handling the given short-code, asks that handler to expand the
+ * short-code, and returns the expanded results
+ */
+export const expandShortCode = function(shortCode) {
+  const targetHandler =
+    _find(shortCodeHandlers, handler => handler.handlesShortCode(shortCode))
+
+  if (!targetHandler) {
+    // Unsupported short code, just return it as-is
+    return shortCode
+  }
+
+  return targetHandler.expandShortCode(shortCode)
+}
+
+/**
+ * Tokenizes string content into an array to separate out short-codes from the
+ * rest of the content. Each element is either content free of short-codes or a
+ * single short-code
+ */
+export const tokenize = function(content) {
+  if (!content) {
+    return []
+  }
+
+  return _compact(_map(
+    // Clear out any empty tokens
+    content.split(shortCodeRegex), token => _isEmpty(token) ? null : token
+  ))
+}
+
+/**
+ * Determines if the given token (from the tokenize function) represents a
+ * short-code
+ */
+export const isShortCodeToken = function(token) {
+  return token.length > 2 && token[0] === '[' && token[token.length - 1] === ']'
+}
+
+/**
+ * Returns appropriate content for the given token, either an expanded short
+ * code if the token represents a short-code or the original content if not
+ */
+export const expandedTokenContent = function(token) {
+  return isShortCodeToken(token) ? expandShortCode(token) : token
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4371,7 +4371,7 @@ default-gateway@^4.2.0:
     execa "^1.0.0"
     ip-regex "^2.1.0"
 
-define-properties@^1.1.1, define-properties@^1.1.2, define-properties@^1.1.3:
+define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   dependencies:
@@ -5989,25 +5989,26 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hast-to-hyperscript@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/hast-to-hyperscript/-/hast-to-hyperscript-4.0.0.tgz#3eb25483ec72a8e9a71e4b1ad7eb8f7c86f755db"
+hast-to-hyperscript@^7.0.0:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/hast-to-hyperscript/-/hast-to-hyperscript-7.0.3.tgz#e36b2a32b237f83bbb80165351398226f12b7d6e"
+  integrity sha512-h4t0U8KIImkFCXswj0IzRhPgps6GpLxyjSPfI4ECF+bE13sHu1fY/UP8tvJmfLNa6blQctiyba4pUsvm3WrXMg==
   dependencies:
     comma-separated-tokens "^1.0.0"
-    is-nan "^1.2.1"
-    kebab-case "^1.0.0"
-    property-information "^3.0.0"
+    property-information "^5.3.0"
     space-separated-tokens "^1.0.0"
-    trim "0.0.1"
-    unist-util-is "^2.0.0"
+    style-to-object "^0.2.1"
+    unist-util-is "^3.0.0"
+    web-namespaces "^1.1.2"
 
 hast-util-parse-selector@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.2.tgz#66aabccb252c47d94975f50a281446955160380b"
 
-hast-util-sanitize@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-1.3.1.tgz#4e60d66336bd67e52354d581967467029a933f2e"
+hast-util-sanitize@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-2.0.1.tgz#de2f32c5aa9e93b61903e4381be6c49887d3829e"
+  integrity sha512-Hk9YC6+HURcdNuBFaPP5nX6xK6zPnm0Dr6QnU4hvvXoStzH5nLI1u71wux6u3fbEQk3/+kTEIcyxRtCA0jt9RA==
   dependencies:
     xtend "^4.0.1"
 
@@ -6342,6 +6343,11 @@ ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
+inline-style-parser@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
+  integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
+
 inquirer@6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.0.tgz#2303317efc9a4ea7ec2e2df6f86569b734accf42"
@@ -6632,12 +6638,6 @@ is-glob@^4.0.0, is-glob@^4.0.1:
 is-hexadecimal@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz#e8a426a69b6d31470d3a33a47bb825cda02506ee"
-
-is-nan@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.2.1.tgz#9faf65b6fb6db24b7f5c0628475ea71f988401e2"
-  dependencies:
-    define-properties "^1.1.1"
 
 is-number-object@^1.0.3:
   version "1.0.3"
@@ -7464,10 +7464,6 @@ jsx-ast-utils@^2.1.0, jsx-ast-utils@^2.2.1:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
 
-kebab-case@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/kebab-case/-/kebab-case-1.0.0.tgz#3f9e4990adcad0c686c0e701f7645868f75f91eb"
-
 killable@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
@@ -7873,9 +7869,10 @@ mdast-util-definitions@^1.2.0, mdast-util-definitions@^1.2.3:
   dependencies:
     unist-util-visit "^1.0.0"
 
-mdast-util-to-hast@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-3.0.4.tgz#132001b266031192348d3366a6b011f28e54dc40"
+mdast-util-to-hast@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-6.0.2.tgz#24a8791b7c624118637d70f03a9d29116e4311cf"
+  integrity sha512-GjcOimC9qHI0yNFAQdBesrZXzUkRdFleQlcoU8+TVNfDW6oLUazUx8MgUoTaUyCJzBOnE5AOgqhpURrSlf0QwQ==
   dependencies:
     collapse-white-space "^1.0.0"
     detab "^2.0.0"
@@ -9869,13 +9866,16 @@ prop-types@15.x, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, pro
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
-property-information@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/property-information/-/property-information-3.2.0.tgz#fd1483c8fbac61808f5fe359e7693a1f48a58331"
-
 property-information@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.1.0.tgz#e4755eee5319f03f7f6f5a9bc1a6a7fea6609e2c"
+  dependencies:
+    xtend "^4.0.1"
+
+property-information@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.3.0.tgz#bc87ac82dc4e72a31bb62040544b1bf9653da039"
+  integrity sha512-IslotQn1hBCZDY7SaJ3zmCjVea219VTwmOk6Pu3z9haU9m4+T8GwaDubur+6NMHEU+Fjs/6/p66z6QULPkcL1w==
   dependencies:
     xtend "^4.0.1"
 
@@ -10788,14 +10788,15 @@ remark-parse@^3.0.0:
     vfile-location "^2.0.0"
     xtend "^4.0.1"
 
-remark-react@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/remark-react/-/remark-react-4.0.3.tgz#980938f3bcc93bef220215b26b0b0a80f3158c7d"
+remark-react@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/remark-react/-/remark-react-6.0.0.tgz#2bc46ce2ba74a8561d8984bf7885b5eb1ebc8273"
+  integrity sha512-5g73p8ZuqKoSdKByEf6IbXtVaHnbSEV0aamhIIqpzeNvj1wWDPX0USSPs4Gf3ZAsQIehIp6QiqJIbbXpq74bug==
   dependencies:
     "@mapbox/hast-util-table-cell-style" "^0.1.3"
-    hast-to-hyperscript "^4.0.0"
-    hast-util-sanitize "^1.0.0"
-    mdast-util-to-hast "^3.0.0"
+    hast-to-hyperscript "^7.0.0"
+    hast-util-sanitize "^2.0.0"
+    mdast-util-to-hast "^6.0.0"
 
 remark-stringify@^3.0.0:
   version "3.0.1"
@@ -11802,6 +11803,13 @@ style-loader@1.0.0:
     loader-utils "^1.2.3"
     schema-utils "^2.0.1"
 
+style-to-object@^0.2.1:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.2.3.tgz#afcf42bc03846b1e311880c55632a26ad2780bcb"
+  integrity sha512-1d/k4EY2N7jVLOqf2j04dTc37TPOv/hHxZmvpg8Pdh8UYydxeu/C1W1U4vD8alzf5V2Gt7rLsmkr4dxAlDm9ng==
+  dependencies:
+    inline-style-parser "0.1.1"
+
 stylehacks@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.3.tgz#6718fcaf4d1e07d8a1318690881e8d96726a71d5"
@@ -12315,10 +12323,6 @@ unist-util-generated@^1.1.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.4.tgz#2261c033d9fc23fae41872cdb7663746e972c1a7"
 
-unist-util-is@^2.0.0:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.3.tgz#459182db31f4742fceaea88d429693cbf0043d20"
-
 unist-util-is@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
@@ -12627,6 +12631,11 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
   dependencies:
     minimalistic-assert "^1.0.0"
+
+web-namespaces@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.3.tgz#9bbf5c99ff0908d2da031f1d732492a96571a83f"
+  integrity sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
* Support OSM element reference short-codes, such as `[n12345]`,
in comments

* Short-codes expand to links to Overpass Turbo, but on click will load
data into JOSM instead if that is the user's configured editor

* Multiple comma-separated elements can be included in the same
short-code, e.g. `[n12345, w98765]`

* References contain the element type (spelled out or abbreviated),
followed by a space or slash, followed by the OSM id. For example,
node 12345 could be represented by any of the following short-codes:
  - `[n12345]`
  - `[n 12345]`
  - `[n/12345]`
  - `[node12345]`
  - `[node/12345]`
  - `[node 12345]`