### PR TITLE
Fix task tags showing blank when editing

### DIFF
--- a/src/components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
+++ b/src/components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
@@ -148,7 +148,7 @@ export class MarkdownEditField extends Component {
 export const TagsInputField = props => {
   let tags = []
   if (_isArray(props.formData)) {
-    tags = _map(props.formData, (tag) => tag.name)
+    tags = _map(props.formData, (tag) => tag.name ? tag.name : tag)
   }
   else if (_isString(props.formData) && props.formData !== "") {
     tags = props.formData.split(',')

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -172,7 +172,7 @@ export class ActiveTaskControls extends Component {
     }
 
     if (this.state.tags === null && _get(this.props, 'task.tags')) {
-      this.setState({tags: _map(this.props.task.tags, (tag) => tag.name).join(', ')})
+      this.setState({tags: _map(this.props.task.tags, (tag) => (tag.name ? tag.name : tag)).join(', ')})
     }
   }
 


### PR DESCRIPTION
Back-end is now returning tags on task causing tags to show up blank on the front-end. Change so that if no name is present on the tag, just show the string tag.