### PR TITLE
Add support of apply status change to all selected tasks

### DIFF
--- a/src/components/AdminPane/HOCs/WithChallengeManagement/WithChallengeManagement.js
+++ b/src/components/AdminPane/HOCs/WithChallengeManagement/WithChallengeManagement.js
@@ -14,7 +14,7 @@ import { saveChallenge,
          deleteChallenge } from '../../../../services/Challenge/Challenge'
 import { recordChallengeSnapshot }
           from '../../../../services/Challenge/ChallengeSnapshot'
-import { bulkUpdateTasks, deleteChallengeTasks }
+import { bulkUpdateTasks, deleteChallengeTasks, bulkTaskStatusChange }
        from '../../../../services/Task/Task'
 import { TaskStatus } from '../../../../services/Task/TaskStatus/TaskStatus'
 import { addError } from '../../../../services/Error/Error'
@@ -209,6 +209,10 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
 
     return dispatch(bulkUpdateTasks(alteredTasks, true))
   },
+
+  applyBulkTaskStatusChange: (newStatus, challengeId, searchCriteria) => {
+    return dispatch(bulkTaskStatusChange(newStatus, challengeId, searchCriteria))
+  }
 })
 
 export default WithChallengeManagement

--- a/src/components/TaskAnalysisTable/TaskAnalysisTableHeader.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTableHeader.js
@@ -44,7 +44,8 @@ export class TaskAnalysisTableHeader extends Component {
 
     render() {
         const {countShown, configureColumns} = this.props
-        const selectedCount = this.props.selectedTasks.size
+
+        const selectedCount = this.props.selectedTasks.length
         const totalTaskCount = _get(this.props, 'totalTaskCount') || countShown || 0
         const totalTasksInChallenge = _get(this.props, 'totalTasksInChallenge', 0)
         const percentShown = Math.round(totalTaskCount / totalTasksInChallenge * 100.0)
@@ -127,7 +128,7 @@ export class TaskAnalysisTableHeader extends Component {
                         <span className="mr-mr-2">
                           <FormattedMessage
                             {...messages.taskCountSelectedStatus}
-                            values={{selectedCount}}
+                            values={{selectedCount: (this.props.allTasksAreSelected() ? totalTaskCount : selectedCount)}}
                           />
                         </span>
                         <span className="mr-mr-6">
@@ -176,7 +177,7 @@ export class TaskAnalysisTableHeader extends Component {
                                            skipConfirmation={e => e.target.value === ""}
                                          >
                                            <select
-                                             onChange={e => { if (e.target.value !== "") this.props.changeStatus(e.target.value) }}
+                                             onChange={e => { if (e.target.value !== "") this.props.changeStatus(this.props.selectedTasks, e.target.value) }}
                                              defaultValue={this.state.statusChange}
                                              className="mr-min-w-20 mr-select mr-text-xs"
                                            >

--- a/src/components/TaskFilters/TaskPriorityFilter.js
+++ b/src/components/TaskFilters/TaskPriorityFilter.js
@@ -26,7 +26,10 @@ export default class TaskPriorityFilter extends Component {
                   className="mr-checkbox-toggle mr-mr-2"
                   type="checkbox"
                   checked={this.props.includeTaskPriorities[priority]}
-                  onChange={() => this.props.toggleIncludedTaskPriority(priority)} />
+                  onChange={(e) =>
+                    this.props.toggleIncludedTaskPriority(priority,
+                                                          e.nativeEvent.shiftKey)
+                  } />
                 <FormattedMessage {...messagesByPriority[priority]} />
               </label>
             </li>

--- a/src/components/TaskFilters/TaskReviewStatusFilter.js
+++ b/src/components/TaskFilters/TaskReviewStatusFilter.js
@@ -26,7 +26,10 @@ export default class TaskReviewStatusFilter extends Component {
                   className="mr-checkbox-toggle mr-mr-2"
                   type="checkbox"
                   checked={this.props.includeTaskReviewStatuses[status]}
-                  onChange={() => this.props.toggleIncludedTaskReviewStatus(status)} />
+                  onChange={(e) =>
+                    this.props.toggleIncludedTaskReviewStatus(status,
+                                                              e.nativeEvent.shiftKey)
+                  } />
                 <FormattedMessage {...messagesByReviewStatus[status]} />
               </label>
             </li>

--- a/src/components/TaskFilters/TaskStatusFilter.js
+++ b/src/components/TaskFilters/TaskStatusFilter.js
@@ -25,7 +25,10 @@ export default class TaskStatusFilter extends Component {
                   className="mr-checkbox-toggle mr-mr-2"
                   type="checkbox"
                   checked={this.props.includeTaskStatuses[status]}
-                  onChange={() => this.props.toggleIncludedTaskStatus(status)} />
+                  onChange={(e) =>
+                    this.props.toggleIncludedTaskStatus(status,
+                                                        e.nativeEvent.shiftKey)
+                  } />
                 <FormattedMessage {...messagesByStatus[status]} />
               </label>
             </li>

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -83,6 +83,7 @@ const apiRoutes = factory => {
       'random': factory.get('/tasks/random', {noCache: true}),
       'withinBounds': factory.put('/tasks/box/:left/:bottom/:right/:top'),
       'bulkUpdate': factory.put('/tasks'),
+      'bulkStatusChange': factory.put('/tasks/changeStatus'),
       'review': factory.get('/tasks/review'),
       'reviewed': factory.get('/tasks/reviewed'),
       'reviewNext': factory.get('/tasks/review/next'),


### PR DESCRIPTION
Closes #1127 

* When indicating you want all tasks selected and applying a
bulk status change, allow for changing status on all tasks
matching current filters not just tasks being shown on current
page for admin tasks table.

* Allow for shift+click to indicate you want a
  status/priority/reviewStatus exclusively checked.

Relies on maproulette/maproulette2#715