### PR TITLE
Indicate task priority in task nearby map

### DIFF
--- a/src/components/HOCs/WithTaskMarkers/WithTaskMarkers.js
+++ b/src/components/HOCs/WithTaskMarkers/WithTaskMarkers.js
@@ -41,7 +41,8 @@ export default function WithTaskMarkers(WrappedComponent,
                 isVirtualChallenge: challengeTasks.isVirtualChallenge,
                 challengeName: task.parentName,
                 taskId: task.id,
-                status: task.status
+                status: task.status,
+                priority: task.priority,
               },
             })
           })

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -36,7 +36,7 @@ class Modal extends Component {
           <div
             className={classNames(
               {'mr-p-8': !this.props.fullBleed},
-              'mr-relative mr-bg-blue-dark mr-rounded mr-shadow mr-w-full mr-w-full mr-w-md mr-mx-auto mr-overflow-y-auto mr-max-h-screen80 mr-min-w-72',
+              'mr-relative mr-bg-blue-dark mr-rounded mr-shadow mr-w-full mr-w-full mr-w-md mr-mx-auto mr-overflow-y-auto mr-max-h-screen90 mr-min-w-72',
               this.props.contentClassName
             )}
           >

--- a/src/components/TaskPane/TaskNearbyList/Messages.js
+++ b/src/components/TaskPane/TaskNearbyList/Messages.js
@@ -13,4 +13,14 @@ export default defineMessages({
     id: "Widgets.TaskNearbyMap.noTasksAvailable.label",
     defaultMessage: "No nearby tasks are available.",
   },
+
+  priorityLabel: {
+    id: "Widgets.TaskNearbyMap.tooltip.priorityLabel",
+    defaultMessage: "Priority: ",
+  },
+
+  statusLabel: {
+    id: "Widgets.TaskNearbyMap.tooltip.statusLabel",
+    defaultMessage: "Status: ",
+  },
 })

--- a/src/components/TaskPane/TaskNearbyList/TaskNearbyMap.js
+++ b/src/components/TaskPane/TaskNearbyList/TaskNearbyMap.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import L from 'leaflet'
 import 'leaflet-vectoricon'
-import { ZoomControl, Marker } from 'react-leaflet'
+import { ZoomControl, Marker, Tooltip } from 'react-leaflet'
 import MarkerClusterGroup from 'react-leaflet-markercluster'
 import { point, featureCollection } from '@turf/helpers'
 import bbox from '@turf/bbox'
@@ -13,7 +13,8 @@ import _map from 'lodash/map'
 import _cloneDeep from 'lodash/cloneDeep'
 import { latLng } from 'leaflet'
 import { layerSourceWithId } from '../../../services/VisibleLayer/LayerSources'
-import { TaskStatusColors } from '../../../services/Task/TaskStatus/TaskStatus'
+import { TaskStatusColors, messagesByStatus } from '../../../services/Task/TaskStatus/TaskStatus'
+import { messagesByPriority } from '../../../services/Task/TaskPriority/TaskPriority'
 import AsMappableTask from '../../../interactions/Task/AsMappableTask'
 import EnhancedMap from '../../EnhancedMap/EnhancedMap'
 import SourcedTileLayer from '../../EnhancedMap/SourcedTileLayer/SourcedTileLayer'
@@ -48,10 +49,10 @@ const starIconSvg = L.vectorIcon({
   },
 })
 
-const markerIconSvg = (fillColor=colors['blue-leaflet']) => L.vectorIcon({
+const markerIconSvg = (fillColor=colors['blue-leaflet'], priority) => L.vectorIcon({
   viewBox: '0 0 20 20',
-  svgHeight: 30,
-  svgWidth: 30,
+  svgHeight: 40 - (priority * 10),
+  svgWidth: 40 - (priority * 10),
   type: 'path',
   shape: { // zondicons "location" icon
     d: "M10 20S3 10.87 3 7a7 7 0 1 1 14 0c0 3.87-7 13-7 13zm0-11a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"
@@ -121,10 +122,26 @@ export class TaskNearbyMap extends Component {
             key={marker.options.taskId}
             {...markerData}
             icon={markerIconSvg(isRequestedMarker ? colors.yellow :
-              TaskStatusColors[_get(marker.options, 'status', 0)])}
+              TaskStatusColors[_get(marker.options, 'status', 0)],
+              isRequestedMarker ? undefined : _get(marker.options, 'priority', 0))}
             zIndexOffset={isRequestedMarker ? 1000 : undefined}
             onClick={() => this.markerClicked(markerData)}
-          />
+          >
+            <Tooltip>
+              <div>
+                <FormattedMessage {...messages.priorityLabel} /> {
+                  this.props.intl.formatMessage(
+                    messagesByPriority[_get(marker.options, 'priority', 0)])
+                }
+              </div>
+              <div>
+                <FormattedMessage {...messages.statusLabel} /> {
+                  this.props.intl.formatMessage(
+                    messagesByStatus[_get(marker.options, 'status', 0)])
+                }
+              </div>
+            </Tooltip>
+          </Marker>
         )
       })
     }

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -781,6 +781,8 @@
   "Task.management.controls.modify.label": "Modify",
   "Widgets.TaskNearbyMap.currentTaskTooltip": "Current Task",
   "Widgets.TaskNearbyMap.noTasksAvailable.label": "No nearby tasks are available.",
+  "Widgets.TaskNearbyMap.tooltip.priorityLabel": "Priority:",
+  "Widgets.TaskNearbyMap.tooltip.statusLabel": "Status:",
   "Challenge.controls.taskLoadBy.label": "Load tasks by:",
   "Task.controls.track.label": "Track this Task",
   "Task.controls.untrack.label": "Stop tracking this Task",

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -351,6 +351,7 @@ module.exports = {
       '5/6': '83.33333%',
       'screen60': '60vw',
       'screen80': '80vw',
+      'screen90': '90vw',
     },
 
     maxHeight: {


### PR DESCRIPTION
Add ability to distinguish tasks by priority on task nearby map: 

* Vary size of markers based on priority

* Add tooltip with info on priority and status