### PR TITLE
Add option to change dataOriginDate on rebuild Tasks

### DIFF
--- a/src/components/AdminPane/HOCs/WithChallengeManagement/WithChallengeManagement.js
+++ b/src/components/AdminPane/HOCs/WithChallengeManagement/WithChallengeManagement.js
@@ -47,7 +47,7 @@ const WithChallengeManagement = WrappedComponent =>
  *
  * @private
  */
-async function uploadLineByLine(dispatch, ownProps, challenge, geoJSON) {
+async function uploadLineByLine(dispatch, ownProps, challenge, geoJSON, dataOriginDate) {
   ownProps.updateCreatingTasksProgress(true, 0)
   const lineFile = AsLineReadableFile(geoJSON)
   let allLinesRead = false
@@ -61,7 +61,7 @@ async function uploadLineByLine(dispatch, ownProps, challenge, geoJSON) {
     }
 
     await dispatch(
-      uploadChallengeGeoJSON(challenge.id, taskLines.join('\n'), true)
+      uploadChallengeGeoJSON(challenge.id, taskLines.join('\n'), true, false, dataOriginDate)
     )
     totalTasksCreated += taskLines.length
     ownProps.updateCreatingTasksProgress(true, totalTasksCreated)
@@ -140,7 +140,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
 
   deleteIncompleteTasks: challenge => deleteIncompleteTasks(dispatch, ownProps, challenge),
 
-  rebuildChallenge: async (challenge, localFile) => {
+  rebuildChallenge: async (challenge, localFile, dataOriginDate) => {
     ownProps.updateCreatingTasksProgress(true)
 
     try {
@@ -148,11 +148,11 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
       // decide which service call to use
       if (localFile) {
         if (await AsValidatableGeoJSON(localFile).isLineByLine()) {
-          await uploadLineByLine(dispatch, ownProps, challenge, localFile)
+          await uploadLineByLine(dispatch, ownProps, challenge, localFile, dataOriginDate)
         }
         else {
           await dispatch(
-            uploadChallengeGeoJSON(challenge.id, localFile, false)
+            uploadChallengeGeoJSON(challenge.id, localFile, false, false, dataOriginDate)
           )
         }
       }

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
@@ -381,6 +381,13 @@ export class EditChallenge extends Component {
     delete challengeData.actions
     delete challengeData.ignoreSourceErrors
 
+    if (this.props.challenge && challengeData.dataOriginDate) {
+      // Don't update dataOriginDate if it hasn't changed (otherwise it's timezone could change)
+      if (this.props.challenge.dataOriginDate === challengeData.dataOriginDate) {
+        delete challengeData.dataOriginDate
+      }
+    }
+
     // Parent field should just be id, not object.
     if (_isObject(challengeData.parent)) {
       challengeData.parent = challengeData.parent.id

--- a/src/components/AdminPane/Manage/RebuildTasksControl/Messages.js
+++ b/src/components/AdminPane/Manage/RebuildTasksControl/Messages.js
@@ -62,4 +62,9 @@ export default defineMessages({
     id: "RebuildTasksControl.modal.controls.proceed.label",
     defaultMessage: "Proceed"
   },
+
+  dataOriginDateLabel: {
+    id: 'RebuildTasksControl.modal.controls.dataOriginDate.label',
+    defaultMessage: "Date data was sourced",
+  },
 })

--- a/src/components/AdminPane/Manage/RebuildTasksControl/RebuildTasksControl.js
+++ b/src/components/AdminPane/Manage/RebuildTasksControl/RebuildTasksControl.js
@@ -50,7 +50,7 @@ export class RebuildTasksControl extends Component {
                                   Promise.resolve()
 
     deleteStepIfRequested.then(() => {
-      this.props.rebuildChallenge(this.props.challenge, updatedFile)
+      this.props.rebuildChallenge(this.props.challenge, updatedFile, this.state.dataOriginDate)
     })
   }
 
@@ -76,6 +76,22 @@ export class RebuildTasksControl extends Component {
           })
         },
       })
+    }
+
+    let originDateField = null
+    // Only offer an option to change the source origin date if it's a local file
+    // we are uploading.
+    if (challenge.dataSource() === 'local') {
+      originDateField =
+        <div className="form-group field field-string mr-mt-2">
+          <label className="control-label">
+            <FormattedMessage {...messages.dataOriginDateLabel} />
+          </label>
+          <input className="form-control" type="date"
+                 label={this.props.intl.formatMessage(messages.dataOriginDateLabel)}
+                 onChange={e => this.setState({dataOriginDate: e.target.value})}
+                 value={this.state.dataOriginDate || challenge.dataOriginDate} />
+        </div>
     }
 
     return (
@@ -144,6 +160,7 @@ export class RebuildTasksControl extends Component {
                       <form className="rjsf">{fileUploadArea}</form>
                     </div>
                   )}
+                  {originDateField}
                 </div>
 
                 <div className="rebuild-tasks-control__modal-controls">

--- a/src/components/AdminPane/Manage/Widgets/ChallengeOverviewWidget/ChallengeOverviewWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/ChallengeOverviewWidget/ChallengeOverviewWidget.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { FormattedMessage, FormattedDate } from 'react-intl'
 import _get from 'lodash/get'
+import parse from 'date-fns/parse'
 import { ChallengeStatus, messagesByStatus }
        from  '../../../../../services/Challenge/ChallengeStatus/ChallengeStatus'
 import { WidgetDataTarget, registerWidgetType }
@@ -27,9 +28,8 @@ export default class ChallengeOverviewWidget extends Component {
 
     const dataOriginDateText = !this.props.challenge.dataOriginDate ? null :
       this.props.intl.formatMessage(messages.dataOriginDate,
-        {refreshDate: this.props.intl.formatDate(new Date(this.props.challenge.lastTaskRefresh)),
-         sourceDate: this.props.intl.formatDate(new Date(this.props.challenge.dataOriginDate))})
-
+        {refreshDate: this.props.intl.formatDate(parse(this.props.challenge.lastTaskRefresh)),
+         sourceDate: this.props.intl.formatDate(parse(this.props.challenge.dataOriginDate))})
 
     return (
       <QuickWidget {...this.props}
@@ -65,7 +65,7 @@ export default class ChallengeOverviewWidget extends Component {
 
           <div>
             {this.props.challenge.created &&
-             <FormattedDate value={new Date(this.props.challenge.created)}
+             <FormattedDate value={parse(this.props.challenge.created)}
                             year='numeric' month='long' day='2-digit' />
             }
           </div>
@@ -76,7 +76,7 @@ export default class ChallengeOverviewWidget extends Component {
 
           <div>
             {this.props.challenge.modified &&
-             <FormattedDate value={new Date(this.props.challenge.modified)}
+             <FormattedDate value={parse(this.props.challenge.modified)}
                             year='numeric' month='long' day='2-digit' />
             }
           </div>
@@ -87,7 +87,7 @@ export default class ChallengeOverviewWidget extends Component {
 
           <div title={dataOriginDateText}>
             {this.props.challenge.dataOriginDate &&
-             <FormattedDate value={new Date(this.props.challenge.dataOriginDate)}
+             <FormattedDate value={parse(this.props.challenge.dataOriginDate)}
                             year='numeric' month='long' day='2-digit' />
             }
           </div>

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -170,6 +170,7 @@
   "RebuildTasksControl.modal.controls.removeUnmatched.label": "First remove incomplete tasks",
   "RebuildTasksControl.modal.controls.cancel.label": "Cancel",
   "RebuildTasksControl.modal.controls.proceed.label": "Proceed",
+  "RebuildTasksControl.modal.controls.dataOriginDate.label": "Date data was sourced",
   "StepNavigation.controls.cancel.label": "Cancel",
   "StepNavigation.controls.next.label": "Next",
   "StepNavigation.controls.prev.label": "Prev",


### PR DESCRIPTION
* add date field to specify dataOriginDate on rebuildTasks if
  it's a local file

* Modify display of dataOriginDate to not show timestamp on edit

* Fix minor date discrepancies

Requires mr2 change #638