### PR TITLE
Remove checks for available challenge actions

### DIFF
--- a/src/components/ChallengeDetail/ChallengeDetail.js
+++ b/src/components/ChallengeDetail/ChallengeDetail.js
@@ -4,7 +4,6 @@ import { FormattedMessage, FormattedRelative, injectIntl } from 'react-intl'
 import _isObject from 'lodash/isObject'
 import _get from 'lodash/get'
 import _findIndex from 'lodash/findIndex'
-import _isNumber from 'lodash/isNumber'
 import parse from 'date-fns/parse'
 import MapPane from '../EnhancedMap/MapPane/MapPane'
 import TaskClusterMap from '../TaskClusterMap/TaskClusterMap'
@@ -57,14 +56,7 @@ export class ChallengeDetail extends Component {
     let saveControl = null
     let startControl = null
 
-    let startableChallenge = true
-    const tasksComplete = _isNumber(_get(challenge, 'actions.available')) ?
-                          challenge.actions.available === 0 : false
-
-    if (challenge.deleted || tasksComplete ||
-       !isUsableChallengeStatus(challenge.status)) {
-      startableChallenge = false
-    }
+    const startableChallenge = !challenge.deleted && isUsableChallengeStatus(challenge.status)
 
     if (_isObject(this.props.user) && !challenge.isVirtual) {
       if (

--- a/src/components/HOCs/WithChallenges/WithChallenges.js
+++ b/src/components/HOCs/WithChallenges/WithChallenges.js
@@ -5,7 +5,6 @@ import { isUsableChallengeStatus }
        from '../../../services/Challenge/ChallengeStatus/ChallengeStatus'
 import _values from 'lodash/values'
 import _get from 'lodash/get'
-import _isNumber from 'lodash/isNumber'
 import _filter from 'lodash/filter'
 
 /**
@@ -28,15 +27,10 @@ export const mapStateToProps = (state, ownProps) => {
   let usableChallenges = challenges
   if (ownProps.allStatuses !== true) {
     usableChallenges = _filter(challenges, challenge => {
-      // Don't treat as complete if we're simply missing completion data.
-      const tasksComplete = _isNumber(_get(challenge, 'actions.available')) ?
-                            challenge.actions.available === 0 : false
-
       const parent = _get(state, `entities.projects.${challenge.parent}`)
       return challenge.enabled &&
              _get(parent, 'enabled', false) &&
              !challenge.deleted &&
-             !tasksComplete &&
              isUsableChallengeStatus(challenge.status)
     })
   }


### PR DESCRIPTION
* Remove old checks for available challenge actions that were used as a
proxy for determining if the challenge was complete prior to
introduction of a Finished status