### PR TITLE
Change custom date picker to not switch back to default dates

### DIFF
--- a/src/components/PastDurationSelector/PastDurationSelector.js
+++ b/src/components/PastDurationSelector/PastDurationSelector.js
@@ -85,8 +85,7 @@ export class PastDurationSelector extends Component {
                           onClick={() => {
                             this.props.selectCustomRange(
                               this.state.customStartDate,
-                              this.state.customEndDate)
-                            this.setState({showChooseCustomDates: false})
+                              this.state.customEndDate)                            
                             dropdown.closeDropdown()
                           }}>
                     <FormattedMessage {...messages.searchLabel} />


### PR DESCRIPTION
After selecting custom dates in date picker, when reselected show
custom date selector again instead of default dates.