### PR TITLE
Fix admin table not updating on initial filter change

### DIFF
--- a/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
+++ b/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
@@ -185,9 +185,7 @@ export const WithFilterCriteria = function(WrappedComponent) {
        }
 
        if (!_isEqual(prevState.criteria, this.state.criteria) && !this.props.skipRefreshTasks) {
-         if (this.state.criteria.boundingBox) {
-           this.refreshTasks(typedCriteria)
-         }
+         this.refreshTasks(typedCriteria)
        }
        else if (_get(prevProps, 'challenge.id') !== _get(this.props, 'challenge.id') ||
                 this.props.challengeId !== prevProps.challengeId) {


### PR DESCRIPTION
When changing the filters on the admin challenge tasks table,
if the map had not been moved then the table would not update
correctly.