### PR TITLE
Indicate too many tasks for virtual challenge

### DIFF
--- a/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.js
+++ b/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.js
@@ -5,7 +5,7 @@ import _map from 'lodash/map'
 import _findIndex from 'lodash/findIndex'
 import _isObject from 'lodash/isObject'
 import _sumBy from 'lodash/sumBy'
-import { FormattedMessage } from 'react-intl'
+import { FormattedMessage, injectIntl } from 'react-intl'
 import WithCurrentUser from '../../HOCs/WithCurrentUser/WithCurrentUser'
 import WithSortedChallenges from '../../HOCs/WithSortedChallenges/WithSortedChallenges'
 import WithPagedChallenges from '../../HOCs/WithPagedChallenges/WithPagedChallenges'
@@ -79,15 +79,31 @@ export class ChallengeResultList extends Component {
       else if (_get(this.props, 'mapBoundedTaskClusters.clusters.length')) {
         const taskCount = _sumBy(this.props.mapBoundedTaskClusters.clusters,
                                 'numberOfPoints')
-        if (taskCount > 0 && taskCount < maxAllowedVCTasks()) {
-          virtualChallengeOption = (
-            <StartVirtualChallenge
-              {...this.props}
-              taskCount={taskCount}
-              createVirtualChallenge={this.props.startMapBoundedTasks}
-              creatingVirtualChallenge={this.props.creatingVirtualChallenge}
-            />
-          )
+        if (taskCount > 0) {
+          if (taskCount < maxAllowedVCTasks()) {
+            virtualChallengeOption = (
+              <StartVirtualChallenge
+                {...this.props}
+                taskCount={taskCount}
+                createVirtualChallenge={this.props.startMapBoundedTasks}
+                creatingVirtualChallenge={this.props.creatingVirtualChallenge}
+              />
+            )
+          }
+          else {
+            virtualChallengeOption = (
+              <button
+                disabled
+                className="mr-button mr-button--disabled mr-w-full mr-mb-4"
+                title={
+                  this.props.intl.formatMessage(messages.tooManyTasksTooltip,
+                                                {maxTasks: maxAllowedVCTasks()})
+                }
+              >
+                <FormattedMessage {...messages.tooManyTasksLabel} />
+              </button>
+            )
+          }
         }
       }
     }
@@ -150,6 +166,6 @@ ChallengeResultList.propTypes = {
 
 export default WithCurrentUser(
   WithSortedChallenges(
-    WithPagedChallenges(ChallengeResultList, 'challenges', 'pagedChallenges')
+    WithPagedChallenges(injectIntl(ChallengeResultList), 'challenges', 'pagedChallenges')
   )
 )

--- a/src/components/ChallengePane/ChallengeResultList/Messages.js
+++ b/src/components/ChallengePane/ChallengeResultList/Messages.js
@@ -14,6 +14,16 @@ export default defineMessages({
     defaultMessage: "No Results",
   },
 
+  tooManyTasksLabel: {
+    id: "VirtualChallenge.controls.tooMany.label",
+    defaultMessage: "Zoom in to work on mapped tasks",
+  },
+
+  tooManyTasksTooltip: {
+    id: "VirtualChallenge.controls.tooMany.tooltip",
+    defaultMessage: 'At most {maxTasks, number} tasks can be included in a "virtual" challenge',
+  },
+
   createVirtualChallenge: {
     id: "VirtualChallenge.controls.create.label",
     defaultMessage: "Work on {taskCount, number} Mapped Tasks",

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -291,6 +291,8 @@
   "Challenge.signIn.label": "Sign in to get started",
   "Challenge.results.heading": "Challenges",
   "Challenge.results.noResults": "No Results",
+  "VirtualChallenge.controls.tooMany.label": "Zoom in to work on mapped tasks",
+  "VirtualChallenge.controls.tooMany.tooltip": "At most {maxTasks, number} tasks can be included in a \"virtual\" challenge",
   "VirtualChallenge.controls.create.label": "Work on {taskCount, number} Mapped Tasks",
   "VirtualChallenge.fields.name.label": "Name your \"virtual\" challenge",
   "Challenge.controls.loadMore.label": "More Results",

--- a/src/styles/components/buttons.css
+++ b/src/styles/components/buttons.css
@@ -60,6 +60,14 @@
     }
   }
 
+  &--disabled {
+    @apply mr-border-grey-lighter-50 mr-text-grey-lighter-50;
+
+    &:hover {
+      @apply mr-border-grey-lighter-50 mr-text-grey-lighter-50 mr-cursor-not-allowed;
+    }
+  }
+
   &--blue-fill {
     @apply mr-bg-blue mr-border-0 mr-text-white;
 

--- a/src/tailwind.js
+++ b/src/tailwind.js
@@ -61,6 +61,7 @@ let colors = {
   'grey-light-more': '#D8D8D8',
   'grey-lighter': '#F2EFE9',
   'grey-lighter-10': 'rgba(242, 239, 233, .1)',
+  'grey-lighter-50': 'rgba(242, 239, 233, .5)',
   'grey-leaflet': '#666',
   green: '#5B937A',
   'green-light': '#7EBC89',


### PR DESCRIPTION
* When tasks are shown on the Find Challenges page, but there are too
many to create a virtual challenge, show a disabled button indicating
that the user should zoom in to work on mapped tasks (with a tooltip
that explains the maximum number of allowed tasks)