### PR TITLE
Support additional filters on admin tasks table

### DIFF
--- a/src/components/AdminPane/HOCs/WithChallengeReviewMetrics/WithChallengeReviewMetrics.js
+++ b/src/components/AdminPane/HOCs/WithChallengeReviewMetrics/WithChallengeReviewMetrics.js
@@ -4,6 +4,7 @@ import _omit from 'lodash/omit'
 import _get from 'lodash/get'
 import _keys from 'lodash/keys'
 import _pickBy from 'lodash/pickBy'
+import _merge from 'lodash/merge'
 import { fetchReviewMetrics, ReviewTasksType }
        from '../../../../services/Task/TaskReview/TaskReview'
 import WithCurrentUser from '../../../HOCs/WithCurrentUser/WithCurrentUser'
@@ -22,7 +23,11 @@ export const WithChallengeReviewMetrics = function(WrappedComponent) {
     updateMetrics(props) {
       this.setState({loading: true})
 
-      const criteria = {filters:{challengeId: _get(props.challenge, 'id')}}
+      const filters = {challengeId: _get(props.challenge, 'id')}
+       _merge(filters, _get(props.searchFilters, 'filters'))
+
+      const criteria = {filters}
+
       if (props.includeTaskStatuses) {
         criteria.filters.status = _keys(_pickBy(props.includeTaskStatuses)).join(',')
       }
@@ -57,6 +62,10 @@ export const WithChallengeReviewMetrics = function(WrappedComponent) {
       }
 
       if (this.props.includeTaskPriorities !== prevProps.includeTaskPriorities) {
+        this.updateMetrics(this.props)
+      }
+
+      if (_get(this.props.searchFilters, 'filters') !== _get(prevProps.searchFilters, 'filters')) {
         this.updateMetrics(this.props)
       }
     }

--- a/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
+++ b/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
@@ -29,7 +29,12 @@ export const WithFilterCriteria = function(WrappedComponent) {
        const criteria = _cloneDeep(this.state.criteria)
        criteria.sortCriteria = newCriteria.sortCriteria
        criteria.page = newCriteria.page
+       criteria.filters = newCriteria.filters
+
        this.setState({criteria})
+       if (this.props.setSearchFilters) {
+         this.props.setSearchFilters(criteria)
+       }
      }
 
      updateTaskFilterBounds = (bounds, zoom) => {

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -294,6 +294,7 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
       }
     },
     exportable: t => t.id,
+    filterable: true,
     maxWidth: 120,
   }
 
@@ -349,6 +350,7 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
     Header: props.intl.formatMessage(messages.reviewRequestedByLabel),
     accessor: 'reviewRequestedBy',
     sortable: true,
+    filterable: true,
     exportable: t => _get(t.reviewRequestedBy, 'username') || t.reviewRequestedBy,
     maxWidth: 180,
     Cell: ({row}) =>
@@ -403,6 +405,7 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
     id: 'reviewedBy',
     Header: props.intl.formatMessage(messages.reviewedByLabel),
     accessor: 'reviewedBy',
+    filterable: true,
     sortable: true,
     exportable: t => _get(t.reviewedBy, 'username') || t.reviewedBy,
     maxWidth: 180,

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -288,6 +288,7 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
   columns.id = {
     id: 'id',
     Header: props.intl.formatMessage(messages.idLabel),
+    filterable: true,
     accessor: t => {
       if (!t.isBundlePrimary) {
         return <span>{t.id}</span>

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -33,7 +33,8 @@ import { RECEIVE_CHALLENGES, REMOVE_CHALLENGE }
        from './ChallengeActions'
 import { ChallengeStatus } from './ChallengeStatus/ChallengeStatus'
 import { zeroTaskActions } from '../Task/TaskAction/TaskAction'
-import { parseQueryString, RESULTS_PER_PAGE, SortOptions }
+import { parseQueryString, RESULTS_PER_PAGE, SortOptions,
+         generateSearchParametersString }
        from '../Search/Search'
 import startOfDay from 'date-fns/start_of_day'
 
@@ -319,17 +320,10 @@ export const extendedFind = function(criteria, limit=RESULTS_PER_PAGE) {
  */
 export const fetchChallengeActions = function(challengeId = null, suppressReceive = false,
                                               criteria) {
-  const searchParameters = {}
+  let searchParameters = {}
   if (criteria) {
-    if (criteria.status) {
-      searchParameters.tStatus = criteria.status
-    }
-    if (criteria.reviewStatus) {
-      searchParameters.trStatus = criteria.reviewStatus
-    }
-    if (criteria.priorities) {
-      searchParameters.priority = criteria.priorities
-    }
+    searchParameters = generateSearchParametersString(_get(criteria, 'filters', {}),
+                                                      criteria.boundingBox)
   }
 
   return function(dispatch) {

--- a/src/services/Search/Search.js
+++ b/src/services/Search/Search.js
@@ -162,6 +162,10 @@ export const generateSearchParametersString = (filters, boundingBox, savedChalle
     }
   }
 
+  if (filters.id) {
+    searchParameters.tid = filters.id
+  }
+
   if (_isFinite(filters.difficulty)) {
     searchParameters.cd = filters.difficulty
   }


### PR DESCRIPTION
* On admin tasks table add ability to filter by task id, reviewer and mapper

* On review tables add ability to filter by task id

* Changed metrics widgets to honor reviewer and mapper and task id filters

Relies on back-end pr maproulette/maproulette2#684