### PR TITLE
Add checkbox to exclude tasks done by other reviewers

### DIFF
--- a/src/components/HOCs/WithReviewTasks/WithReviewTasks.js
+++ b/src/components/HOCs/WithReviewTasks/WithReviewTasks.js
@@ -55,6 +55,9 @@ export const WithReviewTasks = function(WrappedComponent, reviewStatus=0) {
       if (_isUndefined(criteria.savedChallengesOnly)) {
         criteria.savedChallengesOnly = _get(this.state.criteria[this.props.reviewTasksType], "savedChallengesOnly")
       }
+      if (_isUndefined(criteria.excludeOtherReviewers)) {
+        criteria.excludeOtherReviewers = _get(this.state.criteria[this.props.reviewTasksType], "excludeOtherReviewers")
+      }
 
       const typedCriteria = _cloneDeep(this.state.criteria)
       typedCriteria[props.reviewTasksType] = criteria

--- a/src/components/HOCs/WithTaskReview/WithTaskReview.js
+++ b/src/components/HOCs/WithTaskReview/WithTaskReview.js
@@ -68,6 +68,7 @@ export const parseSearchCriteria = url => {
   let filters = searchParams.filters || {}
   const boundingBox = searchParams.boundingBox
   const savedChallengesOnly = searchParams.savedChallengesOnly
+  const excludeOtherReviewers = searchParams.excludeOtherReviewers
 
   if (_isString(filters)) {
     filters = JSON.parse(searchParams.filters)
@@ -79,8 +80,10 @@ export const parseSearchCriteria = url => {
   }
 
   return {
-    searchCriteria: {sortCriteria: {sortBy, direction}, filters, boundingBox, savedChallengesOnly},
-    newState: {sortBy, direction, filters, boundingBox, savedChallengesOnly}
+    searchCriteria: {sortCriteria: {sortBy, direction}, filters, boundingBox,
+                                    savedChallengesOnly, excludeOtherReviewers},
+    newState: {sortBy, direction, filters, boundingBox, savedChallengesOnly,
+               excludeOtherReviewers}
   }
 }
 

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -920,6 +920,7 @@
   "Review.TaskAnalysisTable.refresh": "Refresh",
   "Review.TaskAnalysisTable.startReviewing": "Review these Tasks",
   "Review.TaskAnalysisTable.onlySavedChallenges": "Limit to favorite challenges",
+  "Review.TaskAnalysisTable.excludeOtherReviewers": "Exclude reviews assigned to others",
   "Review.TaskAnalysisTable.noTasksReviewedByMe": "You have not reviewed any tasks.",
   "Review.TaskAnalysisTable.noTasksReviewed": "None of your mapped tasks have been reviewed.",
   "Review.TaskAnalysisTable.tasksToBeReviewed": "Tasks to be Reviewed",

--- a/src/pages/Review/TasksReview/Messages.js
+++ b/src/pages/Review/TasksReview/Messages.js
@@ -24,6 +24,11 @@ export default defineMessages({
     defaultMessage: "Limit to favorite challenges",
   },
 
+  excludeOtherReviewers: {
+    id: "Review.TaskAnalysisTable.excludeOtherReviewers",
+    defaultMessage: "Exclude reviews assigned to others",
+  },
+
   tasksNoneReviewedByMe: {
     id: "Review.TaskAnalysisTable.noTasksReviewedByMe",
     defaultMessage: "You have not reviewed any tasks.",

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -70,6 +70,12 @@ export class TaskReviewTable extends Component {
     this.props.updateReviewTasks(reviewCriteria)
   }
 
+  toggleExcludeOthers(event) {
+    const reviewCriteria = _cloneDeep(this.props.reviewCriteria)
+    reviewCriteria.excludeOtherReviewers = !reviewCriteria.excludeOtherReviewers
+    this.props.updateReviewTasks(reviewCriteria)
+  }
+
   componentDidMount() {
     this.setupConfigurableColumns(this.props.reviewTasksType)
   }
@@ -200,11 +206,19 @@ export class TaskReviewTable extends Component {
                 {subheader}
               </h1>
               {this.props.reviewTasksType === ReviewTasksType.toBeReviewed &&
-                <div className="field favorites-only-switch mr-mt-2" onClick={() => this.toggleShowFavorites()}>
-                  <input type="checkbox" className="mr-mr-px"
-                         checked={!!this.props.reviewCriteria.savedChallengesOnly}
-                         onChange={() => null} />
-                  <label> {this.props.intl.formatMessage(messages.onlySavedChallenges)}</label>
+                <div className="mr-flex">
+                  <div className="field favorites-only-switch mr-mt-2 mr-mr-4" onClick={() => this.toggleShowFavorites()}>
+                    <input type="checkbox" className="mr-mr-px"
+                           checked={!!this.props.reviewCriteria.savedChallengesOnly}
+                           onChange={() => null} />
+                    <label> {this.props.intl.formatMessage(messages.onlySavedChallenges)}</label>
+                  </div>
+                  <div className="field favorites-only-switch mr-mt-2" onClick={() => this.toggleExcludeOthers()}>
+                    <input type="checkbox" className="mr-mr-px"
+                           checked={!!this.props.reviewCriteria.excludeOtherReviewers}
+                           onChange={() => null} />
+                    <label> {this.props.intl.formatMessage(messages.excludeOtherReviewers)}</label>
+                  </div>
                 </div>
               }
             </div>

--- a/src/services/Search/Search.js
+++ b/src/services/Search/Search.js
@@ -111,7 +111,7 @@ export const parseQueryString = function(rawQueryText) {
  * server accepts for various API endpoints
  */
 export const generateSearchParametersString = (filters, boundingBox, savedChallengesOnly,
-                                               queryString) => {
+                                               excludeOtherReviewers, queryString) => {
   const searchParameters = {}
   if (filters.reviewRequestedBy) {
     searchParameters.o = filters.reviewRequestedBy
@@ -190,6 +190,10 @@ export const generateSearchParametersString = (filters, boundingBox, savedChalle
 
   if (savedChallengesOnly) {
     searchParameters.onlySaved = savedChallengesOnly
+  }
+
+  if (excludeOtherReviewers) {
+    searchParameters.excludeOtherReviewers = excludeOtherReviewers
   }
 
   if (queryString || filters.keywords) {

--- a/src/services/SearchCriteria/SearchCriteria.js
+++ b/src/services/SearchCriteria/SearchCriteria.js
@@ -9,6 +9,7 @@ export function buildSearchCriteria(searchParams, defaultCriteria) {
     const page = _get(searchParams, 'page')
     const boundingBox = searchParams.boundingBox
     const savedChallengesOnly = searchParams.savedChallengesOnly
+    const excludeOtherReviewers = searchParams.excludeOtherReviewers
 
     if (_isString(filters)) {
       filters = JSON.parse(searchParams.filters)
@@ -19,7 +20,8 @@ export function buildSearchCriteria(searchParams, defaultCriteria) {
       direction = _get(searchParams, 'sortCriteria.direction')
     }
 
-    return {sortCriteria: {sortBy, direction}, filters, page, boundingBox, savedChallengesOnly}
+    return {sortCriteria: {sortBy, direction}, filters, page, boundingBox,
+            savedChallengesOnly, excludeOtherReviewers}
   }
   else return defaultCriteria
 }

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -70,7 +70,8 @@ export const fetchBoundedTasks = function(criteria, limit=50, skipDispatch=false
     const filters = _get(criteria, 'filters', {})
     const searchParameters = generateSearchParametersString(filters,
                                                             null,
-                                                            _get(criteria, 'savedChallengesOnly'))
+                                                            _get(criteria, 'savedChallengesOnly'),
+                                                            null)
 
     // If we don't have a challenge Id then we need to do some limiting.
     if (!filters.challengeId) {

--- a/src/services/Task/TaskClusters.js
+++ b/src/services/Task/TaskClusters.js
@@ -56,6 +56,7 @@ export const fetchTaskClusters = function(challengeId, criteria, points=25) {
     const searchParameters = generateSearchParametersString(filters,
                                                             criteria.boundingBox,
                                                             _get(criteria, 'savedChallengesOnly'),
+                                                            null,
                                                             criteria.searchQuery)
     searchParameters.cid = challengeId
 

--- a/src/services/Task/TaskReview/TaskReview.js
+++ b/src/services/Task/TaskReview/TaskReview.js
@@ -82,7 +82,8 @@ export const receiveReviewClusters = function(clusters, status=RequestStatus.suc
   const type = determineType(reviewTasksType)
   const searchParameters = generateSearchParametersString(_get(criteria, 'filters', {}),
                                                        criteria.boundingBox,
-                                                       _get(criteria, 'savedChallengesOnly'))
+                                                       _get(criteria, 'savedChallengesOnly'),
+                                                       _get(criteria, 'excludeOtherReviewers'))
 
   const mappers = (reviewTasksType === ReviewTasksType.myReviewedTasks) ? [userId] : []
   const reviewers = (reviewTasksType === ReviewTasksType.reviewedByMe) ? [userId] : []
@@ -112,7 +113,8 @@ export const receiveReviewClusters = function(clusters, status=RequestStatus.suc
 export const fetchClusteredReviewTasks = function(reviewTasksType, criteria={}) {
   const searchParameters = generateSearchParametersString(_get(criteria, 'filters', {}),
                                                           criteria.boundingBox,
-                                                          _get(criteria, 'savedChallengesOnly'))
+                                                          _get(criteria, 'savedChallengesOnly'),
+                                                          _get(criteria, 'excludeOtherReviewers'))
   return function(dispatch) {
     const type = determineType(reviewTasksType)
     const fetchId = uuidv1()
@@ -161,7 +163,8 @@ export const loadNextReviewTask = function(criteria={}, lastTaskId) {
   const sort = sortBy ? `${_snakeCase(sortBy)}` : null
   const searchParameters = generateSearchParametersString(_get(criteria, 'filters', {}),
                                                        criteria.boundingBox,
-                                                       _get(criteria, 'savedChallengesOnly')                                                       )
+                                                       _get(criteria, 'savedChallengesOnly'),
+                                                       _get(criteria, 'excludeOtherReviewers'))
 
   return function(dispatch) {
     const params = {sort, order, ...searchParameters}

--- a/src/services/Task/TaskReview/TaskReviewNeeded.js
+++ b/src/services/Task/TaskReview/TaskReviewNeeded.js
@@ -41,7 +41,8 @@ export const fetchReviewNeededTasks = function(criteria, limit=50) {
   const page = _get(criteria, 'page', 0)
   const searchParameters = generateSearchParametersString(_get(criteria, 'filters', {}),
                                                           criteria.boundingBox,
-                                                          _get(criteria, 'savedChallengesOnly'))
+                                                          _get(criteria, 'savedChallengesOnly'),
+                                                          _get(criteria, 'excludeOtherReviewers'))
 
   return function(dispatch) {
     return new Endpoint(


### PR DESCRIPTION
In review requested tasks table add checkbox to allow
exclusion of reviews already done by other reviewers
(in case of re-review needed)

Requires back-end MR2 maproulette2/#669