### PR TITLE
Snap nearby-task markers to line strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@turf/centroid": "^6.0.2",
     "@turf/distance": "^6.0.1",
     "@turf/invariant": "^5.1.5",
+    "@turf/nearest-point-on-line": "^6.0.2",
     "bulma": "0.6.0",
     "bulma-badge": "^0.1.0",
     "bulma-checkradio": "^1.0.1",

--- a/src/components/HOCs/WithNearbyTasks/WithNearbyTasks.js
+++ b/src/components/HOCs/WithNearbyTasks/WithNearbyTasks.js
@@ -81,7 +81,6 @@ export const WithNearbyTasks = function(WrappedComponent) {
     componentDidUpdate() {
       if (this.state.nearbyTasks && !this.state.nearbyTasks.loading &&
           this.props.taskId !== this.state.nearbyTasks.nearTaskId) {
-        console.log(this.state.nearbyTasks)
         this.updateNearbyTasks(this.props)
       }
     }

--- a/src/components/HOCs/WithTaskMarkers/WithTaskMarkers.js
+++ b/src/components/HOCs/WithTaskMarkers/WithTaskMarkers.js
@@ -5,6 +5,7 @@ import _isFinite from 'lodash/isFinite'
 import _isObject from 'lodash/isObject'
 import _each from 'lodash/each'
 import { TaskStatus } from '../../../services/Task/TaskStatus/TaskStatus'
+import AsMappableTask from '../../../interactions/Task/AsMappableTask'
 
 /**
  * WithTaskMarkers generates map markers for the given tasks and passes them
@@ -21,41 +22,27 @@ export default function WithTaskMarkers(WrappedComponent,
     render() {
       const challengeTasks = _get(this.props, tasksProp)
 
+      // Only create markers for created, skipped, or too-hard tasks
+      const allowedStatuses = [TaskStatus.created, TaskStatus.skipped, TaskStatus.tooHard]
       const markers = []
       if (_isObject(challengeTasks)) {
         if (_isArray(challengeTasks.tasks) && challengeTasks.tasks.length > 0) {
           _each(challengeTasks.tasks, task => {
-            // Only create markers for created or skipped tasks
-            if (task.point && (task.status === TaskStatus.created ||
-                               task.status === TaskStatus.skipped ||
-                               task.status === TaskStatus.tooHard)) {
-              markers.push({
-                position: [task.point.lat, task.point.lng],
-                options: {
-                  challengeId: _isFinite(challengeTasks.challengeId) ?
-                               challengeTasks.challengeId : (task.challengeId || task.parentId),
-                  isVirtualChallenge: challengeTasks.isVirtualChallenge,
-                  challengeName: task.parentName,
-                  taskId: task.id,
-                },
-              })
+            if (allowedStatuses.indexOf(task.status) === -1) {
+              return
             }
-            else if (task.geometries) {
-              _each(_get(task.geometries, 'features'), (feature) => {
-                if (feature.geometry.type === "Point" )
-                  markers.push({
-                    position: [feature.geometry.coordinates[1], feature.geometry.coordinates[0]],
-                    options: {
-                      challengeId: _isFinite(challengeTasks.challengeId) ?
-                                   challengeTasks.challengeId : (task.challengeId || task.parentId),
-                      isVirtualChallenge: challengeTasks.isVirtualChallenge,
-                      challengeName: task.parentName,
-                      taskId: task.id,
-                    },
-                  })
-                }
-              )
-            }
+
+            const nearestToCenter = AsMappableTask(task).nearestPointToCenter()
+            markers.push({
+              position: [nearestToCenter.geometry.coordinates[1], nearestToCenter.geometry.coordinates[0]],
+              options: {
+                challengeId: _isFinite(challengeTasks.challengeId) ?
+                              challengeTasks.challengeId : (task.challengeId || task.parentId),
+                isVirtualChallenge: challengeTasks.isVirtualChallenge,
+                challengeName: task.parentName,
+                taskId: task.id,
+              },
+            })
           })
         }
       }

--- a/src/interactions/Task/AsMappableTask.js
+++ b/src/interactions/Task/AsMappableTask.js
@@ -1,12 +1,15 @@
+import { getType } from '@turf/invariant'
 import { point } from '@turf/helpers'
 import center from '@turf/center'
 import bbox from '@turf/bbox'
+import nearestPointOnLine from '@turf/nearest-point-on-line'
 import _get from 'lodash/get'
 import _isObject from 'lodash/isObject'
 import _isArray from 'lodash/isArray'
 import _map from 'lodash/map'
 import _fromPairs from 'lodash/fromPairs'
 import _pick from 'lodash/pick'
+import _every from 'lodash/every'
 import _cloneDeep from 'lodash/cloneDeep'
 import { latLng } from 'leaflet'
 import AsIdentifiableFeature from '../TaskFeature/AsIdentifiableFeature'
@@ -37,6 +40,23 @@ export class AsMappableTask {
     }
 
     return true
+  }
+
+  /**
+   * Determines if the geometry features are all of the given feature
+   * type or types (can be a string or array of multiple strings)
+   */
+  isFeatureType(allowedFeatureTypes) {
+    if (!this.hasGeometries()) {
+      return false
+    }
+
+    const allowedTypes = _isArray(allowedFeatureTypes) ?
+                         allowedFeatureTypes : [allowedFeatureTypes]
+
+    return _every(this.geometries.features, feature =>
+      allowedTypes.indexOf(getType(feature)) !== -1
+    )
   }
 
   /**
@@ -84,11 +104,11 @@ export class AsMappableTask {
   }
 
   /**
-   * Returns the task centerpoint as a leaflet LatLng object, calculating it if
-   * necessary (and possible). If the centerpoint can't be determined it will
-   * default to (0, 0).
+   * Returns the task centerpoint as (lng, lat), calculating it if necessary
+   * (and possible). If the centerpoint can't be determined it will default to
+   * (0, 0)
    */
-  calculateCenterPoint() {
+  rawCenterPoint() {
     let centerPoint = _get(this, 'location.coordinates')
 
     // Not all tasks have a center-point. In that case, we try to calculate
@@ -105,9 +125,49 @@ export class AsMappableTask {
       centerPoint = [0, 0]
     }
 
-    // Our centerpoint is a standard GeoJSON Point, which is (Lng, Lat), but
-    // Leaflet maps want (Lat, Lng).
+    return centerPoint
+  }
+
+  /**
+   * Returns the task centerpoint as a leaflet LatLng object, calculating it if
+   * necessary (and possible). If the centerpoint can't be determined it will
+   * default to (0, 0)
+   */
+  calculateCenterPoint() {
+    const centerPoint = this.rawCenterPoint()
+
+    // The raw centerpoint is (Lng, Lat), but Leaflet maps want (Lat, Lng)
     return latLng(centerPoint[1], centerPoint[0])
+  }
+
+  /**
+   * For tasks with LineString or MultiLineString geometry, returns the point
+   * along the line nearest to the task's computed centerpoint. Otherwise the
+   * centerpoint is simply returned as a GeoJSON Point object
+   */
+  nearestPointToCenter() {
+    const centerPoint = this.rawCenterPoint()
+
+    if (this.isFeatureType(['LineString', 'MultiLineString'])) {
+      try {
+        return nearestPointOnLine(this.normalizedGeometries(), centerPoint)
+      }
+      catch(e) {} // Bad geometry can cause turf to blow up
+    }
+
+    return point(centerPoint)
+  }
+
+  /**
+   * If possible, repair common problems with geometries, such as a missing
+   * FeatureCollection type
+   */
+  normalizedGeometries() {
+    if (_isArray(this.geometries.features) && !this.geometries.type) {
+      return Object.assign({type: "FeatureCollection"}, this.geometries)
+    }
+
+    return this.geometries
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1358,12 +1358,28 @@
   dependencies:
     "@turf/helpers" "^5.1.5"
 
+"@turf/bbox@*":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-6.0.1.tgz#b966075771475940ee1c16be2a12cf389e6e923a"
+  integrity sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/meta" "6.x"
+
 "@turf/bbox@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-5.1.5.tgz#3051df514ad4c50f4a4f9b8a2d15fd8b6840eda3"
   dependencies:
     "@turf/helpers" "^5.1.5"
     "@turf/meta" "^5.1.5"
+
+"@turf/bearing@6.x":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/bearing/-/bearing-6.0.1.tgz#8da5d17092e571f170cde7bfb2e5b0d74923c92d"
+  integrity sha512-mXY1NozqV9EFfBTbUItujwfqfQF0G/Xe2fzvnZle90ekPEUfhi4Dgf5JswJTd96J9LiT8kcd6Jonp5khnx0wIg==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
 
 "@turf/boolean-disjoint@^5.1.5":
   version "5.1.6"
@@ -1396,7 +1412,15 @@
     "@turf/helpers" "6.x"
     "@turf/meta" "6.x"
 
-"@turf/distance@^6.0.1":
+"@turf/destination@6.x":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/destination/-/destination-6.0.1.tgz#5275887fa96ec463f44864a2c17f0b712361794a"
+  integrity sha512-MroK4nRdp7as174miCAugp8Uvorhe6rZ7MJiC9Hb4+hZR7gNFJyVKmkdDDXIoCYs6MJQsx0buI+gsCpKwgww0Q==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+
+"@turf/distance@6.x", "@turf/distance@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.0.1.tgz#0761f28784286e7865a427c4e7e3593569c2dea8"
   dependencies:
@@ -1423,6 +1447,17 @@
   dependencies:
     "@turf/helpers" "^5.1.5"
 
+"@turf/line-intersect@6.x":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@turf/line-intersect/-/line-intersect-6.0.2.tgz#b45b7a4e7e08c39a0e4e91099580ed377ef7335f"
+  integrity sha512-pfL/lBu7ukBPdTjvSCmcNUzZ83V4R95htwqs5NqU8zeS4R+5KTwacbrOYKztjpmHBwUmPEIIpSbqkUoD0Fp7kg==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    "@turf/line-segment" "6.x"
+    "@turf/meta" "6.x"
+    geojson-rbush "3.x"
+
 "@turf/line-intersect@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/line-intersect/-/line-intersect-5.1.5.tgz#0e29071ae403295e491723bc49f5cfac8d11ddf3"
@@ -1432,6 +1467,15 @@
     "@turf/line-segment" "^5.1.5"
     "@turf/meta" "^5.1.5"
     geojson-rbush "2.1.0"
+
+"@turf/line-segment@6.x":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@turf/line-segment/-/line-segment-6.0.2.tgz#e280bcde70d28b694028ec1623dc406c928e59b6"
+  integrity sha512-8AkzDHoNw3X68y115josal+lvdAi4b2P1K0YNTKGyLRBaUhPXVSuMBpMd53FRF1hYEb9UJgMbugF9ZE7m5L6zg==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    "@turf/meta" "6.x"
 
 "@turf/line-segment@^5.1.5":
   version "5.1.5"
@@ -1452,6 +1496,19 @@
   resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-5.2.0.tgz#3b1ad485ee0c3b0b1775132a32c384d53e4ba53d"
   dependencies:
     "@turf/helpers" "^5.1.5"
+
+"@turf/nearest-point-on-line@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@turf/nearest-point-on-line/-/nearest-point-on-line-6.0.2.tgz#4b2c1177595d9a1743af76905a9013ced03bc0dc"
+  integrity sha512-re9tSEwYyG1EMo4ObXXAKYVhkMVANPIIJQ1V/J1lKcNfHVc1pYmd3D5jkTNBh+oriI9VL4PVML3eqYE+Zcg0mg==
+  dependencies:
+    "@turf/bearing" "6.x"
+    "@turf/destination" "6.x"
+    "@turf/distance" "6.x"
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    "@turf/line-intersect" "6.x"
+    "@turf/meta" "6.x"
 
 "@turf/polygon-to-line@^5.1.5":
   version "5.1.5"
@@ -5692,6 +5749,16 @@ geojson-rbush@2.1.0:
     "@turf/helpers" "*"
     "@turf/meta" "*"
     rbush "*"
+
+geojson-rbush@3.x:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/geojson-rbush/-/geojson-rbush-3.1.2.tgz#577d6ec70ba986d4e60b741f1df5147faeb82c97"
+  integrity sha512-grkfdg3HIeTjwTfiJe5FT8+fGU3fABCc+vRJDBwdQz9kkLF0Sbif2gs2JUzjewwgmnvLGy9fInySDeADoNuk7w==
+  dependencies:
+    "@turf/bbox" "*"
+    "@turf/helpers" "6.x"
+    "@turf/meta" "6.x"
+    rbush "^2.0.0"
 
 get-caller-file@^1.0.1:
   version "1.0.3"
@@ -10021,7 +10088,7 @@ rbush@*:
   dependencies:
     quickselect "^2.0.0"
 
-rbush@^2.0.2:
+rbush@^2.0.0, rbush@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/rbush/-/rbush-2.0.2.tgz#bb6005c2731b7ba1d5a9a035772927d16a614605"
   dependencies:


### PR DESCRIPTION
* When displaying task markers for nearby tasks with LineString or
MultiLineString geometry, snap the markers to a point on the line near
the centerpoint, instead of rendering at the centerpoint itself

* This results in more natural marker locations for things like curving
roads, where the centerpoint could end up off to the side of the road

![snap_to_line](https://user-images.githubusercontent.com/445970/72025844-47a37300-322e-11ea-82e2-83879cd2901e.png)