### PR TITLE
Encode task property key/value pairs

### DIFF
--- a/src/services/Search/Search.js
+++ b/src/services/Search/Search.js
@@ -165,7 +165,7 @@ export const generateSearchParametersString = (filters, boundingBox, savedChalle
   if (filters.taskProperty) {
     searchParameters.tProps =
       _map(filters.taskProperty,
-           (value, key) => `${key}:${value}`).join(',')
+           (value, key) => `${btoa(key)}:${btoa(value)}`).join(',')
 
     if (filters.taskPropertySearchType) {
       searchParameters.tPropsSearchType = filters.taskPropertySearchType


### PR DESCRIPTION
To ensure that a ':' in a key name is not confused, now require
task property key/values to be base64 encoded.

Closes #1004
Requires back-end PR: "Decode task property filter keys/values #651"