### PR TITLE
Disallow sorting tasks by feature property columns

### DIFF
--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -114,7 +114,8 @@ export class TaskAnalysisTable extends Component {
               return (
                 !row._original ? null : <div className="">{valueToDisplay}</div>
               )
-            }
+            },
+            sortable: false,
           }
         }
         else {


### PR DESCRIPTION
* Do not allow tasks tables to be sorted by a feature property column as
there is no support for this on the server and will result in an error