### PR TITLE
Support viewport short-codes in comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.4.2",
   "private": true,
   "dependencies": {
+    "@mapbox/geo-viewport": "^0.4.0",
     "@mapbox/geojsonhint": "^2.0.1",
     "@nivo/bar": "^0.52.1",
     "@nivo/line": "^0.33.0",

--- a/src/components/HOCs/WithEditor/WithEditor.js
+++ b/src/components/HOCs/WithEditor/WithEditor.js
@@ -1,8 +1,8 @@
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import _get from 'lodash/get'
-import { editTask, closeEditor, loadObjectsIntoJOSM,
-         josmHost, isJosmEditor, DEFAULT_EDITOR }
+import { editTask, closeEditor, loadObjectsIntoJOSM, zoomJOSM,
+         josmHost, isJosmEditor, viewportToBBox, DEFAULT_EDITOR }
        from '../../../services/Editor/Editor'
 import { addError } from '../../../services/Error/Error'
 import AppErrors from '../../../services/Error/AppErrors'
@@ -31,18 +31,24 @@ export const mapStateToProps = state => {
 export const mapDispatchToProps = dispatch => {
   return Object.assign({
     loadObjectsIntoJOSM: (objectIds, asNewLayer) => {
-      return loadObjectsIntoJOSM(objectIds, asNewLayer).then(success => {
-        if (!success) {
-          dispatch(addError(AppErrors.josm.noResponse))
-        }
-      })
+      josmAction(() => loadObjectsIntoJOSM(objectIds, asNewLayer), dispatch)
     },
+    zoomJOSM: bbox => josmAction(() => zoomJOSM(bbox), dispatch),
     isJosmEditor,
     josmHost,
+    viewportToBBox,
   }, bindActionCreators({
     editTask,
     closeEditor,
   }, dispatch))
+}
+
+export const josmAction = function(action, dispatch) {
+  return action().then(success => {
+    if (!success) {
+      dispatch(addError(AppErrors.josm.noResponse))
+    }
+  })
 }
 
 export default WithEditor

--- a/src/components/OSMViewportReference/OSMViewportReference.js
+++ b/src/components/OSMViewportReference/OSMViewportReference.js
@@ -1,0 +1,45 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import WithEditor from '../HOCs/WithEditor/WithEditor'
+
+/**
+ * Renders a zoom/lat/lon viewport reference as an OSM map link but on click
+ * will try to zoom JOSM to the viewport if that is the user's chosen editor --
+ * otherwise will proceed to open OSM in a new browser tab
+ */
+export class OSMViewportReference extends PureComponent {
+  zoomJOSMIfActive(clickEvent) {
+    if (!this.props.isJosmEditor(this.props.configuredEditor)) {
+      return
+    }
+
+    clickEvent.preventDefault()
+    const bbox = this.props.viewportToBBox(this.props.zoom, this.props.lat, this.props.lon,
+                                           window.innerWidth, window.innerHeight)
+    this.props.zoomJOSM(bbox)
+  }
+
+  render() {
+    const osmUrl =
+      `https://www.openstreetmap.org/#map=${this.props.zoom}/${this.props.lat}/${this.props.lon}`
+
+    return (
+      <a
+        href={osmUrl}
+        target="_blank"
+        rel="noopener noreferrer nofollow"
+        onClick={e => this.zoomJOSMIfActive(e)}
+      >
+        {this.props.zoom}/{this.props.lat}/{this.props.lon}
+      </a>
+    )
+  }
+}
+
+OSMViewportReference.propTypes = {
+  zoom: PropTypes.string.isRequired,
+  lat: PropTypes.string.isRequired,
+  lon: PropTypes.string.isRequired,
+}
+
+export default WithEditor(OSMViewportReference)

--- a/src/services/Editor/Editor.js
+++ b/src/services/Editor/Editor.js
@@ -1,3 +1,4 @@
+import geoViewport from '@mapbox/geo-viewport'
 import _compact from 'lodash/compact'
 import _fromPairs from 'lodash/fromPairs'
 import _map from 'lodash/map'
@@ -452,6 +453,23 @@ export const loadObjectsIntoJOSM = function(objectIds, asNewLayer) {
   }
 
   return sendJOSMCommand(josmURI)
+}
+
+/**
+ * Zoom JOSM to the given bounding box
+ */
+export const zoomJOSM = function(bbox) {
+  const bounds = `left=${bbox[0]}&bottom=${bbox[1]}&right=${bbox[2]}&top=${bbox[3]}`
+  const josmURI = `${josmHost()}zoom?${bounds}`
+
+  return sendJOSMCommand(josmURI)
+}
+
+/**
+ * Computes a bbox from the given zoom, lat, lon, and target viewport size
+ */
+export const viewportToBBox = function(zoom, lat, lon, viewportWidth, viewportHeight) {
+  return geoViewport.bounds([lon, lat], zoom, [viewportWidth, viewportHeight])
 }
 
 /**

--- a/src/services/ShortCodes/Handlers/OSMElementHandler.js
+++ b/src/services/ShortCodes/Handlers/OSMElementHandler.js
@@ -14,7 +14,7 @@ import OSMElementReference
  * Codes are expanded into links that either pull element data into JOSM (if
  * active) or else open a new browser tab to display them in Overpass Turbo
  */
-const OSMElementReferenceCode = {
+const OSMElementHandler = {
   osmElementRegex: "(n|w|r|node|way|rel|relation)[/ ]?(\\d+)[,\\s]*",
 
   elementTypeMap: {
@@ -49,4 +49,4 @@ const OSMElementReferenceCode = {
   }
 }
 
-export default OSMElementReferenceCode
+export default OSMElementHandler

--- a/src/services/ShortCodes/Handlers/OSMViewportHandler.js
+++ b/src/services/ShortCodes/Handlers/OSMViewportHandler.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import OSMViewportReference
+       from '../../../components/OSMViewportReference/OSMViewportReference'
+
+
+/**
+ * Expands viewport shortcodes containing zoom/lat/lon to links to
+ * OpenStreetMap, e.g. `[v/14/42.3824/12.2633]` would be expanded to
+ * https://www.openstreetmap.org/#map=14/42.3824/12.2633
+ *
+ * For convenience, this will also handle the full OSM vewport URL, making its
+ * display consistent with other viewport short-codes
+ */
+const OSMViewportHandler = {
+  osmViewportRegex: "(v|viewport)[/ ]?(\\d+)\\/(-?[\\.\\d]+)\\/(-?[\\.\\d]+)",
+
+  osmMapRegex: "https?://(www.openstreetmap.org)/?#map=(\\d+)\\/(-?[\\.\\d]+)\\/(-?[\\.\\d]+)",
+
+  handlesShortCode(shortCode) {
+    return new RegExp(this.osmViewportRegex).test(shortCode) ||
+           new RegExp(this.osmMapRegex).test(shortCode)
+  },
+
+  expandShortCode(shortCode) {
+    const viewport = new RegExp(this.osmViewportRegex).test(shortCode) ?
+                     this.extractViewport(new RegExp(this.osmViewportRegex), shortCode) :
+                     this.extractViewport(new RegExp(this.osmMapRegex), shortCode) 
+
+    return viewport ? <OSMViewportReference {...viewport} /> : shortCode
+  },
+
+  extractViewport(regex, shortCode) {
+    const match = regex.exec(shortCode.slice(1, -1))
+    if (!match) {
+      return null
+    }
+
+    return {
+      zoom: match[2],
+      lat: match[3],
+      lon: match[4],
+    }
+  },
+}
+
+export default OSMViewportHandler

--- a/src/services/ShortCodes/ShortCodes.js
+++ b/src/services/ShortCodes/ShortCodes.js
@@ -7,9 +7,10 @@ import _isString from 'lodash/isString'
 import _uniqueId from 'lodash/uniqueId'
 
 import OSMElementHandler from './Handlers/OSMElementHandler'
+import OSMViewportHandler from './Handlers/OSMViewportHandler'
 
 // All available short-code handlers
-const shortCodeHandlers = [OSMElementHandler]
+const shortCodeHandlers = [OSMElementHandler, OSMViewportHandler]
 
 // Short codes are surrounded by brackets, but -- to avoid confusion with
 // Markdown links -- cannot be immediately followed by an open parenthesees

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,6 +1163,13 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@mapbox/geo-viewport@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/geo-viewport/-/geo-viewport-0.4.0.tgz#0a8dc5812d3be12c778d6545b2f3f4dec9c633da"
+  integrity sha512-5OAXoP8C96Co3UDIzFliSzrK5njb9oG2H/RTMaZUW1swxIZlj3n3A5ccep5XAEIhTWxBLg/Cz48D3rUbAdXwHQ==
+  dependencies:
+    "@mapbox/sphericalmercator" "~1.1.0"
+
 "@mapbox/geojsonhint@^2.0.1":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@mapbox/geojsonhint/-/geojsonhint-2.2.0.tgz#75ca94706e9a56e6debf4e1c78fabdc67978b883"
@@ -1178,6 +1185,11 @@
   resolved "https://registry.yarnpkg.com/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.1.3.tgz#5b7166ae01297d72216932b245e4b2f0b642dca6"
   dependencies:
     unist-util-visit "^1.3.0"
+
+"@mapbox/sphericalmercator@~1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/sphericalmercator/-/sphericalmercator-1.1.0.tgz#f3b1af042620716a1289fc41e1e97f610823aefe"
+  integrity sha512-pEsfZyG4OMThlfFQbCte4gegvHUjxXCjz0KZ4Xk8NdOYTQBLflj6U8PL05RPAiuRAMAQNUUKJuL6qYZ5Y4kAWA==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
* Support viewport short-codes in comments that reference a zoom/lat/lon,
such as `[v 17/37.11777/126.99754]`

* Short-codes expand to links to the referenced location on
OpenStreetMap, but on click will instead zoom JOSM to the viewport if
that is the user's configured editor

* For convenience, a viewport short-code can alternatively be created
by pasting an OSM map url, e.g.
`[https://www.openstreetmap.org/#map=17/37.11777/126.99754]`

* Supported variants are `v` or `viewport` optionally followed by a
space or slash and then slash-separated zoom, latitude, and longitude
values. For example, all of the following are equivalent:
  - `[v17/37.11777/126.99754]`
  - `[v 17/37.11777/126.99754]`
  - `[v/17/37.11777/126.99754]`
  - `[viewport17/37.11777/126.99754]`
  - `[viewport 17/37.11777/126.99754]`
  - `[viewport/17/37.11777/126.99754]`
  - `[https://www.openstreetmap.org/#map=17/37.11777/126.99754]`