### PR TITLE
Fix "other" keyword filter styling. Fixes #960

### DIFF
--- a/src/components/ChallengePane/ChallengeFilterSubnav/FilterByKeyword.js
+++ b/src/components/ChallengePane/ChallengeFilterSubnav/FilterByKeyword.js
@@ -44,8 +44,8 @@ export class FilterByKeyword extends Component {
     this.props.setKeywordFilter([keywordString])
   }
 
-  clearOtherKeywords = () => {
-    this.updateFilter({value: null})
+  clearOtherKeywords = closeDropdown => {
+    this.updateFilter({value: null}, closeDropdown)
   }
 
   render() {
@@ -82,7 +82,7 @@ export class FilterByKeyword extends Component {
             activeCategory={activeCategory}
             otherKeyword={otherKeyword}
             setOtherKeywords={this.setOtherKeywords}
-            clearOtherKeywords={this.clearOtherKeywords}
+            clearOtherKeywords={() => this.clearOtherKeywords(dropdown.closeDropdown)}
             updateFilter={this.updateFilter}
             closeDropdown={dropdown.closeDropdown}
           />
@@ -119,6 +119,7 @@ const ListFilterItems = function(props) {
         searchQuery={{query: props.otherKeyword}}
         setSearch={props.setOtherKeywords}
         clearSearch={props.clearOtherKeywords}
+        deactivate={props.closeDropdown}
         placeholder=''
       />
     </li>

--- a/src/components/ChallengePane/ChallengeFilterSubnav/OtherKeywordsOption.js
+++ b/src/components/ChallengePane/ChallengeFilterSubnav/OtherKeywordsOption.js
@@ -6,7 +6,7 @@ import messages from './Messages'
 export default class OtherKeywordsOption extends Component {
   render() {
     return (
-      <div className="mr-flex mr-items-center">
+      <div className="mr-flex mr-items-center mr-py-3">
         <label
           className="mr-text-green-lighter mr-mr-4 mr-cursor-pointer"
         >
@@ -17,7 +17,9 @@ export default class OtherKeywordsOption extends Component {
           suppressIcon
           showDoneButton
           leftAligned
-          className="mr-appearance-none mr-outline-none mr-rounded-none mr-bg-transparent mr-text-white mr-border-b mr-border-green-lighter"
+          className="mr-appearance-none mr-outline-none mr-rounded-none mr-bg-transparent mr-text-white mr-border-b mr-border-green-lighter mr-h-6 mr-pb-1"
+          inputClassName="mr-text-white"
+          buttonClassName="mr-fill-green-lighter"
         />
       </div>
     )

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -54,7 +54,11 @@ export default class SearchBox extends Component {
       null :
       <button className="button is-clear has-svg-icon search-box--done-button"
               onClick={() => this.props.deactivate && this.props.deactivate()}>
-        <SvgSymbol viewBox='0 0 20 20' sym="outline-arrow-right-icon"/>
+        <SvgSymbol
+          className={this.props.buttonClassName}
+          viewBox='0 0 20 20'
+          sym="outline-arrow-right-icon"
+        />
       </button>
 
 


### PR DESCRIPTION
* Fix styling of "Other" option in keyword-filter dropdown menu,
including making text and submission button colors easier to see

* Fix keyword-filter dropdown so that it closes properly when an "other"
keyword is submitted or cleared