### PR TITLE
Add explicit unlock-task control for mappers

### DIFF
--- a/src/components/Sprites/Sprites.js
+++ b/src/components/Sprites/Sprites.js
@@ -10,6 +10,9 @@ export default function() {
   return (
     <div className="sprites">
       <svg xmlns="http://www.w3.org/2000/svg" hidden>
+        <symbol id="locked-icon" viewBox="0 0 20 20">
+          <path d="M4 8V6a6 6 0 1 1 12 0v2h1a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-8c0-1.1.9-2 2-2h1zm5 6.73V17h2v-2.27a2 2 0 1 0-2 0zM7 6v2h6V6a3 3 0 0 0-6 0z" />
+        </symbol>
         <symbol id="box-icon" viewBox="0 0 20 20">
           <path d="M0 2C0 .9.9 0 2 0h16a2 2 0 0 1 2 2v2H0V2zm1 3h18v13a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V5zm6 2v2h6V7H7z"/>
         </symbol>

--- a/src/components/TaskPane/Messages.js
+++ b/src/components/TaskPane/Messages.js
@@ -8,4 +8,14 @@ export default defineMessages({
     id: "Task.pane.controls.inspect.label",
     defaultMessage: "Inspect",
   },
+
+  taskLockedLabel: {
+    id: "Task.pane.indicators.locked.label",
+    defaultMessage: "Task locked",
+  },
+
+  taskUnlockLabel: {
+    id: "Task.pane.controls.unlock.label",
+    defaultMessage: "Unlock",
+  },
 })

--- a/src/components/TaskPane/TaskPane.js
+++ b/src/components/TaskPane/TaskPane.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import MediaQuery from 'react-responsive'
+import { Link } from 'react-router-dom'
 import _get from 'lodash/get'
 import { generateWidgetId, WidgetDataTarget, widgetDescriptor }
        from '../../services/Widget/Widget'
@@ -23,6 +24,7 @@ import VirtualChallengeNameLink
 import ChallengeNameLink from '../ChallengeNameLink/ChallengeNameLink'
 import OwnerContactLink from '../ChallengeOwnerContactLink/ChallengeOwnerContactLink'
 import BusySpinner from '../BusySpinner/BusySpinner'
+import SvgSymbol from '../SvgSymbol/SvgSymbol'
 import MobileTaskDetails from './MobileTaskDetails/MobileTaskDetails'
 import messages from './Messages'
 import './TaskPane.scss'
@@ -181,23 +183,43 @@ export class TaskPane extends Component {
               </h1>
             }
             workspaceInfo={
-              <ul className="mr-list-ruled mr-text-xs">
-                <li className="mr-links-inverse">
-                  {_get(this.props.task, 'parent.parent.displayName')}
-                </li>
+              <React.Fragment>
+                <div>
+                  <ul className="mr-list-ruled mr-text-xs">
+                    <li className="mr-links-inverse">
+                      {_get(this.props.task, 'parent.parent.displayName')}
+                    </li>
 
-                <li className="mr-links-green-lighter">
-                  <OwnerContactLink {...this.props} />
-                </li>
+                    <li className="mr-links-green-lighter">
+                      <OwnerContactLink {...this.props} />
+                    </li>
 
-                {isManageable && !this.props.inspectTask && (
-                  <li>
-                    <button className="mr-transition mr-text-current hover:mr-text-green-lighter" onClick={() => this.props.history.push(taskInspectRoute)}>
-                      <FormattedMessage {...messages.inspectLabel} />
-                    </button>
-                  </li>
-                )}
-              </ul>
+                    {isManageable && !this.props.inspectTask && (
+                      <li>
+                        <button className="mr-transition mr-text-current hover:mr-text-green-lighter" onClick={() => this.props.history.push(taskInspectRoute)}>
+                          <FormattedMessage {...messages.inspectLabel} />
+                        </button>
+                      </li>
+                    )}
+                  </ul>
+                </div>
+                <div className="mr-links-green-lighter mr-text-sm mr-flex mr-items-center mr-mt-2">
+                  <SvgSymbol
+                    sym="locked-icon"
+                    viewBox="0 0 20 20"
+                    className="mr-fill-current mr-w-4 mr-h-4 mr-mr-1"
+                  />
+                  <span className="mr-flex mr-items-baseline">
+                    <FormattedMessage {...messages.taskLockedLabel} />
+                  </span>
+                  <Link
+                    to={`/browse/challenges/${_get(this.props.task, 'parent.id', this.props.task.parent)}`}
+                    className="mr-button mr-button--xsmall mr-ml-3"
+                  >
+                    <FormattedMessage {...messages.taskUnlockLabel} />
+                  </Link>
+                </div>
+              </React.Fragment>
             }
             completeTask={this.completeTask}
             completingTask={this.state.completingTask}

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -688,6 +688,8 @@
   "ActiveTask.subheading.progress": "Challenge Progress",
   "ActiveTask.subheading.social": "Share",
   "Task.pane.controls.inspect.label": "Inspect",
+  "Task.pane.indicators.locked.label": "Task locked",
+  "Task.pane.controls.unlock.label": "Unlock",
   "MobileTask.subheading.instructions": "Instructions",
   "Task.management.heading": "Management Options",
   "Task.management.controls.inspect.label": "Inspect",


### PR DESCRIPTION
* Indicate on task completion page that task has been locked, and add
explicit unlock control that simply returns mapper to the challenge
browse page (which will naturally cause the task to be unlocked)

<img width="508" alt="task_unlock_control" src="https://user-images.githubusercontent.com/445970/70186631-2ab0d880-16a1-11ea-80a2-eb855ebd563b.png">
