### PR TITLE
Fix TaskBuildProgress refresh call

### DIFF
--- a/src/components/AdminPane/Manage/ViewChallengeTasks/TaskBuildProgress.js
+++ b/src/components/AdminPane/Manage/ViewChallengeTasks/TaskBuildProgress.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 import FormattedDuration, { TIMER_FORMAT } from 'react-intl-formatted-duration'
 import parse from 'date-fns/parse'
@@ -21,6 +22,7 @@ export default class TaskBuildProgress extends Component {
 
   state = {
     startTime: new Date(),
+    lastTimerRun: Date.now(),
   }
 
   clearTimer = () => {
@@ -31,8 +33,8 @@ export default class TaskBuildProgress extends Component {
   }
 
   /**
-   * Returns the total elapsed seconds since the start time (usually the challenge
-   * modification date)
+   * Returns the total elapsed seconds since the initial start time (usually
+   * the challenge modification date)
    */
   totalElapsedSeconds = () => {
     return (Date.now() - this.state.startTime) / 1000
@@ -42,20 +44,22 @@ export default class TaskBuildProgress extends Component {
    * Returns the number of seconds until the next status update
    */
   nextUpdateSeconds = () => {
-    return (
-      new Date(this.props.challenge._meta.fetchedAt + TIMER_INTERVAL).getTime() - Date.now()
+    const secondsRemaining =  (
+      new Date(this.state.lastTimerRun + TIMER_INTERVAL).getTime() - Date.now()
     ) / 1000
+
+    return secondsRemaining
   }
 
   refresh = () => {
     this.props.refreshChallenge()
     this.props.refreshTasks()
+    this.setState({lastTimerRun: Date.now()})
   }
 
   componentDidMount() {
     this.clearTimer()
-    this.timerHandle =
-      setInterval(this.props.refresh, TIMER_INTERVAL)
+    this.timerHandle = setInterval(this.refresh, TIMER_INTERVAL)
 
     if (this.props.challenge.modified) {
       this.setState({startTime: parse(this.props.challenge.modified)})
@@ -109,4 +113,10 @@ export default class TaskBuildProgress extends Component {
       </div>
     )
   }
+}
+
+TaskBuildProgress.propTypes = {
+  challenge: PropTypes.object.isRequired,
+  refreshChallenge: PropTypes.func.isRequired,
+  refreshTasks: PropTypes.func.isRequired,
 }


### PR DESCRIPTION
* Fix erroneous call to props.refresh instead of own refresh method

* Base the next-refresh timer off the last refresh time instead of the
challenge modification date for better accuracy and to avoid occasional
negative timers

* Add PropTypes listing required props