### PR TITLE
Refactor challenge detail map to use new cluster api

### DIFF
--- a/src/components/ChallengeDetail/ChallengeDetail.js
+++ b/src/components/ChallengeDetail/ChallengeDetail.js
@@ -7,7 +7,7 @@ import _findIndex from 'lodash/findIndex'
 import _isNumber from 'lodash/isNumber'
 import parse from 'date-fns/parse'
 import MapPane from '../EnhancedMap/MapPane/MapPane'
-import ChallengeBrowseMap from '../ChallengeBrowseMap/ChallengeBrowseMap'
+import TaskClusterMap from '../TaskClusterMap/TaskClusterMap'
 import { messagesByDifficulty } from '../../services/Challenge/ChallengeDifficulty/ChallengeDifficulty'
 import { isUsableChallengeStatus } from '../../services/Challenge/ChallengeStatus/ChallengeStatus'
 import messages from './Messages'
@@ -17,13 +17,18 @@ import ChallengeProgress from '../ChallengeProgress/ChallengeProgress'
 import MarkdownContent from '../MarkdownContent/MarkdownContent'
 import SignInButton from '../SignInButton/SignInButton'
 import AsManager from '../../interactions/User/AsManager'
-import WithTaskMarkers from '../HOCs/WithTaskMarkers/WithTaskMarkers'
 import WithStartChallenge from '../HOCs/WithStartChallenge/WithStartChallenge'
 import WithBrowsedChallenge from '../HOCs/WithBrowsedChallenge/WithBrowsedChallenge'
 import WithClusteredTasks from '../HOCs/WithClusteredTasks/WithClusteredTasks'
 import WithCurrentUser from '../HOCs/WithCurrentUser/WithCurrentUser'
+import WithChallengeTaskClusters from '../HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters'
+import WithTaskClusterMarkers from '../HOCs/WithTaskClusterMarkers/WithTaskClusterMarkers'
+import WithFilterCriteria from '../HOCs/WithFilterCriteria/WithFilterCriteria'
 
-const BrowseMap = WithTaskMarkers(ChallengeBrowseMap)
+const ClusterMap = WithFilterCriteria(
+                    WithChallengeTaskClusters(
+                      WithTaskClusterMarkers(TaskClusterMap('challengeDetail')))
+                  )
 
 /**
  * ChallengeDetail represents a specific challenge view. It presents an
@@ -124,17 +129,20 @@ export class ChallengeDetail extends Component {
         {refreshDate: this.props.intl.formatDate(new Date(challenge.lastTaskRefresh)),
          sourceDate: this.props.intl.formatDate(new Date(challenge.dataOriginDate))})
 
+   const map =
+       <ClusterMap
+         className="split-pane"
+         onTaskClick={taskId => this.props.startChallengeWithTask(challenge.id, false, taskId)}
+         challenge={challenge}
+         allowClusterToggle={false}
+         skipRefreshTasks
+         {...this.props}
+       />
+
     return (
       <div className="mr-bg-gradient-r-green-dark-blue mr-text-white lg:mr-flex">
         <div className="mr-flex-1">
-          <MapPane>
-            <BrowseMap
-              className="split-pane"
-              challenge={challenge}
-              onTaskClick={this.props.startChallengeWithTask}
-              {...this.props}
-            />
-          </MapPane>
+          <MapPane>{map}</MapPane>
         </div>
         <div className="mr-flex-1">
           <div className="mr-h-content mr-overflow-auto">

--- a/src/components/ChallengeDetail/ChallengeDetail.js
+++ b/src/components/ChallengeDetail/ChallengeDetail.js
@@ -23,12 +23,12 @@ import WithClusteredTasks from '../HOCs/WithClusteredTasks/WithClusteredTasks'
 import WithCurrentUser from '../HOCs/WithCurrentUser/WithCurrentUser'
 import WithChallengeTaskClusters from '../HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters'
 import WithTaskClusterMarkers from '../HOCs/WithTaskClusterMarkers/WithTaskClusterMarkers'
-import WithFilterCriteria from '../HOCs/WithFilterCriteria/WithFilterCriteria'
+import { fromLatLngBounds } from '../../services/MapBounds/MapBounds'
 
-const ClusterMap = WithFilterCriteria(
+const ClusterMap =
                     WithChallengeTaskClusters(
                       WithTaskClusterMarkers(TaskClusterMap('challengeDetail')))
-                  )
+
 
 /**
  * ChallengeDetail represents a specific challenge view. It presents an
@@ -38,6 +38,9 @@ const ClusterMap = WithFilterCriteria(
  * @author [Ryan Scherler](https://github.com/ryanscherler)
  */
 export class ChallengeDetail extends Component {
+  state = {
+  }
+
   render() {
     const challenge = this.props.browsedChallenge
     if (!_isObject(challenge) || this.props.loadingBrowsedChallenge) {
@@ -135,6 +138,8 @@ export class ChallengeDetail extends Component {
          onTaskClick={taskId => this.props.startChallengeWithTask(challenge.id, false, taskId)}
          challenge={challenge}
          allowClusterToggle={false}
+         criteria={{boundingBox: fromLatLngBounds(this.state.bounds), zoom: this.state.zoom}}
+         updateTaskFilterBounds={(bounds, zoom) => this.setState({bounds, zoom})}
          skipRefreshTasks
          {...this.props}
        />

--- a/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.js
+++ b/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.js
@@ -24,7 +24,7 @@ const FRESHNESS_THRESHOLD = 60000 // 1 minute
  *
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
-export const WithBrowsedChallenge = function(WrappedComponent, includeTasks=true) {
+export const WithBrowsedChallenge = function(WrappedComponent) {
   class _WithBrowsedChallenge extends Component {
     state = {
       browsedChallenge: null,
@@ -109,12 +109,6 @@ export const WithBrowsedChallenge = function(WrappedComponent, includeTasks=true
               loadingBrowsedChallenge: null,
               isVirtual
             })
-
-            if (includeTasks &&
-               (challenge.id !== _get(props, 'clusteredTasks.challengeId') ||
-                isVirtual !== _get(props, 'clusteredTasks.isVirtualChallenge'))) {
-              props.fetchClusteredTasks(challenge.id, isVirtual, undefined, undefined, undefined, true)
-            }
           }
           else if (!isVirtual && !_isFinite(this.state.loadingBrowsedChallenge)) {
             // We don't have the challenge available (and we're not in the middle

--- a/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
+++ b/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
@@ -166,7 +166,7 @@ export const WithFilterCriteria = function(WrappedComponent) {
          this.updateIncludedFilters(this.props)
        }
 
-       if (!_isEqual(prevState.criteria, this.state.criteria)) {
+       if (!_isEqual(prevState.criteria, this.state.criteria) && !this.props.skipRefreshTasks) {
          if (this.state.criteria.boundingBox) {
            this.refreshTasks()
          }

--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -161,6 +161,9 @@ export class TaskClusterMap extends Component {
         // Reset Map so that it zooms to new marker bounds
         this.setState({mapMarkers: null})
       }
+      else if (this.props.onTaskClick) {
+        this.props.onTaskClick(marker.options.taskId)
+      }
     }
   }
 
@@ -324,10 +327,6 @@ export class TaskClusterMap extends Component {
       this.props.totalTaskCount > CLUSTER_POINTS &&
       this.currentZoom < MAX_ZOOM
 
-    if (!this.currentBounds && _get(this.props, 'boundingBox.length', 0) > 0) {
-      this.currentBounds = toLatLngBounds(this.props.boundingBox)
-    }
-
     if (!this.currentBounds && this.state.mapMarkers) {
       // Set Current Bounds to the minimum bounding box of our markers
       this.currentBounds = toLatLngBounds(
@@ -358,7 +357,7 @@ export class TaskClusterMap extends Component {
       </EnhancedMap>
 
     return (
-      <div className={classNames('taskcluster-map', {"full-screen-map": this.props.isMobile})}>
+      <div className={classNames('taskcluster-map', {"full-screen-map": this.props.isMobile}, this.props.className)}>
         {canClusterToggle && !this.props.loading &&
          <label className="mr-absolute mr-z-10 mr-pin-t mr-pin-l mr-mt-2 mr-ml-2 mr-shadow mr-rounded-sm mr-bg-black-50 mr-px-2 mr-py-1 mr-text-white mr-text-xs mr-flex mr-items-center">
             <input type="checkbox" className="mr-mr-2"

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -345,7 +345,7 @@ registerWidgetType(
             WithBrowsedChallenge(
               WithWebSocketSubscriptions(
                 TaskBundleWidget,
-              ), false
+              )
             ),
             'filteredClusteredTasks',
             'taskInfo'

--- a/src/components/Widgets/TaskBundleWidget/TaskMarkerContent.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskMarkerContent.js
@@ -29,7 +29,7 @@ class TaskMarkerContent extends Component {
           <div className="mr-flex">
             <div className="mr-w-1/2 mr-mr-2 mr-text-right"><FormattedMessage {...messages.statusLabel} /></div>
             <div className="mr-w-1/2 mr-text-left">
-              {this.props.intl.formatMessage(messagesByStatus[this.props.marker.options.status])}
+              {this.props.intl.formatMessage(messagesByStatus[this.props.marker.options.taskStatus])}
             </div>
           </div>
           <div className="mr-flex">


### PR DESCRIPTION
Change challenge detail map to use new cluster api so that not
all tasks are pulled back from the server but only a limited
number of clusters.