### PR TITLE
Truncate long property names in map popup

### DIFF
--- a/src/components/EnhancedMap/PropertyList/PropertyList.js
+++ b/src/components/EnhancedMap/PropertyList/PropertyList.js
@@ -5,6 +5,7 @@ import _compact from 'lodash/compact'
 import _map from 'lodash/map'
 import _isEmpty from 'lodash/isEmpty'
 import _isObject from 'lodash/isObject'
+import _truncate from 'lodash/truncate'
 import messages from './Messages'
 
 /**
@@ -34,7 +35,14 @@ const PropertyList = props => {
 
     const link =
       !_isEmpty(tagInfo) ?
-      <a target="_blank" rel="noopener noreferrer" href={`${tagInfo}/keys/${key}`}>{key}</a> :
+      <a
+        target="_blank"
+        rel="noopener noreferrer"
+        href={`${tagInfo}/keys/${key}`}
+        title={key}
+      >
+        {_truncate(key, {length: 20})}
+      </a> :
       <span className="not-linked mr-text-grey">{key}</span>
 
     return (

--- a/src/styles/components/cards/widget.css
+++ b/src/styles/components/cards/widget.css
@@ -72,10 +72,10 @@
     .mr-cards-inverse & {
 
       a {
-        @apply mr-text-green-light;
+        @apply mr-text-green-lighter;
 
         &:hover {
-          @apply mr-text-blue;
+          @apply mr-text-white;
         }
       }
     }


### PR DESCRIPTION
* Truncate long property/tag names in popup when user clicks on a task
feature on the map

* Add a tooltip to property/tag names with the full name of the property