### PR TITLE
Clear query when switching search types in search box.

### DIFF
--- a/src/components/HOCs/WithCommandInterpreter/WithCommandInterpreter.js
+++ b/src/components/HOCs/WithCommandInterpreter/WithCommandInterpreter.js
@@ -46,7 +46,9 @@ const WithCommandInterpreter = function(WrappedComponent) {
     clearSearch = () => {
       // Temporary: until we add an Advanced Search dialog where a user can
       // clear a project search filter, we need to do it explicitly here
+      this.props.removeSearchFilters(['query'])
       this.props.removeSearchFilters(['project'])
+      this.props.removeSearchFilters(['searchType'])
 
       this.props.clearSearch()
       this.setState({commandString: null, searchType: null, searchActive: true})
@@ -55,6 +57,21 @@ const WithCommandInterpreter = function(WrappedComponent) {
     deactivate = () => {
       executeCommand(this.props, this.state.commandString, this.state.searchType,
                      (loading) => this.setState({mapLoading: loading}), true)
+    }
+
+    componentDidUpdate(prevProps) {
+      if (_get(prevProps, 'searchQuery.filters.searchType') !==
+            _get(this.props, 'searchQuery.filters.searchType')) {
+        // Happens when clearing filters, we are no longer searching projects
+        if (this.state.commandString) {
+          this.setState({commandString: null, searchType: null})
+        }
+        else {
+          // Happens when project query is on url route
+          this.setState({commandString: _get(this.props, 'searchQuery.filters.project'),
+                         searchType: _get(this.props, 'searchQuery.filters.searchType')})
+        }
+      }
     }
 
     render() {

--- a/src/components/HOCs/WithSearchRoute/WithSearchRoute.js
+++ b/src/components/HOCs/WithSearchRoute/WithSearchRoute.js
@@ -7,6 +7,7 @@ import _debounce from 'lodash/debounce'
 import queryString from 'query-string'
 import { toLatLngBounds, fromLatLngBounds }
        from '../../../services/MapBounds/MapBounds'
+import { SEARCH_TYPE_PROJECT } from '../../SearchTypeFilter/SearchTypeFilter'
 
 /**
  * WithSearchRoute adds functionality to WithSearch to add/remove values to the URL route
@@ -31,6 +32,7 @@ export const WithSearchRoute = function(WrappedComponent, searchGroup) {
        difficulty: param => this.props.setSearchFilters({difficulty: parseInt(param, 10)}),
        keywords: param => this.props.setKeywordFilter(param.split(',')),
        location: param => this.props.setSearchFilters({location: param}),
+       project: param => this.props.setSearchFilters({project: param, searchType: SEARCH_TYPE_PROJECT}),
        query: param => this.props.setSearch(param),
        challengeSearch: param => this.props.setChallengeSearchMapBounds(toLatLngBounds(param), true)
     }

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -39,12 +39,6 @@ export default class SearchBox extends Component {
     this.props.setSearch(e.target.value, this.getSearchType(this.props))
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.getSearchType(prevProps) !== this.getSearchType(this.props)) {
-      this.props.setSearch(this.getQuery(this.props), this.getSearchType(this.props))
-    }
-  }
-
   getSearchType(props) {
     return _get(props, 'searchFilters.searchType')
   }

--- a/src/components/SearchTypeFilter/SearchTypeFilter.js
+++ b/src/components/SearchTypeFilter/SearchTypeFilter.js
@@ -17,6 +17,7 @@ export const SEARCH_TYPE_CHALLENGE = "challenges"
  */
 export class SearchTypeFilter extends Component {
   updateFilter = (value, closeDropdown) => {
+    this.props.clearSearch()
     this.props.setSearchFilters({searchType: value})
     closeDropdown()
   }


### PR DESCRIPTION
* Clear query when switching search types (projects/challenges)

* Clear query when 'clear filters' is clicked

* If project query is on URL then execute project query search