### PR TITLE
Fix URI encoding used for URL property replacement

### DIFF
--- a/src/components/MarkdownContent/MarkdownTemplate.js
+++ b/src/components/MarkdownContent/MarkdownTemplate.js
@@ -152,8 +152,8 @@ export default class MarkdownTemplate extends Component {
       // representation (and url-encode the substituted property value since
       // it's presumably being used in a URL)
       substituted = substituted.replace(
-        RegExp(`${encodeURIComponent('{{')}\\s*${encodeURIComponent(key)}\\s*${encodeURIComponent('}}')}`, "g"),
-        encodeURIComponent(safe)
+        RegExp(`${encodeURI('{{')}\\s*${encodeURI(key)}\\s*${encodeURI('}}')}`, "g"),
+        encodeURI(safe)
       )
     })
     return substituted


### PR DESCRIPTION
* Switch from encodeURIComponent to encodeURI during property
replacement within URLs to better match the encoding the Markdown parser
is using