### PR TITLE
Auto-refresh lock of task actively being worked on

### DIFF
--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
@@ -268,7 +268,9 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
         return Promise.reject("Invalid task")
       }
 
-      return dispatch(refreshTaskLock(task.id))
+      return dispatch(refreshTaskLock(task.id)).catch(err => {
+        dispatch(addError(AppErrors.task.lockRefreshFailure))
+      })
     },
   }
 }

--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
@@ -13,6 +13,7 @@ import { taskDenormalizationSchema,
          loadRandomTaskFromChallenge,
          loadRandomTaskFromVirtualChallenge,
          startTask,
+         refreshTaskLock,
          addTaskComment,
          addTaskBundleComment,
          completeTask,
@@ -257,6 +258,17 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
       return fetchOSMData(bbox).catch(error => {
         dispatch(addError(error))
       })
+    },
+
+    /**
+     * Refresh the lock on the task, extending its allowed duration
+     */
+    refreshTaskLock: task => {
+      if (!task) {
+        return Promise.reject("Invalid task")
+      }
+
+      return dispatch(refreshTaskLock(task.id))
     },
   }
 }

--- a/src/components/HOCs/WithLockedTask/WithLockedTask.js
+++ b/src/components/HOCs/WithLockedTask/WithLockedTask.js
@@ -40,7 +40,7 @@ export const mapDispatchToProps = (dispatch, ownProps) => ({
   startTask: (task) => {
     dispatch(startTask(task.id)).catch(error => {
       dispatch(addError(AppErrors.task.locked))
-      ownProps.history.push('/browse/challenges')
+      ownProps.history.push(`/browse/challenges/${_get(task, 'parent.id', task.parent)}`)
     })
   },
   releaseTask: (task) => dispatch(releaseTask(task.id)),

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -972,6 +972,7 @@
   "Errors.task.fetchFailure": "Unable to fetch a task to work on.",
   "Errors.task.doesNotExist": "That task does not exist.",
   "Errors.task.alreadyLocked": "Task has already been locked by someone else.",
+  "Errors.task.lockRefreshFailure": "Unable to extend your task lock. Your lock may have expired. We recommend refreshing the page to try establishing a fresh lock.",
   "Errors.task.bundleFailure": "Unable to bundling tasks together",
   "Errors.osm.requestTooLarge": "OpenStreetMap data request too large",
   "Errors.osm.bandwidthExceeded": "OpenStreetMap allowed bandwidth exceeded",

--- a/src/services/Error/AppErrors.js
+++ b/src/services/Error/AppErrors.js
@@ -28,6 +28,7 @@ export default {
     fetchFailure: messages.taskFetchFailure,
     doesNotExist: messages.taskDoesNotExist,
     locked: messages.taskLocked,
+    lockRefreshFailure: messages.taskLockRefreshFailure,
     bundleFailure: messages.taskBundleFailure,
   },
 

--- a/src/services/Error/Messages.js
+++ b/src/services/Error/Messages.js
@@ -66,6 +66,10 @@ export default defineMessages({
     id: 'Errors.task.alreadyLocked',
     defaultMessage: "Task has already been locked by someone else.",
   },
+  taskLockRefreshFailure: {
+    id: 'Errors.task.lockRefreshFailure',
+    defaultMessage: "Unable to extend your task lock. Your lock may have expired. We recommend refreshing the page to try establishing a fresh lock.",
+  },
   taskBundleFailure: {
     id: 'Errors.task.bundleFailure',
     defaultMessage: "Unable to bundling tasks together",

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -98,6 +98,7 @@ const apiRoutes = factory => {
       'single': factory.get('/task/:id'),
       'start': factory.get('/task/:id/start'),
       'release': factory.get('/task/:id/release'),
+      'refreshLock': factory.get('/task/:id/refreshLock'),
       'startReview': factory.get('/task/:id/review/start'),
       'cancelReview': factory.get('/task/:id/review/cancel'),
       'updateStatus': factory.put('/task/:id/:status'),

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -229,6 +229,18 @@ export const releaseTask = function(taskId) {
 }
 
 /**
+ * Refreshes an active task lock owned by the current user
+ */
+export const refreshTaskLock = function(taskId) {
+  return function(dispatch) {
+    return new Endpoint(api.task.refreshLock, {
+      schema: taskSchema(),
+      variables: {id: taskId}
+    }).execute()
+  }
+}
+
+/**
  * Mark the given task as completed with the given status.
  */
 export const completeTask = function(taskId, taskStatus, needsReview,


### PR DESCRIPTION
> Note that this PR relies on backend PR maproulette/maproulette2#649

* Periodically refresh the task lock of a task being actively worked on
to prevent the lock from expiring

* When a user attempts to work on a task locked by someone else, redirect
them to the details page of the parent challenge instead of the Find
Challenges page