### PR TITLE
Turn challenge names into links on Find Challenges

### DIFF
--- a/src/components/CardChallenge/CardChallenge.js
+++ b/src/components/CardChallenge/CardChallenge.js
@@ -60,11 +60,19 @@ export class CardChallenge extends Component {
           {'is-active': this.props.isExpanded}
         )}
       >
-        <header className="mr-card-challenge__header" onClick={this.props.toggleExpanded}>
+        <header className="mr-card-challenge__header" onClick={this.props.cardClicked}>
           <div>
             <ChallengeTaxonomy {...this.props} />
             <h3 className="mr-card-challenge__title">
-              {this.props.challenge.name}
+              <Link
+                to={{
+                  pathname: `/browse/challenges/${this.props.challenge.id}`,
+                  state: { fromSearch: true },
+                }}
+                onClick={e => e.stopPropagation()}
+              >
+                {this.props.challenge.name}
+              </Link>
             </h3>
 
             {this.props.challenge.parent && // virtual challenges don't have projects
@@ -161,8 +169,8 @@ CardChallenge.propTypes = {
   startChallenge: PropTypes.func.isRequired,
   /** Set to true if card should be in expanded view */
   isExpanded: PropTypes.bool,
-  /** Invoked to toggle expansion of the card, if provided */
-  toggleExpanded: PropTypes.func,
+  /** Invoked when the card is clicked, if provided */
+  cardClicked: PropTypes.func,
   /** Set to true if this challenge has been saved by the user */
   isSaved: PropTypes.bool,
   /** Optional control to be used for saving the challenge */
@@ -181,7 +189,7 @@ CardChallenge.defaultProps = {
   isExpanded: true,
   isSaved: false,
   isLoading: false,
-  toggleExpanded: _noop,
+  cardClicked: _noop,
 }
 
 export default WithStartChallenge(CardChallenge)

--- a/src/components/ChallengeDetail/ChallengeDetail.js
+++ b/src/components/ChallengeDetail/ChallengeDetail.js
@@ -39,6 +39,10 @@ export class ChallengeDetail extends Component {
   state = {
   }
 
+  componentDidMount() {
+    window.scrollTo(0, 0)
+  }
+
   render() {
     const challenge = this.props.browsedChallenge
     if (!_isObject(challenge) || this.props.loadingBrowsedChallenge) {

--- a/src/components/ChallengePane/ChallengeResultItem/ChallengeResultItem.js
+++ b/src/components/ChallengePane/ChallengeResultItem/ChallengeResultItem.js
@@ -128,7 +128,7 @@ export class ChallengeResultItem extends Component {
    *
    * @private
    */
-  startBrowsing = () => {
+  viewChallengeDetails = () => {
     this.setState({isBrowsing: true})
     setTimeout(() => {
       this.props.startBrowsingChallenge(this.props.challenge)
@@ -145,15 +145,6 @@ export class ChallengeResultItem extends Component {
   stopBrowsing = () => {
     this.setState({isBrowsing: false})
     setTimeout(() => this.props.stopBrowsingChallenge(), 0)
-  }
-
-  /**
-   * Toggle whether this challeng is being actively browsed
-   *
-   * @private
-   */
-  toggleActive = () => {
-    this.state.isBrowsing ? this.stopBrowsing() : this.startBrowsing()
   }
 
   /**
@@ -234,8 +225,8 @@ export class ChallengeResultItem extends Component {
         <CardChallenge
           className="mr-mb-4"
           challenge={this.props.challenge}
-          isExpanded={this.state.isBrowsing}
-          toggleExpanded={this.toggleActive}
+          isExpanded={false}
+          cardClicked={this.viewChallengeDetails}
           isSaved={isSaved}
           isLoading={this.props.isStarting}
           saveControl={saveChallengeControl}

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -831,7 +831,7 @@
   "Admin.EditChallenge.overpass.errors.noTurboShortcuts": "Overpass Turbo shortcuts are not supported. If you wish to use them, please visit Overpass Turbo and test your query, then choose Export -> Query -> Standalone -> Copy and then paste that here.",
   "Dashboard.header": "Dashboard",
   "Home.FeaturedChallenges.improveOSM": "Start improving OpenStreetMap!",
-  "Home.FeaturedChallenges.start": "Start",
+  "Home.FeaturedChallenges.start": "Explore",
   "Inbox.header": "Notifications",
   "Inbox.controls.refreshNotifications.label": "Refresh",
   "Inbox.controls.manageSubscriptions.label": "Manage Subscriptions",

--- a/src/pages/Home/FeaturedChallenges.js
+++ b/src/pages/Home/FeaturedChallenges.js
@@ -20,9 +20,11 @@ export class FeaturedChallenges extends Component {
 
     return (
       <Link
-        to={{}}
+        to={{
+          pathname: `/browse/challenges/${challenge.id}`,
+          state: { fromSearch: true },
+        }}
         className="mr-button mr-button--small"
-        onClick={() => this.props.startChallenge(challenge)}
       >
         <FormattedMessage {...messages.startChallenge} />
       </Link>

--- a/src/pages/Home/Messages.js
+++ b/src/pages/Home/Messages.js
@@ -11,6 +11,6 @@ export default defineMessages({
 
   startChallenge: {
     id: "Home.FeaturedChallenges.start",
-    defaultMessage: "Start",
+    defaultMessage: "Explore",
   },
 })


### PR DESCRIPTION
* Turn challenge names on Find Challenges page into links so that users
have the ability to open them in a new tab, if desired

* Change FeaturedChallenges on home page to take user to challenge
details page using "Explore" button instead of starting the challenge

* Make ChallengeDetail scroll window back to top when mounted

* Closes #997