### PR TITLE
TaskAnalysisTable status-change visual fixes

### DIFF
--- a/src/components/TagDiffVisualization/TagDiffVisualization.js
+++ b/src/components/TagDiffVisualization/TagDiffVisualization.js
@@ -97,6 +97,7 @@ export class TagDiffVisualization extends Component {
     }
     else {
       tagEdits[tagName].status = 'removed'
+      tagEdits[tagName].newValue = null
     }
 
     this.setState({tagEdits})
@@ -269,7 +270,7 @@ export class TagDiffVisualization extends Component {
         </div>
       )
     }
-        
+
     const tagNames = tagChanges.map(change => (
       <li
         className='mr-border-2 mr-border-transparent mr-my-2 mr-py-3 mr-flex mr-h-6 mr-items-center'
@@ -334,6 +335,7 @@ export class TagDiffVisualization extends Component {
             <React.Fragment>
               <input
                 type="text"
+                className="mr-text-black mr-px-2"
                 value={change.newValue}
                 onChange={e => this.updateTagValue(change.name, e.target.value)}
               />
@@ -455,7 +457,7 @@ export const AddTagControl = props => {
     <div className="mr-flex">
       <input
         type="text"
-        className="mr-mr-2"
+        className="mr-mr-2 mr-text-black mr-px-2"
         value={props.newTagName}
         onChange={e => props.setNewTagName(e.target.value)}
         placeholder={props.intl.formatMessage(messages.tagNamePlaceholder)}

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -174,7 +174,7 @@ export class TaskAnalysisTable extends Component {
 
     return (
       <React.Fragment>
-        <section className="mr-my-4 mr-fixed-containing-block">
+        <section className="mr-my-4">
           {!this.props.suppressHeader &&
            <header className="mr-mb-4">
              <TaskAnalysisTableHeader

--- a/src/components/TaskAnalysisTable/TaskAnalysisTableHeader.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTableHeader.js
@@ -166,7 +166,7 @@ export class TaskAnalysisTableHeader extends Component {
                                               <select
                                                 onChange={e => { if (e.target.value !== "") this.props.changeStatus(e.target.value) }}
                                                 defaultValue={this.state.statusChange}
-                                                className="select mr-min-w-20 mr-bg-grey-lighter mr-rounded mr-px-1 mr-text-xs mr-pl-2"
+                                                className="select mr-min-w-20 mr-bg-black-15 mr-w-full mr-rounded mr-px-1 mr-text-xs mr-pl-2"
                                               >
                                                 <option key="choose" value="">
                                                   {this.props.intl.formatMessage(messages.chooseStatusLabel)}


### PR DESCRIPTION
* Fix background of status-change select box in TaskAnalysisTable

* Fix potential truncated display of status-change confirmation dialog
in TaskAnalysisTable when a very small number of results were being
displayed in the table

* Fix display of input boxes on TagDiffVisualization