### PR TITLE
Make 'review time' column on admin tasks table not sortable.

### DIFF
--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -348,7 +348,7 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
     id: 'reviewDuration',
     Header: props.intl.formatMessage(messages.reviewDurationLabel),
     accessor: 'reviewStartedAt',
-    sortable: true,
+    sortable: false,
     defaultSortDesc: true,
     exportable: t => t.reviewStartedAt,
     maxWidth: 120,


### PR DESCRIPTION
Since review time is a calculated column, make this column not sortable.