### PR TITLE
Add 'view by priority' toggle to review status metrics

### DIFF
--- a/src/components/AdminPane/HOCs/WithChallengeReviewMetrics/WithChallengeReviewMetrics.js
+++ b/src/components/AdminPane/HOCs/WithChallengeReviewMetrics/WithChallengeReviewMetrics.js
@@ -80,7 +80,10 @@ export const WithChallengeReviewMetrics = function(WrappedComponent) {
   }
 }
 
-const mapStateToProps = state => ({allReviewMetrics: _get(state, 'currentReviewTasks.metrics')})
+const mapStateToProps = state => (
+  {reviewMetrics: _get(state, 'currentReviewTasks.metrics.reviewActions'),
+   reviewMetricsByPriority: _get(state, 'currentReviewTasks.metrics.priorityReviewActions')}
+)
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   updateReviewMetrics: (userId, criteria) => {

--- a/src/components/AdminPane/HOCs/WithProjectReviewMetrics/WithProjectReviewMetrics.js
+++ b/src/components/AdminPane/HOCs/WithProjectReviewMetrics/WithProjectReviewMetrics.js
@@ -60,7 +60,10 @@ export const WithProjectReviewMetrics = function(WrappedComponent) {
   }
 }
 
-const mapStateToProps = state => ({ reviewMetrics: _get(state, 'currentReviewTasks.metrics') })
+const mapStateToProps = state => (
+  {reviewMetrics: _get(state, 'currentReviewTasks.metrics.reviewActions'),
+   reviewMetricsByPriority: _get(state, 'currentReviewTasks.metrics.priorityReviewActions')}
+)
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   refreshReviewMetrics: (userId, challengeIds) => {

--- a/src/components/HOCs/WithReviewMetrics/WithReviewMetrics.js
+++ b/src/components/HOCs/WithReviewMetrics/WithReviewMetrics.js
@@ -44,13 +44,17 @@ export const WithReviewMetrics = function(WrappedComponent) {
     render() {
       return (
         <WrappedComponent reviewMetrics = {this.props.reviewMetrics}
+                          reviewMetricsByPriority = {this.props.reviewMetricsByPriority}
                           loading={this.state.loading}
                           {..._omit(this.props, ['updateReviewMetrics'])} />)
     }
   }
 }
 
-const mapStateToProps = state => ({ reviewMetrics: _get(state, 'currentReviewTasks.metrics') })
+const mapStateToProps = state => {
+  return ({ reviewMetrics: _get(state, 'currentReviewTasks.metrics.reviewActions'),
+            reviewMetricsByPriority: _get(state, 'currentReviewTasks.metrics.priorityReviewActions') })
+}
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   updateReviewMetrics: (userId, reviewTasksType, searchCriteria={}) => {

--- a/src/components/Widgets/ReviewStatusMetricsWidget/ReviewStatusMetricsWidget.js
+++ b/src/components/Widgets/ReviewStatusMetricsWidget/ReviewStatusMetricsWidget.js
@@ -9,15 +9,22 @@ import messages from './Messages'
 const descriptor = {
   widgetKey: 'ReviewStatusMetricsWidget',
   label: messages.label,
-  targets: [WidgetDataTarget.review, WidgetDataTarget.challenge, 
+  targets: [WidgetDataTarget.review, WidgetDataTarget.challenge,
             WidgetDataTarget.challenges],
   minWidth: 2,
   defaultWidth: 4,
   minHeight: 4,
   defaultHeight: 6,
+  defaultConfiguration: {
+    showByPriority: false,
+  },
 }
 
 export default class ReviewStatusMetricsWidget extends Component {
+  setShowByPriority = showByPriority => {
+    this.props.updateWidgetConfiguration({showByPriority: !!showByPriority})
+  }
+
   render() {
     return (
       <QuickWidget
@@ -28,7 +35,11 @@ export default class ReviewStatusMetricsWidget extends Component {
         }
         noMain
       >
-        <ReviewStatusMetrics {...this.props} />
+        <ReviewStatusMetrics
+          {...this.props}
+          showByPriority={this.props.widgetConfiguration.showByPriority}
+          setShowByPriority={this.setShowByPriority}
+        />
       </QuickWidget>
     )
   }

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -950,6 +950,8 @@
   "ReviewStatus.metrics.falsePositive": "NOT AN ISSUE",
   "ReviewStatus.metrics.alreadyFixed": "ALREADY FIXED",
   "ReviewStatus.metrics.tooHard": "TOO HARD",
+  "ReviewStatus.metrics.priority.toggle": "View by Task Priority",
+  "ReviewStatus.metrics.priority.label": "{priority} Priority Tasks",
   "Review.TaskAnalysisTable.noTasks": "No tasks found",
   "Review.TaskAnalysisTable.refresh": "Refresh",
   "Review.TaskAnalysisTable.startReviewing": "Review these Tasks",

--- a/src/pages/Review/Metrics/Messages.js
+++ b/src/pages/Review/Metrics/Messages.js
@@ -53,4 +53,15 @@ export default defineMessages({
     id: "ReviewStatus.metrics.tooHard",
     defaultMessage: "TOO HARD",
   },
+
+  byPriorityToggle: {
+    id: "ReviewStatus.metrics.priority.toggle",
+    defaultMessage: "View by Task Priority"
+  },
+
+  priorityLabel: {
+    id: "ReviewStatus.metrics.priority.label",
+    defaultMessage: "{priority} Priority Tasks"
+  },
+
 })

--- a/src/pages/Review/Metrics/ReviewStatusMetrics.js
+++ b/src/pages/Review/Metrics/ReviewStatusMetrics.js
@@ -1,8 +1,13 @@
 import React, { Component } from 'react'
 import classNames from 'classnames'
 import { FormattedMessage } from 'react-intl'
+import _map from 'lodash/map'
 import messages from './Messages'
 import { ReviewTasksType } from '../../../services/Task/TaskReview/TaskReview'
+import { TaskPriority, keysByPriority, taskPriorityLabels }
+       from '../../../services/Task/TaskPriority/TaskPriority'
+import SvgSymbol from '../../../components/SvgSymbol/SvgSymbol'
+
 
 /**
  * ReviewStatusMetrics displays metrics by Review Status
@@ -10,83 +15,134 @@ import { ReviewTasksType } from '../../../services/Task/TaskReview/TaskReview'
  * @author [Kelli Rotstan](https://github.com/krotstan)
  */
 export default class ReviewStatusMetrics extends Component {
+  buildReviewStats = (type, metrics) => {
+    return (
+      <div className="mr-grid mr-grid-columns-1 mr-grid-gap-4">
+        {type === ReviewTasksType.toBeReviewed &&
+          buildMetric(metrics.reviewRequested, metrics.total,
+            <FormattedMessage {...messages.awaitingReview} />,
+            this.props.lightMode)}
+        {type === ReviewTasksType.toBeReviewed &&
+          buildMetric(metrics.reviewDisputed, metrics.total,
+            <FormattedMessage {...messages.disputedReview} />,
+            this.props.lightMode)}
+
+        {type === ReviewTasksType.reviewedByMe &&
+          buildMetric(metrics.reviewApproved, metrics.total,
+            <FormattedMessage {...messages.approvedReview} />,
+            this.props.lightMode)}
+        {type === ReviewTasksType.reviewedByMe &&
+          buildMetric(metrics.reviewRejected, metrics.total,
+            <FormattedMessage {...messages.rejectedReview} />,
+            this.props.lightMode)}
+        {type === ReviewTasksType.reviewedByMe &&
+          buildMetric(metrics.reviewAssisted, metrics.total,
+            <FormattedMessage {...messages.assistedReview} />,
+            this.props.lightMode)}
+        {type === ReviewTasksType.reviewedByMe &&
+          buildMetric(metrics.reviewDisputed, metrics.total,
+            <FormattedMessage {...messages.disputedReview} />,
+            this.props.lightMode)}
+
+        {type === ReviewTasksType.myReviewedTasks &&
+          buildMetric(metrics.reviewRequested, metrics.total,
+            <FormattedMessage {...messages.awaitingReview} />,
+            this.props.lightMode)}
+        {type === ReviewTasksType.myReviewedTasks &&
+          buildMetric(metrics.reviewApproved, metrics.total,
+            <FormattedMessage {...messages.approvedReview} />,
+            this.props.lightMode)}
+        {type === ReviewTasksType.myReviewedTasks &&
+          buildMetric(metrics.reviewRejected, metrics.total,
+            <FormattedMessage {...messages.rejectedReview} />,
+            this.props.lightMode)}
+        {type === ReviewTasksType.myReviewedTasks &&
+          buildMetric(metrics.reviewAssisted, metrics.total,
+            <FormattedMessage {...messages.assistedReview} />,
+            this.props.lightMode)}
+        {type === ReviewTasksType.myReviewedTasks &&
+          buildMetric(metrics.reviewDisputed, metrics.total,
+            <FormattedMessage {...messages.disputedReview} />,
+            this.props.lightMode)}
+
+        {type === ReviewTasksType.allReviewedTasks &&
+          buildMetric(metrics.reviewRequested, metrics.total,
+            <FormattedMessage {...messages.awaitingReview} />,
+            this.props.lightMode)}
+        {type === ReviewTasksType.allReviewedTasks &&
+          buildMetric(metrics.reviewApproved, metrics.total,
+            <FormattedMessage {...messages.approvedReview} />,
+            this.props.lightMode)}
+        {type === ReviewTasksType.allReviewedTasks &&
+          buildMetric(metrics.reviewRejected, metrics.total,
+            <FormattedMessage {...messages.rejectedReview} />,
+            this.props.lightMode)}
+        {type === ReviewTasksType.allReviewedTasks &&
+          buildMetric(metrics.reviewAssisted, metrics.total,
+            <FormattedMessage {...messages.assistedReview} />,
+            this.props.lightMode)}
+        {type === ReviewTasksType.allReviewedTasks &&
+          buildMetric(metrics.reviewDisputed, metrics.total,
+            <FormattedMessage {...messages.disputedReview} />,
+            this.props.lightMode)}
+      </div>
+    )
+  }
   render() {
     const metrics = this.props.reviewMetrics
+    const reviewMetricsByPriority = this.props.reviewMetricsByPriority
+
     const type = this.props.reviewTasksType || ReviewTasksType.allReviewedTasks
+
+    const prioritizedReviewStats = _map(TaskPriority, (priority, key) => {
+      if (reviewMetricsByPriority && reviewMetricsByPriority[priority]) {
+        const localizedPriorityLabels = taskPriorityLabels(this.props.intl)
+
+        return (
+          <div className="mr-mt-6" key={priority}>
+            <div
+              className={classNames(
+                "mr-text-md mr-mb-4",
+                this.props.lightMode ? "mr-text-matisse-blue mr-font-medium" :
+                                       "mr-text-yellow mr-font-normal"
+              )}
+            >
+              <FormattedMessage
+                {...messages.priorityLabel}
+                values={{priority: localizedPriorityLabels[keysByPriority[priority]]}}
+              />
+            </div>
+            {this.buildReviewStats(type, reviewMetricsByPriority[priority])}
+          </div>
+        )
+      }
+    })
 
     return (
       <div className={classNames("review-status-metrics")}>
-        {metrics &&
-          <div className="mr-grid mr-grid-columns-1 mr-grid-gap-4">
-            {type === ReviewTasksType.toBeReviewed &&
-              buildMetric(metrics.reviewRequested, metrics.total,
-                <FormattedMessage {...messages.awaitingReview} />,
-                this.props.lightMode)}
-            {type === ReviewTasksType.toBeReviewed &&
-              buildMetric(metrics.reviewDisputed, metrics.total,
-                <FormattedMessage {...messages.disputedReview} />,
-                this.props.lightMode)}
-
-            {type === ReviewTasksType.reviewedByMe &&
-              buildMetric(metrics.reviewApproved, metrics.total,
-                <FormattedMessage {...messages.approvedReview} />,
-                this.props.lightMode)}
-            {type === ReviewTasksType.reviewedByMe &&
-              buildMetric(metrics.reviewRejected, metrics.total,
-                <FormattedMessage {...messages.rejectedReview} />,
-                this.props.lightMode)}
-            {type === ReviewTasksType.reviewedByMe &&
-              buildMetric(metrics.reviewAssisted, metrics.total,
-                <FormattedMessage {...messages.assistedReview} />,
-                this.props.lightMode)}
-            {type === ReviewTasksType.reviewedByMe &&
-              buildMetric(metrics.reviewDisputed, metrics.total,
-                <FormattedMessage {...messages.disputedReview} />,
-                this.props.lightMode)}
-
-            {type === ReviewTasksType.myReviewedTasks &&
-              buildMetric(metrics.reviewRequested, metrics.total,
-                <FormattedMessage {...messages.awaitingReview} />,
-                this.props.lightMode)}
-            {type === ReviewTasksType.myReviewedTasks &&
-              buildMetric(metrics.reviewApproved, metrics.total,
-                <FormattedMessage {...messages.approvedReview} />,
-                this.props.lightMode)}
-            {type === ReviewTasksType.myReviewedTasks &&
-              buildMetric(metrics.reviewRejected, metrics.total,
-                <FormattedMessage {...messages.rejectedReview} />,
-                this.props.lightMode)}
-            {type === ReviewTasksType.myReviewedTasks &&
-              buildMetric(metrics.reviewAssisted, metrics.total,
-                <FormattedMessage {...messages.assistedReview} />,
-                this.props.lightMode)}
-            {type === ReviewTasksType.myReviewedTasks &&
-              buildMetric(metrics.reviewDisputed, metrics.total,
-                <FormattedMessage {...messages.disputedReview} />,
-                this.props.lightMode)}
-
-            {type === ReviewTasksType.allReviewedTasks &&
-              buildMetric(metrics.reviewRequested, metrics.total,
-                <FormattedMessage {...messages.awaitingReview} />,
-                this.props.lightMode)}
-            {type === ReviewTasksType.allReviewedTasks &&
-              buildMetric(metrics.reviewApproved, metrics.total,
-                <FormattedMessage {...messages.approvedReview} />,
-                this.props.lightMode)}
-            {type === ReviewTasksType.allReviewedTasks &&
-              buildMetric(metrics.reviewRejected, metrics.total,
-                <FormattedMessage {...messages.rejectedReview} />,
-                this.props.lightMode)}
-            {type === ReviewTasksType.allReviewedTasks &&
-              buildMetric(metrics.reviewAssisted, metrics.total,
-                <FormattedMessage {...messages.assistedReview} />,
-                this.props.lightMode)}
-            {type === ReviewTasksType.allReviewedTasks &&
-              buildMetric(metrics.reviewDisputed, metrics.total,
-                <FormattedMessage {...messages.disputedReview} />,
-                this.props.lightMode)}
+        {metrics && this.buildReviewStats(type, metrics)}
+        {reviewMetricsByPriority && this.props.setShowByPriority &&
+          <div
+            className={classNames(
+              "mr-cursor-pointer mr-flex mr-items-center mr-mt-6",
+              this.props.lightMode ? "mr-text-green-light" : "mr-text-green-lighter"
+            )}
+            onClick={(e) => this.props.setShowByPriority(!this.props.showByPriority)}
+          >
+            <span className="mr-align-top">
+              <FormattedMessage {...messages.byPriorityToggle} />
+            </span>
+            <span>
+              <SvgSymbol
+                sym="icon-cheveron-down"
+                viewBox="0 0 20 20"
+                className={classNames("mr-fill-current mr-w-5 mr-h-5 mr-transition",
+                                      {"mr-expand-available": !this.props.showByPriority})}
+              />
+            </span>
           </div>
         }
+        {this.props.showByPriority && prioritizedReviewStats}
       </div>
     )
   }

--- a/src/services/Task/TaskReview/TaskReview.js
+++ b/src/services/Task/TaskReview/TaskReview.js
@@ -93,14 +93,12 @@ export const receiveReviewClusters = function(clusters, status=RequestStatus.suc
       api.tasks.reviewMetrics,
       {
         schema: null,
-        params: {reviewTasksType: type, ...searchParameters, mappers, reviewers},
+        params: {reviewTasksType: type, ...searchParameters, mappers, reviewers,
+                 includeByPriority: true},
       }
     ).execute().then(normalizedResults => {
-      if (normalizedResults.length > 0) {
-        dispatch(receiveReviewMetrics(normalizedResults[0], RequestStatus.success))
-      }
-
-      return normalizedResults[0]
+      dispatch(receiveReviewMetrics(normalizedResults, RequestStatus.success))
+      return normalizedResults
     }).catch((error) => {
       console.log(error.response || error)
     })


### PR DESCRIPTION
When showing review status metrics widget show a 'view by priority' toggle that shows a break down
of metrics by priority (same as challenge progress).

Relies on backend PR: maproulette/maproulette2#692