### PR TITLE
Extra cleaning of cloned challenges. Fixes #918

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
@@ -289,14 +289,24 @@ export class EditChallenge extends Component {
       this.state.formData
     )
 
-    // If we're cloning a challenge, reset the id, status, and name.
+    // If we're cloning a challenge, reset the id, status, and name, and remove
+    // #maproulette hashtag from changeset comment as its presence will be
+    // controlled by an explicit option offered to user during setup
     if (this.isCloningChallenge()) {
       delete challengeData.id
       delete challengeData.status
+      delete challengeData.virtualParents
 
       if (_isEmpty(this.state.formData.name)) {
         delete challengeData.name
       }
+
+      challengeData.checkinComment =
+        AsEditableChallenge(challengeData).checkinCommentWithoutMaprouletteHashtag()
+
+      // Reset the default task data origin date to today since user will need to
+      // provide new task data
+      challengeData.dataOriginDate = new Date().toISOString().substring(0, 10)
     }
 
     // The server uses two fields to represent the default basemap: a legacy

--- a/src/interactions/Challenge/AsEditableChallenge.js
+++ b/src/interactions/Challenge/AsEditableChallenge.js
@@ -61,6 +61,16 @@ export class AsEditableChallenge {
   }
 
   /**
+   * Returns the checkin/changeset comment less any #maproulette hashtags
+   */
+  checkinCommentWithoutMaprouletteHashtag() {
+    // Strip out any separator whitespace before the hashtag too
+    return this.checkinComment ?
+           this.checkinComment.replace(new RegExp("\\s*" + maprouletteHashtag, "g"), '') :
+           this.checkinComment
+  }
+
+  /**
    * The edit-challenge form can set defaultBasemap to one of the numeric
    * constants, but can also set it to the string identifier of a layer not
    * otherwise represented by a constant.


### PR DESCRIPTION
* When cloning a challenge, remove any occurrences of #maproulette
hashtag from the changeset comment as its final presence is controlled
by a separate option that will be presented to the user during setup of
the clone

* Reset the task-data origin date on the clone as the user will need to
setup new task data for the clone

* Ensure any residual virtual-project data is cleaned up on the clone