### PR TITLE
Constrain task table status change confirmation

### DIFF
--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -174,7 +174,7 @@ export class TaskAnalysisTable extends Component {
 
     return (
       <React.Fragment>
-        <section className="mr-my-4">
+        <section className="mr-my-4 mr-min-h-100 mr-fixed-containing-block">
           {!this.props.suppressHeader &&
            <header className="mr-mb-4">
              <TaskAnalysisTableHeader

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -293,6 +293,7 @@ module.exports = {
       full: '100%',
       screen: '100vh',
       '48': '12rem',
+      '100': '25rem',
       '120': '30rem',
       'screen-50': '50vh',
       'content-no-filters': 'calc(100vh - 103px)',


### PR DESCRIPTION
* Restore the status-change confirmation dialog to being constrained by
the TaskAnalysisTable, but ensure the minimum table height is tall
enough for the dialog when only a small number of results are shown