### PR TITLE
Support challenge-completed notifications

### DIFF
--- a/src/pages/Inbox/Messages.js
+++ b/src/pages/Inbox/Messages.js
@@ -99,6 +99,11 @@ export default defineMessages({
     defaultMessage: "The mapper has revised their work and is requesting an additional review.",
   },
 
+  challengeCompleteNotificationLead: {
+    id: "Inbox.challengeCompleteNotification.lead",
+    defaultMessage: "A challenge you manage has been completed.",
+  },
+
   deleteNotificationLabel: {
     id: "Inbox.notification.controls.deleteNotification.label",
     defaultMessage: "Delete",
@@ -107,5 +112,10 @@ export default defineMessages({
   viewTaskLabel: {
     id: "Inbox.notification.controls.viewTask.label",
     defaultMessage: "View Task",
+  },
+
+  manageChallengeLabel: {
+    id: "Inbox.notification.controls.manageChallenge.label",
+    defaultMessage: "Manage Challenge",
   },
 })

--- a/src/pages/Inbox/Notification.js
+++ b/src/pages/Inbox/Notification.js
@@ -28,6 +28,8 @@ class Notification extends Component {
       case NotificationType.reviewRejected:
       case NotificationType.reviewAgain:
         return <ReviewBody notification={notification} />
+      case NotificationType.challengeCompleted:
+        return <ChallengeCompletionBody notification={notification} />
       default:
         return null
     }
@@ -155,6 +157,20 @@ const ReviewBody = function(props) {
   )
 }
 
+const ChallengeCompletionBody = function(props) {
+  return (
+    <React.Fragment>
+      <p className="mr-mb-8 mr-text-base">
+        <FormattedMessage {...messages.challengeCompleteNotificationLead} />
+      </p>
+
+      <p className="mr-text-md mr-text-yellow">{props.notification.description}</p>
+
+      <ViewChallengeAdmin notification={props.notification} />
+    </React.Fragment>
+  )
+}
+
 const AttachedComment = function(props) {
   if (_isEmpty(props.notification.extra)) {
     return null
@@ -185,6 +201,24 @@ const ViewTask = function(props) {
               state: {fromInbox: true}
             }}>
         <FormattedMessage {...messages.viewTaskLabel} />
+      </Link>
+    </div>
+  )
+}
+
+const ViewChallengeAdmin = function(props) {
+  if (!_isFinite(props.notification.challengeId) ||
+      !_isFinite(props.notification.projectId)) {
+    return null
+  }
+
+  return (
+    <div className="mr-mt-8">
+      <Link to={{
+        pathname: `admin/project/${props.notification.projectId}/challenge/${props.notification.challengeId}`,
+        state: {fromInbox: true}
+      }}>
+        <FormattedMessage {...messages.manageChallengeLabel} />
       </Link>
     </div>
   )

--- a/src/pages/Profile/UserSettings/UserSettingsSchema.js
+++ b/src/pages/Profile/UserSettings/UserSettingsSchema.js
@@ -82,7 +82,7 @@ export const jsSchema = (intl, user, editor) => {
         title: intl.formatMessage(messages.notificationSubscriptionsLabel),
         type: "array",
         items: _map(NotificationType, (type, name) => ({
-          title: `${localizedNotificationLabels[name]} ${intl.formatMessage(messages.notificationLabel)}`,
+          title: `${localizedNotificationLabels[`${name}Long`] || localizedNotificationLabels[name]} ${intl.formatMessage(messages.notificationLabel)}`,
           type: "number",
           enum: _values(SubscriptionType),
           enumNames: _map(SubscriptionType, (value, key) => localizedSubscriptionLabels[key]),

--- a/src/services/Notification/NotificationType/Messages.js
+++ b/src/services/Notification/NotificationType/Messages.js
@@ -24,4 +24,12 @@ export default defineMessages({
     id: "Notification.type.review.again",
     defaultMessage: "Review"
   },
+  challengeCompleted: {
+    id: "Notification.type.challengeCompleted",
+    defaultMessage: "Completed"
+  },
+  challengeCompletedLong: {
+    id: "Notification.type.challengeCompletedLong",
+    defaultMessage: "Challenge Completed"
+  },
 })

--- a/src/services/Notification/NotificationType/NotificationType.js
+++ b/src/services/Notification/NotificationType/NotificationType.js
@@ -9,6 +9,7 @@ export const NOTIFICATION_TYPE_MENTION = 1
 export const NOTIFICATION_TYPE_REVIEW_APPROVED = 2
 export const NOTIFICATION_TYPE_REVIEW_REJECTED = 3
 export const NOTIFICATION_TYPE_REVIEW_AGAIN = 4
+export const NOTIFICATION_TYPE_CHALLENGE_COMPLETED = 5
 
 export const NotificationType = Object.freeze({
   system: NOTIFICATION_TYPE_SYSTEM,
@@ -16,6 +17,7 @@ export const NotificationType = Object.freeze({
   reviewApproved: NOTIFICATION_TYPE_REVIEW_APPROVED,
   reviewRejected: NOTIFICATION_TYPE_REVIEW_REJECTED,
   reviewAgain: NOTIFICATION_TYPE_REVIEW_AGAIN,
+  challengeCompleted: NOTIFICATION_TYPE_CHALLENGE_COMPLETED,
 })
 
 export const keysByNotificationType = Object.freeze(_invert(NotificationType))

--- a/src/services/Server/Server.js
+++ b/src/services/Server/Server.js
@@ -144,7 +144,7 @@ export const sendContent = function(method, url, jsonBody, formData, normalizati
           resolve(jsonData)
         }
       }).catch(error => reject(error))
-    })
+    }).catch(error => reject(error))
   })
 }
 


### PR DESCRIPTION
> Note that is depends on backend PR maproulette/maproulette2#657

* Add support for displaying notifications that a challenge managed by
the current user has been completed

* Support "long" notification type names that allow the subscription
header to provide a more meaningful type name than the short
notification type shown in the Inbox table listing