### PR TITLE
Remove references to `mr3/` URL path from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,7 @@ server for development use*
 ## Staging/Production build:
 
 1. Setup a `.env.production` file with the desired production setting overrides.
- * set `REACT_APP_BASE_PATH='/mr3'`
- * set `REACT_APP_URL='https://myserver.com/mr3'`
+ * set `REACT_APP_URL='https://myserver.com'`
    (substituting your domain, of course)
  * set `REACT_APP_MAP_ROULETTE_SERVER_URL='https://myserver.com'`
  * if you wish to use [Matomo/PIWIK](https://github.com/matomo-org/matomo) for


### PR DESCRIPTION
* Remove references to `mr3/` path in frontend URL (e.g.
maproulette.org/mr3) from the setup instructions in the README as the
frontend now runs at the root (e.g. maproulette.org)