### PR TITLE
Don't show 'view by priority' link on project detail page

### DIFF
--- a/src/components/ChallengeProgress/ChallengeProgress.js
+++ b/src/components/ChallengeProgress/ChallengeProgress.js
@@ -256,7 +256,7 @@ export class ChallengeProgress extends Component {
         {this.generateProgressBar(taskActions, completionData, statusColors, orderedKeys)}
         {this.generateProgressBarLabel(taskActions)}
 
-        {taskPriorityActions &&
+        {taskPriorityActions && this.props.setShowByPriority &&
           <div className="mr-text-green-light mr-cursor-pointer"
                onClick={(e) => this.props.setShowByPriority(!this.props.showByPriority)}>
             <span className="mr-align-top">


### PR DESCRIPTION
On project detail page hide challenge progress 'view by priority'