### PR TITLE
Replace markdown br tags with new paragraphs

### DIFF
--- a/src/components/MarkdownContent/MarkdownContent.js
+++ b/src/components/MarkdownContent/MarkdownContent.js
@@ -18,8 +18,12 @@ export default class MarkdownContent extends Component {
       return null
     }
 
-    // Replace any occurrences of \r\n with newlines.
-    const normalizedMarkdown = this.props.markdown.replace(/\r\n/mg, "\n\n")
+    // Replace any occurrences of \r\n with newlines, and since we don't
+    // support <br> tags replace `  \n` with `\n\n` to generate a new paragraph
+    // instead
+    const normalizedMarkdown =
+      this.props.markdown.replace(/\r\n/mg, "\n\n").replace(/\s{2}\n/mg, "\n\n")
+
     let parsedMarkdown =
       remark().use(externalLinks, {target: '_blank', rel: ['nofollow']})
               .use(reactRenderer).processSync(normalizedMarkdown).contents


### PR DESCRIPTION
* Replace occurrences of two spaces before a newline (which generates a
br tag in markdown) with two lines instead, which will generate a new
paragraph

* This avoids potential problems with very strict rules about br tags in
React which can easily lead to invariant violation errors