### PR TITLE
Fix refresh after adding to virtual project

### DIFF
--- a/src/services/Project/VirtualProject.js
+++ b/src/services/Project/VirtualProject.js
@@ -17,7 +17,7 @@ export const addChallenge = function(challengeId, toProjectId) {
       {variables: {challengeId, projectId: toProjectId}}
     ).execute().then(() => {
       fetchProject(toProjectId)(dispatch) // Refresh challenge data
-      fetchProjectChallenges(toProjectId)(dispatch) // Refresh challenge data
+      fetchProjectChallenges(toProjectId, -1)(dispatch) // Refresh challenge data
     }).catch(error => {
       if (isSecurityError(error)) {
         dispatch(ensureUserLoggedIn()).then(() =>


### PR DESCRIPTION
* When refreshing a virtual project's challenges after adding a new
challenge to the project, ensure all of the project's challenges are
fetched