### PR TITLE
Fall back to default if current map layer fails

### DIFF
--- a/src/components/EnhancedMap/EnhancedMap.js
+++ b/src/components/EnhancedMap/EnhancedMap.js
@@ -208,9 +208,12 @@ export default class EnhancedMap extends Map {
   }
 
   componentWillUnmount() {
-    this.leafletElement.stop()
-    this.leafletElement.off('zoomend', this.onZoomOrMoveEnd)
-    this.leafletElement.off('moveend', this.onZoomOrMoveEnd)
+    try {
+      this.leafletElement.stop()
+      this.leafletElement.off('zoomend', this.onZoomOrMoveEnd)
+      this.leafletElement.off('moveend', this.onZoomOrMoveEnd)
+    }
+    catch(e) {} // Bad custom basemaps can cause problems when stopping Leaflet
 
     super.componentWillUnmount()
   }

--- a/src/components/EnhancedMap/MapPane/MapPane.js
+++ b/src/components/EnhancedMap/MapPane/MapPane.js
@@ -15,7 +15,7 @@ export class MapPane extends Component {
 
   componentDidCatch(error, info) {
     this.setState({hasError: true})
-    this.props.addError(AppErrors.map.renderFailure)
+    this.props.addErrorWithDetails(AppErrors.map.renderFailure, error.message)
   }
 
   render() {
@@ -23,7 +23,7 @@ export class MapPane extends Component {
       return (
         <div className="map-pane">
           <div className="notification">
-            <FormattedMessage {...AppErrors.map.renderFailure} />
+            <FormattedMessage {...AppErrors.map.renderFailure} values={{details: ''}} />
           </div>
         </div>
       )

--- a/src/components/EnhancedMap/SourcedTileLayer/SourcedTileLayer.js
+++ b/src/components/EnhancedMap/SourcedTileLayer/SourcedTileLayer.js
@@ -1,10 +1,12 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { injectIntl } from 'react-intl'
+import { injectIntl, FormattedMessage } from 'react-intl'
 import { TileLayer } from 'react-leaflet'
 import { BingLayer } from 'react-leaflet-bing'
 import _isEmpty from 'lodash/isEmpty'
-import { layerSourceShape, normalizeLayer }
+import WithErrors from '../../HOCs/WithErrors/WithErrors'
+import AppErrors from '../../../services/Error/AppErrors'
+import { layerSourceShape, normalizeLayer, defaultLayerSource }
        from '../../../services/VisibleLayer/LayerSources'
 
 /**
@@ -17,6 +19,8 @@ import { layerSourceShape, normalizeLayer }
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export class SourcedTileLayer extends Component {
+  state = {}
+
   attribution = layer => {
     if (this.props.skipAttribution || _isEmpty(layer.attribution)) {
       return null
@@ -27,7 +31,37 @@ export class SourcedTileLayer extends Component {
            layer.attribution.text
   }
 
+  componentDidCatch(error, info) {
+    // Errors here are almost always related to bad layer info, e.g. from a
+    // custom basemap. The most common problem is inclusion of an interpolation
+    // variable in the URL that doesn't get replaced, which will cause Leaflet
+    // to throw an exception
+    const details =
+      (this.props.source.name === "Custom" ? "custom basemap: " : "") + error.message
+    this.props.addErrorWithDetails(AppErrors.map.renderFailure, details)
+  }
+
+  static getDerivedStateFromError(error) {
+    return {layerRenderFailed: true}
+  }
+
   render() {
+    if (this.state.layerRenderFailed) {
+      // Try rendering the default layer as a fallback. If we *are* the
+      // fallback, just render an error message
+      if (this.props.fallbackLayer) {
+        return (
+          <FormattedMessage
+            {...AppErrors.map.renderFailure}
+            values={{details: 'fallback to default layer failed'}}
+          />
+        )
+      }
+      else {
+        return <SourcedTileLayer source={defaultLayerSource()} fallbackLayer={true} />
+      }
+    }
+
     const normalizedLayer = normalizeLayer(this.props.source)
     if (normalizedLayer.type === 'bing') {
       // Bing layers have to be specially rendered
@@ -64,4 +98,4 @@ SourcedTileLayer.defaultProps = {
   skipAttribution: false,
 }
 
-export default injectIntl(SourcedTileLayer)
+export default WithErrors(injectIntl(SourcedTileLayer))

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -1043,7 +1043,7 @@
   "Errors.project.searchFailure": "Unable to search projects.",
   "Errors.project.deleteFailure": "Unable to delete project.",
   "Errors.project.notManager": "You must be a manager of that project to proceed.",
-  "Errors.map.renderFailure": "Unable to render the map. This may be caused by a problematic custom basemap.",
+  "Errors.map.renderFailure": "Unable to render the map{details}. Attempting to fall back to default map layer.",
   "Errors.map.placeNotFound": "No results found by Nominatim.",
   "Errors.widgetWorkspace.renderFailure": "Unable to render workspace. Switching to a working layout.",
   "Errors.widgetWorkspace.importFailure": "Unable to import layout{details}",

--- a/src/services/Error/Messages.js
+++ b/src/services/Error/Messages.js
@@ -188,7 +188,7 @@ export default defineMessages({
 
   mapRenderFailure: {
     id: 'Errors.map.renderFailure',
-    defaultMessage: "Unable to render the map. This may be caused by a problematic custom basemap.",
+    defaultMessage: "Unable to render the map{details}. Attempting to fall back to default map layer.",
   },
 
   placeNotFound: {


### PR DESCRIPTION
* If rendering of current map layer results in an error (e.g. due to a
bad custom basemap), attempt to render the default map layer instead

* Attempt to determine if a custom basemap seems to be the actual cause
of failure, rather than always assuming it is, and communicate that to
user