### PR TITLE
Show details for challenge-completed notifications

### DIFF
--- a/src/pages/Inbox/Notification.js
+++ b/src/pages/Inbox/Notification.js
@@ -164,7 +164,7 @@ const ChallengeCompletionBody = function(props) {
         <FormattedMessage {...messages.challengeCompleteNotificationLead} />
       </p>
 
-      <p className="mr-text-md mr-text-yellow">{props.notification.description}</p>
+      <p className="mr-text-md mr-text-yellow">{props.notification.extra}</p>
 
       <ViewChallengeAdmin notification={props.notification} />
     </React.Fragment>


### PR DESCRIPTION
> Note: this relies on backend PR maproulette/maproulette2#666

* Show `extra` field instead of `description` field when viewing
challenge notifications to include a bit more detail about the challenge