### PR TITLE
Add option to skip current task being reviewed

### DIFF
--- a/src/components/HOCs/WithChallenge/WithChallenge.js
+++ b/src/components/HOCs/WithChallenge/WithChallenge.js
@@ -43,6 +43,12 @@ const WithChallenge = function(WrappedComponent) {
       this.updateChallenge(this.props)
     }
 
+    componentDidUpdate(prevProps) {
+      if (this.parseChallengeId(this.props) !== this.parseChallengeId(prevProps)) {
+        this.updateChallenge(this.props)
+      }
+    }
+
     render() {
       return (
         <WrappedComponent challenge = {this.state.challenge}

--- a/src/components/HOCs/WithTaskReview/WithTaskReview.js
+++ b/src/components/HOCs/WithTaskReview/WithTaskReview.js
@@ -29,40 +29,17 @@ const mapDispatchToProps = (dispatch, ownProps) => {
         completeBundleReview(taskBundle.bundleId, status, comment, tags) :
         completeReview(task.id, status, comment, tags)
 
-      dispatch(doReview).then(() => {
-        let newState = url.location.state
-        const searchCriteria = parseSearchCriteria(url, newState)
-
-        dispatch(loadNextReviewTask(searchCriteria)).then((task) => {
-          if (task && loadBy === TaskReviewLoadMethod.next) {
-            url.push({
-              pathname:`/challenge/${task.parentId || task.parent}/task/${task.id}/review`,
-              state: newState
-            })
-          }
-          else if (task && loadBy === TaskReviewLoadMethod.inbox) {
-            url.push({
-              pathname:'/inbox',
-              state: newState
-            })
-          }
-          else {
-            url.push({
-              pathname: '/review',
-              state: newState,
-            })
-          }
-        }).catch(error => {
-          console.log(error)
-          url.push({
-            pathname: '/review',
-            state: newState,
-          })
-        })
-      }).catch(error => {
+      loadNextTaskForReview(dispatch, url, task.id).then(nextTask =>
+        dispatch(doReview).then(() => visitTaskForReview(loadBy, url, nextTask))
+      ).catch(error => {
         console.log(error)
         url.push('/review')
       })
+    },
+
+    skipTaskReview: (task, loadBy, url) => {
+      dispatch(cancelReviewClaim(task.id))
+      loadNextTaskForReview(dispatch, url, task.id).then(nextTask => visitTaskForReview(loadBy, url, nextTask))
     },
 
     stopReviewing: (task, url) => {
@@ -72,7 +49,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 
       url.push({
         pathname: '/review',
-        state: parseSearchCriteria(url)
+        state: parseSearchCriteria(url).searchCriteria
       })
     },
 
@@ -84,7 +61,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   }
 }
 
-export const parseSearchCriteria = (url, newState) => {
+export const parseSearchCriteria = url => {
   const searchParams = _merge(new URLSearchParams(url.location.search), url.location.state)
   let sortBy = searchParams.sortBy
   let direction = searchParams.direction
@@ -101,9 +78,36 @@ export const parseSearchCriteria = (url, newState) => {
     direction = _get(searchParams, 'sortCriteria.direction')
   }
 
-  newState = {sortBy, direction, filters, boundingBox, savedChallengesOnly}
-  return {sortCriteria: {sortBy, direction}, filters, boundingBox, savedChallengesOnly}
+  return {
+    searchCriteria: {sortCriteria: {sortBy, direction}, filters, boundingBox, savedChallengesOnly},
+    newState: {sortBy, direction, filters, boundingBox, savedChallengesOnly}
+  }
 }
 
+export const visitTaskForReview = (loadBy, url, task) => {
+  const newState = parseSearchCriteria(url).newState
+  if (task && loadBy === TaskReviewLoadMethod.next) {
+    url.push({
+      pathname:`/challenge/${_get(task, 'parent.id', task.parent)}/task/${task.id}/review`,
+      state: newState
+    })
+  }
+  else if (task && loadBy === TaskReviewLoadMethod.inbox) {
+    url.push({
+      pathname: '/inbox',
+      state: newState
+    })
+  }
+  else {
+    url.push({
+      pathname: '/review',
+      state: newState,
+    })
+  }
+}
+
+export const loadNextTaskForReview = (dispatch, url, lastTaskId) => {
+  return dispatch(loadNextReviewTask(parseSearchCriteria(url).searchCriteria, lastTaskId))
+}
 
 export default WithTaskReview

--- a/src/components/ReviewTaskControls/Messages.js
+++ b/src/components/ReviewTaskControls/Messages.js
@@ -70,9 +70,9 @@ export default defineMessages({
     defaultMessage: "Start Review",
   },
 
-  stopReview: {
-    id: "Admin.TaskReview.controls.stopReview",
-    defaultMessage: "Cancel Review",
+  skipReview: {
+    id: "Admin.TaskReview.controls.skipReview",
+    defaultMessage: "Skip Review",
   },
 
   resubmit: {

--- a/src/components/ReviewTaskControls/ReviewTaskControls.js
+++ b/src/components/ReviewTaskControls/ReviewTaskControls.js
@@ -9,7 +9,6 @@ import { TaskStatus, messagesByStatus }
        from '../../services/Task/TaskStatus/TaskStatus'
 import { TaskReviewLoadMethod } from '../../services/Task/TaskReview/TaskReviewLoadMethod'
 import { messagesByReviewStatus } from '../../services/Task/TaskReview/TaskReviewStatus'
-import WithTaskReview from '../HOCs/WithTaskReview/WithTaskReview'
 import WithTaskTags from '../HOCs/WithTaskTags/WithTaskTags'
 import WithSearch from '../HOCs/WithSearch/WithSearch'
 import WithKeyboardShortcuts from '../HOCs/WithKeyboardShortcuts/WithKeyboardShortcuts'
@@ -57,9 +56,11 @@ export class ReviewTaskControls extends Component {
     this.setState({reviewStatus, confirmingTask: true})
   }
 
-  /** Stop Reviewing (release claim) */
-  stopReviewing = () => {
-    this.props.stopReviewing(this.props.task, this.props.history)
+  /** Skip review of this task */
+  skipReview = () => {
+    this.props.skipTaskReview(this.props.task, this.state.loadBy,
+                              this.props.history, this.props.taskBundle)
+    this.setState({confirmingTask: false, comment: ""})
   }
 
   /** Start Reviewing (claim this task) */
@@ -187,8 +188,8 @@ export class ReviewTaskControls extends Component {
             <FormattedMessage {...messages.approvedWithFixes} />
           </button>
           <button className="mr-button mr-button--white"
-                  onClick={() => this.stopReviewing()}>
-            <FormattedMessage {...messages.stopReview} />
+                  onClick={() => this.skipReview()}>
+            <FormattedMessage {...messages.skipReview} />
           </button>
         </div>
 
@@ -222,10 +223,8 @@ ReviewTaskControls.propTypes = {
 export default
   WithSearch(
     WithTaskTags(
-      WithTaskReview(
-        WithEditor(
-          WithKeyboardShortcuts(ReviewTaskControls)
-        )
+      WithEditor(
+        WithKeyboardShortcuts(ReviewTaskControls)
       )
     ),
     'task'

--- a/src/components/ReviewTaskPane/Messages.js
+++ b/src/components/ReviewTaskPane/Messages.js
@@ -1,0 +1,16 @@
+import { defineMessages } from 'react-intl'
+
+/**
+ * Internationalized messages for use with ReviewTaskPane
+ */
+export default defineMessages({
+  taskLockedLabel: {
+    id: "ReviewTaskPane.indicators.locked.label",
+    defaultMessage: "Task locked",
+  },
+
+  taskUnlockLabel: {
+    id: "ReviewTaskPane.controls.unlock.label",
+    defaultMessage: "Unlock",
+  },
+})

--- a/src/components/ReviewTaskPane/ReviewTaskPane.js
+++ b/src/components/ReviewTaskPane/ReviewTaskPane.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import MediaQuery from 'react-responsive'
+import { FormattedMessage } from 'react-intl'
 import _isFinite from 'lodash/isFinite'
 import _get from 'lodash/get'
 import { generateWidgetId, WidgetDataTarget, widgetDescriptor }
@@ -10,14 +11,18 @@ import WithWidgetWorkspaces
 import WithCurrentUser from '../HOCs/WithCurrentUser/WithCurrentUser'
 import WithChallengePreferences
        from '../HOCs/WithChallengePreferences/WithChallengePreferences'
+import WithChallenge from '../HOCs/WithChallenge/WithChallenge'
 import WithTaskBundle from '../HOCs/WithTaskBundle/WithTaskBundle'
+import WithTaskReview from '../HOCs/WithTaskReview/WithTaskReview'
 import WidgetWorkspace from '../WidgetWorkspace/WidgetWorkspace'
 import MapPane from '../EnhancedMap/MapPane/MapPane'
 import TaskMap from '../TaskPane/TaskMap/TaskMap'
 import ChallengeNameLink from '../ChallengeNameLink/ChallengeNameLink'
 import OwnerContactLink from '../ChallengeOwnerContactLink/ChallengeOwnerContactLink'
+import SvgSymbol from '../SvgSymbol/SvgSymbol'
 import BusySpinner from '../BusySpinner/BusySpinner'
 import MobileTaskDetails from '../TaskPane/MobileTaskDetails/MobileTaskDetails'
+import messages from './Messages'
 import './ReviewTaskPane.scss'
 
 // Setup child components with necessary HOCs
@@ -110,15 +115,33 @@ export class ReviewTaskPane extends Component {
               </h1>
             }
             workspaceInfo={
-              <ul className="mr-list-ruled mr-text-xs">
-                <li className="mr-links-inverse">
-                  {_get(this.props.task, 'parent.parent.displayName')}
-                </li>
+              <div>
+                 <ul className="mr-list-ruled mr-text-xs">
+                   <li className="mr-links-inverse">
+                     {_get(this.props.task, 'parent.parent.displayName')}
+                   </li>
 
-                <li className="mr-links-green-lighter">
-                  <OwnerContactLink {...this.props} />
-                </li>
-              </ul>
+                   <li className="mr-links-green-lighter">
+                     <OwnerContactLink {...this.props} />
+                   </li>
+                 </ul>
+                 <div className="mr-links-green-lighter mr-text-sm mr-flex mr-items-center mr-mt-2">
+                   <SvgSymbol
+                     sym="locked-icon"
+                     viewBox="0 0 20 20"
+                     className="mr-fill-current mr-w-4 mr-h-4 mr-mr-1"
+                   />
+                   <span className="mr-flex mr-items-baseline">
+                     <FormattedMessage {...messages.taskLockedLabel} />
+                   </span>
+                   <button
+                     onClick={() => this.props.stopReviewing(this.props.task, this.props.history)}
+                     className="mr-button mr-button--xsmall mr-ml-3"
+                   >
+                     <FormattedMessage {...messages.taskUnlockLabel} />
+                   </button>
+                 </div>
+              </div>
             }
             setCompletionResponse={this.setCompletionResponse}
             completionResponses={completionResponses}
@@ -148,8 +171,12 @@ ReviewTaskPane.propTypes = {
 export default
 WithChallengePreferences(
   WithWidgetWorkspaces(
-    WithTaskBundle(
-      ReviewTaskPane
+    WithChallenge(
+      WithTaskBundle(
+        WithTaskReview(
+          ReviewTaskPane
+        )
+      )
     ),
     WidgetDataTarget.task,
     WIDGET_WORKSPACE_NAME,

--- a/src/services/Task/TaskReview/TaskReview.js
+++ b/src/services/Task/TaskReview/TaskReview.js
@@ -5,6 +5,7 @@ import _set from 'lodash/set'
 import _isArray from 'lodash/isArray'
 import _cloneDeep from 'lodash/cloneDeep'
 import _snakeCase from 'lodash/snakeCase'
+import _isFinite from 'lodash/isFinite'
 import Endpoint from '../../Server/Endpoint'
 import { defaultRoutes as api, isSecurityError } from '../../Server/Server'
 import { RECEIVE_REVIEW_NEEDED_TASKS } from './TaskReviewNeeded'
@@ -154,7 +155,7 @@ const determineType = (reviewTasksType) => {
 /**
  * Retrieve the next task to review with the given sort and filter criteria
  */
-export const loadNextReviewTask = function(criteria={}) {
+export const loadNextReviewTask = function(criteria={}, lastTaskId) {
   const sortBy = _get(criteria, 'sortCriteria.sortBy')
   const order = (_get(criteria, 'sortCriteria.direction') || 'DESC').toUpperCase()
   const sort = sortBy ? `${_snakeCase(sortBy)}` : null
@@ -163,12 +164,17 @@ export const loadNextReviewTask = function(criteria={}) {
                                                        _get(criteria, 'savedChallengesOnly')                                                       )
 
   return function(dispatch) {
+    const params = {sort, order, ...searchParameters}
+    if (_isFinite(lastTaskId)) {
+      params.lastTaskId = lastTaskId
+    }
+
     return retrieveChallengeTask(dispatch, new Endpoint(
       api.tasks.reviewNext,
       {
         schema: taskSchema(),
         variables: {},
-        params: {sort, order, ...searchParameters},
+        params,
       }
     ))
   }


### PR DESCRIPTION
* Add new control in task review that allows the reviewer to skip review
of current task and move to the next one

* Replace "Cancel Review" control in task review with "Unlock Task"
control near top of page to be consistent with task completion

* Ensure parent challenge is loaded when reviewing tasks