### PR TITLE
Remove extra fetchTaskClusters call in admin challenge view

### DIFF
--- a/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
+++ b/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
@@ -6,7 +6,7 @@ import _keys from 'lodash/keys'
 import _pickBy from 'lodash/pickBy'
 import _omit from 'lodash/omit'
 import _sortBy from 'lodash/sortBy'
-import { fromLatLngBounds } from '../../../services/MapBounds/MapBounds'
+import { fromLatLngBounds, GLOBAL_MAPBOUNDS } from '../../../services/MapBounds/MapBounds'
 import { fetchPropertyKeys } from '../../../services/Challenge/Challenge'
 
 const DEFAULT_PAGE_SIZE = 20
@@ -142,8 +142,19 @@ export const WithFilterCriteria = function(WrappedComponent) {
        const challengeId = _get(this.props, 'challenge.id') || this.props.challengeId
        this.setState({loading: true})
 
+       const criteria = _cloneDeep(this.state.criteria)
+
+       // If we don't have bounds yet, we still want results so let's fetch all
+       // tasks globally for this challenge.
+       if (!criteria.boundingBox) {
+         if (this.props.skipInitialFetch || !challengeId) {
+           return
+         }
+         criteria.boundingBox = GLOBAL_MAPBOUNDS
+       }
+
        this.props.augmentClusteredTasks(challengeId, false,
-                                        this.state.criteria,
+                                        criteria,
                                         this.state.criteria.pageSize,
                                         false).then((results) => {
          this.setState({loading: false})
@@ -170,6 +181,10 @@ export const WithFilterCriteria = function(WrappedComponent) {
          if (this.state.criteria.boundingBox) {
            this.refreshTasks()
          }
+       }
+       else if (_get(prevProps, 'challenge.id') !== _get(this.props, 'challenge.id') ||
+                this.props.challengeId !== prevProps.challengeId) {
+         this.refreshTasks()
        }
      }
 

--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -70,6 +70,7 @@ export class TaskClusterMap extends Component {
   currentSize = null
   currentZoom = MIN_ZOOM
   timerHandle = null
+  skipNextBoundsUpdate = false
 
   state = {
     mapMarkers: null,
@@ -163,6 +164,11 @@ export class TaskClusterMap extends Component {
     this.currentBounds = toLatLngBounds(bounds)
     this.currentZoom = zoom
     this.currentSize = mapSize
+
+    if (this.skipNextBoundsUpdate) {
+      this.skipNextBoundsUpdate = false
+      return
+    }
     this.debouncedUpdateBounds(bounds, zoom)
   }
 
@@ -354,6 +360,8 @@ export class TaskClusterMap extends Component {
           )
         ))
       )
+      // We've calculated the bounds so we don't need to do the next bounds update
+      this.skipNextBoundsUpdate = true
     }
     else if (this.props.initialBounds) {
       this.currentBounds = this.props.initialBounds

--- a/src/services/MapBounds/MapBounds.js
+++ b/src/services/MapBounds/MapBounds.js
@@ -14,6 +14,8 @@ export const DEFAULT_MAP_BOUNDS = [
   22.51255695405145, // north
 ]
 
+export const GLOBAL_MAPBOUNDS = [-180, -90, 180, 90]
+
 // utility functions
 
 /**


### PR DESCRIPTION
FetchTaskClusters in admin challenge view was being called
twice. First with no bounds to fetch initial markers, then
when the map was rendered with the updated bounding box. This
would then allow tasksInBounds (table tasks) to be fetched
as it had bounds. Changed to remove second fetchTaskClusters
and have tasksInBounds fetch all tasks using global bounds.
Thereby eliminating redundant fetchTaskClusters.