### PR TITLE
Temporarily removed reviewer status metrics pending back-end fix

### DIFF
--- a/src/pages/Metrics/Metrics.js
+++ b/src/pages/Metrics/Metrics.js
@@ -140,7 +140,7 @@ class Metrics extends Component {
                 <TaskStats {...this.props} />
                 <LeaderboardStats {...this.props} />
               </div>
-              {this.props.reviewerMetrics &&
+              {this.props.reviewerMetrics && false &&
                 <div className="mr-mt-8">
                   <ReviewStats {...this.props}
                     reviewMetrics={this.props.reviewerMetrics}


### PR DESCRIPTION
Awaiting this fix "Fix current-month not correct for user metrics. #677"