### PR TITLE
Consolidate overlapping task clusters when feasible

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@turf/bbox-polygon": "^5.1.5",
     "@turf/boolean-disjoint": "^5.1.5",
     "@turf/center": "^5.1.5",
+    "@turf/centroid": "^6.0.2",
+    "@turf/distance": "^6.0.1",
     "@turf/invariant": "^5.1.5",
     "bulma": "0.6.0",
     "bulma-badge": "^0.1.0",

--- a/src/components/EnhancedMap/EnhancedMap.js
+++ b/src/components/EnhancedMap/EnhancedMap.js
@@ -42,7 +42,8 @@ export default class EnhancedMap extends Map {
       if (!this.leafletElement.getCenter().equals(this.props.center) ||
           this.leafletElement.getZoom() !== this.props.zoom) {
         this.props.onBoundsChange(this.leafletElement.getBounds(),
-                                  this.leafletElement.getZoom())
+                                  this.leafletElement.getZoom(),
+                                  this.leafletElement.getSize())
       }
     }
   }

--- a/src/interactions/TaskCluster/AsMappableCluster.js
+++ b/src/interactions/TaskCluster/AsMappableCluster.js
@@ -6,6 +6,7 @@ import _merge from 'lodash/merge'
 import _cloneDeep from 'lodash/cloneDeep'
 import _fromPairs from 'lodash/fromPairs'
 import _map from 'lodash/map'
+import _get from 'lodash/get'
 import { TaskStatusColors }
       from '../../services/Task/TaskStatus/TaskStatus'
 import { colors } from '../../tailwind'
@@ -67,7 +68,8 @@ export class AsMappableCluster {
    */
   leafletMarkerIcon(mapLayerName, selectedTasks, highlightPrimaryTask) {
     const count = _isFunction(this.rawData.getChildCount) ?
-                  this.rawData.getChildCount() : this.numberOfPoints
+                  this.rawData.getChildCount() :
+                  _get(this.options, 'numberOfPoints', this.numberOfPoints)
     if (count > 1) {
       let colorScheme = null
       switch(mapLayerName) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1428,6 +1428,22 @@
     "@turf/bbox" "^5.1.5"
     "@turf/helpers" "^5.1.5"
 
+"@turf/centroid@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@turf/centroid/-/centroid-6.0.2.tgz#c4eb16b4bc60b692f74e1809cf9a7c4a4f5ba1cc"
+  integrity sha512-auyDauOtC4eddH7GC3CHFTDu2PKhpSeKCRhwhHhXtJqn2dWCJQNIoCeJRmfXRIbzCWhWvgvQafvvhq8HNvmvWw==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/meta" "6.x"
+
+"@turf/distance@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.0.1.tgz#0761f28784286e7865a427c4e7e3593569c2dea8"
+  integrity sha512-q7t7rWIWfkg7MP1Vt4uLjSEhe5rPfCO2JjpKmk7JC+QZKEQkuvHEqy3ejW1iC7Kw5ZcZNR3qdMGGz+6HnVwqvg==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+
 "@turf/helpers@*", "@turf/helpers@6.x":
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.1.4.tgz#d6fd7ebe6782dd9c87dca5559bda5c48ae4c3836"
@@ -1435,6 +1451,13 @@
 "@turf/helpers@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-5.1.5.tgz#153405227ab933d004a5bb9641a9ed999fcbe0cf"
+
+"@turf/invariant@6.x":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.1.2.tgz#6013ed6219f9ac2edada9b31e1dfa5918eb0a2f7"
+  integrity sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==
+  dependencies:
+    "@turf/helpers" "6.x"
 
 "@turf/invariant@^5.1.5":
   version "5.2.0"
@@ -1460,7 +1483,7 @@
     "@turf/invariant" "^5.1.5"
     "@turf/meta" "^5.1.5"
 
-"@turf/meta@*":
+"@turf/meta@*", "@turf/meta@6.x":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.0.2.tgz#eb92951126d24a613ac1b7b99d733fcc20fd30cf"
   dependencies:


### PR DESCRIPTION
* Consolidate task clusters together in TaskClusterMap if they would
visually overlap

* Update EnhancedMap to pass the current map size (in pixels) as a third
argument to `onBoundsChange`