### PR TITLE
Pause keyboard shortcuts during task confirmation

### DIFF
--- a/src/components/HOCs/WithKeyboardShortcuts/WithKeyboardShortcuts.js
+++ b/src/components/HOCs/WithKeyboardShortcuts/WithKeyboardShortcuts.js
@@ -1,10 +1,13 @@
 import { connect } from 'react-redux'
 import _get from 'lodash/get'
-import { addKeyboardShortcutGroup,
-         removeKeyboardShortcutGroup,
-         addKeyboardShortcut,
-         removeKeyboardShortcut }
-       from '../../../services/KeyboardShortcuts/KeyboardShortcuts'
+import {
+  addKeyboardShortcutGroup,
+  removeKeyboardShortcutGroup,
+  addKeyboardShortcut,
+  removeKeyboardShortcut,
+  pauseKeyboardShortcuts,
+  resumeKeyboardShortcuts,
+} from '../../../services/KeyboardShortcuts/KeyboardShortcuts'
 import KeyMappings from '../../../services/KeyboardShortcuts/KeyMappings'
 
 const mapStateToProps = state => {
@@ -47,6 +50,12 @@ const mapDispatchToProps = dispatch => {
     },
     removeExternalKeyboardShortcut: (groupName, shortcutName) => {
       dispatch(removeKeyboardShortcut(groupName, shortcutName))
+    },
+    pauseKeyboardShortcuts: () => {
+      dispatch(pauseKeyboardShortcuts())
+    },
+    resumeKeyboardShortcuts: () => {
+      dispatch(resumeKeyboardShortcuts())
     },
     textInputActive: textInputActive,
     quickKeyHandler: (key, handler, allowModifierKeys=false) => (event => {

--- a/src/components/InspectTaskControls/InspectTaskControls.js
+++ b/src/components/InspectTaskControls/InspectTaskControls.js
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom'
 import _pick from 'lodash/pick'
 import _omit from 'lodash/omit'
 import _get from 'lodash/get'
+import _isEmpty from 'lodash/isEmpty'
 import BusySpinner from '../BusySpinner/BusySpinner'
 import AsManager from '../../interactions/User/AsManager'
 import WithSearch from '../HOCs/WithSearch/WithSearch'
@@ -16,6 +17,8 @@ import UserEditorSelector
        from '../UserEditorSelector/UserEditorSelector'
 import messages from './Messages'
 import './InspectTaskControls.scss'
+
+const shortcutGroup = 'taskInspect'
 
 /**
  * InspectTaskControls presents controls used during task inspect by a challenge
@@ -38,11 +41,16 @@ export class InspectTaskControls extends Component {
 
   /** Process keyboard shortcuts for the inspect controls */
   handleKeyboardShortcuts = (event) => {
+    // Ignore if shortcut group is not active
+    if (_isEmpty(this.props.activeKeyboardShortcuts[shortcutGroup])) {
+      return
+    }
+
     if (this.props.textInputActive(event)) { // ignore typing in inputs
       return
     }
 
-    const inspectShortcuts = this.props.keyboardShortcutGroups.taskInspect
+    const inspectShortcuts = this.props.keyboardShortcutGroups[shortcutGroup]
     if (event.key === inspectShortcuts.prevTask.key) {
       this.prevTask()
     }
@@ -63,13 +71,13 @@ export class InspectTaskControls extends Component {
 
   componentDidMount() {
     this.props.activateKeyboardShortcutGroup(
-      _pick(this.props.keyboardShortcutGroups, 'taskInspect'),
+      _pick(this.props.keyboardShortcutGroups, shortcutGroup),
       this.handleKeyboardShortcuts
     )
   }
 
   componentWillUnmount() {
-    this.props.deactivateKeyboardShortcutGroup('taskInspect',
+    this.props.deactivateKeyboardShortcutGroup(shortcutGroup,
                                                this.handleKeyboardShortcuts)
   }
   render() {

--- a/src/components/TaskConfirmationModal/TaskConfirmationModal.js
+++ b/src/components/TaskConfirmationModal/TaskConfirmationModal.js
@@ -3,7 +3,6 @@ import { FormattedMessage } from 'react-intl'
 import classNames from 'classnames'
 import _kebabCase from 'lodash/kebabCase'
 import _isUndefined from 'lodash/isUndefined'
-import _pick from 'lodash/pick'
 import _noop from 'lodash/noop'
 import _split from 'lodash/split'
 import _get from 'lodash/get'
@@ -27,14 +26,25 @@ import External from '../External/External'
 import Modal from '../Modal/Modal'
 import messages from './Messages'
 
+const shortcutGroup = 'taskConfirmation'
+
 export class TaskConfirmationModal extends Component {
   commentInputRef = React.createRef()
 
   handleKeyboardShortcuts = event => {
+    // Ignore if shortcut group is not active
+    if (_isEmpty(this.props.activeKeyboardShortcuts[shortcutGroup])) {
+      return
+    }
+
     if (event.key ===
-          this.props.keyboardShortcutGroups.taskCompletion.confirmSubmit.key &&
+        this.props.keyboardShortcutGroups.taskConfirmation.confirmSubmit.key &&
         event.shiftKey) {
       this.props.onConfirm()
+      event.preventDefault()
+    }
+    else if (event.key === this.props.keyboardShortcutGroups.taskConfirmation.cancel.key) {
+      this.props.onCancel()
       event.preventDefault()
     }
   }
@@ -42,15 +52,18 @@ export class TaskConfirmationModal extends Component {
   componentDidMount(prevProps, prevState) {
     this.commentInputRef.current.focus()
 
+    this.props.pauseKeyboardShortcuts()
     this.props.activateKeyboardShortcut(
-      'taskCompletion',
-      _pick(this.props.keyboardShortcutGroups.taskCompletion, 'confirmSubmit'),
-      this.handleKeyboardShortcuts)
+      shortcutGroup,
+      this.props.keyboardShortcutGroups.taskConfirmation,
+      this.handleKeyboardShortcuts
+    )
   }
 
   componentWillUnmount() {
-    this.props.deactivateKeyboardShortcut('taskCompletion', 'confirmSubmit',
+    this.props.deactivateKeyboardShortcut(shortcutGroup, 'confirmSubmit',
                                           this.handleKeyboardShortcuts)
+    this.props.resumeKeyboardShortcuts()
   }
 
   handleAddTag = (value) => {

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskAlreadyFixedControl/TaskAlreadyFixedControl.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskAlreadyFixedControl/TaskAlreadyFixedControl.js
@@ -2,10 +2,13 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 import _pick from 'lodash/pick'
+import _isEmpty from 'lodash/isEmpty'
 import { TaskStatus }
        from '../../../../../services/Task/TaskStatus/TaskStatus'
 import Button from '../../../../Button/Button'
 import messages from './Messages'
+
+const shortcutGroup = 'taskCompletion'
 
 /**
  * TaskAlreadyFixedControl displays the a control for marking a task with an
@@ -14,20 +17,29 @@ import messages from './Messages'
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default class TaskAlreadyFixedControl extends Component {
+  completeTask = () => {
+    // Ignore if shortcut group is not active
+    if (_isEmpty(this.props.activeKeyboardShortcuts[shortcutGroup])) {
+      return
+    }
+
+    this.props.complete(TaskStatus.alreadyFixed)
+  }
+
   handleKeyboardShortcuts = this.props.quickKeyHandler(
     this.props.keyboardShortcutGroups.taskCompletion.alreadyFixed.key,
-    () => this.props.complete(TaskStatus.alreadyFixed)
+    () => this.completeTask()
   )
 
   componentDidMount() {
     this.props.activateKeyboardShortcut(
-      'taskCompletion',
+      shortcutGroup,
       _pick(this.props.keyboardShortcutGroups.taskCompletion, 'alreadyFixed'),
       this.handleKeyboardShortcuts)
   }
 
   componentWillUnmount() {
-    this.props.deactivateKeyboardShortcut('taskCompletion', 'alreadyFixed',
+    this.props.deactivateKeyboardShortcut(shortcutGroup, 'alreadyFixed',
                                           this.handleKeyboardShortcuts)
   }
 

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCancelEditingControl/TaskCancelEditingControl.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskCancelEditingControl/TaskCancelEditingControl.js
@@ -2,9 +2,12 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 import _pick from 'lodash/pick'
+import _isEmpty from 'lodash/isEmpty'
 import classNames from 'classnames'
 import messages from './Messages'
 import './TaskCancelEditingControl.scss'
+
+const shortcutGroup = 'taskEditing'
 
 /**
  * TaskCancelEditingControl displays a control for cancelling the current
@@ -14,6 +17,11 @@ import './TaskCancelEditingControl.scss'
  */
 export default class TaskCancelEditingControl extends Component {
   handleKeyboardShortcuts = (event) => {
+    // Ignore if shortcut group is not active
+    if (_isEmpty(this.props.activeKeyboardShortcuts[shortcutGroup])) {
+      return
+    }
+
     if (this.props.textInputActive(event)) { // ignore typing in inputs
       return
     }
@@ -26,13 +34,13 @@ export default class TaskCancelEditingControl extends Component {
 
   componentDidMount() {
     this.props.activateKeyboardShortcut(
-      'taskEditing',
+      shortcutGroup,
       _pick(this.props.keyboardShortcutGroups.taskEditing, 'cancel'),
       this.handleKeyboardShortcuts)
   }
 
   componentWillUnmount() {
-    this.props.deactivateKeyboardShortcut('taskEditing', 'cancel',
+    this.props.deactivateKeyboardShortcut(shortcutGroup, 'cancel',
                                           this.handleKeyboardShortcuts)
   }
 

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskEditControl/TaskEditControl.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskEditControl/TaskEditControl.js
@@ -3,10 +3,13 @@ import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 import _get from 'lodash/get'
 import _pick from 'lodash/pick'
+import _isEmpty from 'lodash/isEmpty'
 import { DEFAULT_EDITOR, Editor }
        from '../../../../../services/Editor/Editor'
 import Button from '../../../../Button/Button'
 import messages from './Messages'
+
+const shortcutGroup = 'openEditor'
 
 /**
  * TaskEditControl renders a control for initiating the editing process for a
@@ -19,6 +22,11 @@ import messages from './Messages'
 export default class TaskEditControl extends Component {
   /** Process keyboard shortcuts for the edit controls */
   handleKeyboardShortcuts = (event) => {
+    // Ignore if shortcut group is not active
+    if (_isEmpty(this.props.activeKeyboardShortcuts[shortcutGroup])) {
+      return
+    }
+
     if (this.props.textInputActive(event)) { // ignore typing in inputs
       return
     }
@@ -28,7 +36,7 @@ export default class TaskEditControl extends Component {
       return
     }
 
-    const editShortcuts = this.props.keyboardShortcutGroups.openEditor
+    const editShortcuts = this.props.keyboardShortcutGroups[shortcutGroup]
 
     switch(event.key) {
       case editShortcuts.editId.key:
@@ -61,12 +69,12 @@ export default class TaskEditControl extends Component {
 
   componentDidMount() {
     this.props.activateKeyboardShortcutGroup(
-      _pick(this.props.keyboardShortcutGroups, 'openEditor'),
+      _pick(this.props.keyboardShortcutGroups, shortcutGroup),
       this.handleKeyboardShortcuts)
   }
 
   componentWillUnmount() {
-    this.props.deactivateKeyboardShortcutGroup('openEditor',
+    this.props.deactivateKeyboardShortcutGroup(shortcutGroup,
                                                this.handleKeyboardShortcuts)
   }
 

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFalsePositiveControl/TaskFalsePositiveControl.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFalsePositiveControl/TaskFalsePositiveControl.js
@@ -2,10 +2,13 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 import _pick from 'lodash/pick'
+import _isEmpty from 'lodash/isEmpty'
 import { TaskStatus }
        from '../../../../../services/Task/TaskStatus/TaskStatus'
 import Button from '../../../../Button/Button'
 import messages from './Messages'
+
+const shortcutGroup = 'taskCompletion'
 
 /**
  * TaskFalsePositiveControl displays a control for marking a task with a
@@ -14,20 +17,29 @@ import messages from './Messages'
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default class TaskFalsePositiveControl extends Component {
+  completeTask = () => {
+    // Ignore if shortcut group is not active
+    if (_isEmpty(this.props.activeKeyboardShortcuts[shortcutGroup])) {
+      return
+    }
+
+    this.props.complete(TaskStatus.falsePositive)
+  }
+
   handleKeyboardShortcuts = this.props.quickKeyHandler(
     this.props.keyboardShortcutGroups.taskCompletion.falsePositive.key,
-    () => this.props.complete(TaskStatus.falsePositive)
+    () => this.completeTask()
   )
 
   componentDidMount() {
     this.props.activateKeyboardShortcut(
-      'taskCompletion',
+      shortcutGroup,
       _pick(this.props.keyboardShortcutGroups.taskCompletion, 'falsePositive'),
       this.handleKeyboardShortcuts)
   }
 
   componentWillUnmount() {
-    this.props.deactivateKeyboardShortcut('taskCompletion', 'falsePositive',
+    this.props.deactivateKeyboardShortcut(shortcutGroup, 'falsePositive',
                                           this.handleKeyboardShortcuts)
   }
 

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFixedControl/TaskFixedControl.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskFixedControl/TaskFixedControl.js
@@ -2,10 +2,13 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 import _pick from 'lodash/pick'
+import _isEmpty from 'lodash/isEmpty'
 import { TaskStatus }
        from '../../../../../services/Task/TaskStatus/TaskStatus'
 import Button from '../../../../Button/Button'
 import messages from './Messages'
+
+const shortcutGroup = 'taskCompletion'
 
 /**
  * TaskFixedControl displays a control for marking a task with a fixed status.
@@ -13,20 +16,29 @@ import messages from './Messages'
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default class TaskFixedControl extends Component {
+  completeTask = () => {
+    // Ignore if shortcut group is not active
+    if (_isEmpty(this.props.activeKeyboardShortcuts[shortcutGroup])) {
+      return
+    }
+
+    this.props.complete(TaskStatus.fixed)
+  }
+
   handleKeyboardShortcuts = this.props.quickKeyHandler(
     this.props.keyboardShortcutGroups.taskCompletion.fixed.key,
-    () => this.props.complete(TaskStatus.fixed)
+    () => this.completeTask()
   )
 
   componentDidMount() {
     this.props.activateKeyboardShortcut(
-      'taskCompletion',
+      shortcutGroup,
       _pick(this.props.keyboardShortcutGroups.taskCompletion, 'fixed'),
       this.handleKeyboardShortcuts)
   }
 
   componentWillUnmount() {
-    this.props.deactivateKeyboardShortcut('taskCompletion', 'fixed',
+    this.props.deactivateKeyboardShortcut(shortcutGroup, 'fixed',
                                           this.handleKeyboardShortcuts)
   }
 

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskSkipControl/TaskSkipControl.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskSkipControl/TaskSkipControl.js
@@ -2,10 +2,13 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 import _pick from 'lodash/pick'
+import _isEmpty from 'lodash/isEmpty'
 import { TaskStatus }
        from '../../../../../services/Task/TaskStatus/TaskStatus'
 import Button from '../../../../Button/Button'
 import messages from './Messages'
+
+const shortcutGroup = 'taskCompletion'
 
 /**
  * TaskSkipControl displays a control for marking a task with a skipped status.
@@ -13,20 +16,29 @@ import messages from './Messages'
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default class TaskSkipControl extends Component {
+  completeTask = () => {
+    // Ignore if shortcut group is not active
+    if (_isEmpty(this.props.activeKeyboardShortcuts[shortcutGroup])) {
+      return
+    }
+
+    this.props.complete(TaskStatus.skipped)
+  }
+
   handleKeyboardShortcuts = this.props.quickKeyHandler(
     this.props.keyboardShortcutGroups.taskCompletion.skip.key,
-    () => this.props.complete(TaskStatus.skipped)
+    () => this.completeTask()
   )
 
   componentDidMount() {
     this.props.activateKeyboardShortcut(
-      'taskCompletion',
+      shortcutGroup,
       _pick(this.props.keyboardShortcutGroups.taskCompletion, 'skip'),
       this.handleKeyboardShortcuts)
   }
 
   componentWillUnmount() {
-    this.props.deactivateKeyboardShortcut('taskCompletion', 'skip',
+    this.props.deactivateKeyboardShortcut(shortcutGroup, 'skip',
                                           this.handleKeyboardShortcuts)
   }
 

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskTooHardControl/TaskTooHardControl.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskTooHardControl/TaskTooHardControl.js
@@ -2,10 +2,13 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 import _pick from 'lodash/pick'
+import _isEmpty from 'lodash/isEmpty'
 import { TaskStatus }
        from '../../../../../services/Task/TaskStatus/TaskStatus'
 import Button from '../../../../Button/Button'
 import messages from './Messages'
+
+const shortcutGroup = 'taskCompletion'
 
 /**
  * TaskTooHardControl displays a control for marking a task with a too-hard
@@ -14,20 +17,29 @@ import messages from './Messages'
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default class TaskTooHardControl extends Component {
+  completeTask = () => {
+    // Ignore if shortcut group is not active
+    if (_isEmpty(this.props.activeKeyboardShortcuts[shortcutGroup])) {
+      return
+    }
+
+    this.props.complete(TaskStatus.tooHard)
+  }
+
   handleKeyboardShortcuts = this.props.quickKeyHandler(
     this.props.keyboardShortcutGroups.taskCompletion.tooHard.key,
-    () => this.props.complete(TaskStatus.tooHard)
+    () => this.completeTask()
   )
 
   componentDidMount() {
     this.props.activateKeyboardShortcut(
-      'taskCompletion',
+      shortcutGroup,
       _pick(this.props.keyboardShortcutGroups.taskCompletion, 'tooHard'),
       this.handleKeyboardShortcuts)
   }
 
   componentWillUnmount() {
-    this.props.deactivateKeyboardShortcut('taskCompletion', 'tooHard',
+    this.props.deactivateKeyboardShortcut(shortcutGroup, 'tooHard',
                                           this.handleKeyboardShortcuts)
   }
   render() {

--- a/src/components/TaskPane/TaskMap/TaskMap.js
+++ b/src/components/TaskPane/TaskMap/TaskMap.js
@@ -43,6 +43,8 @@ import { supportedSimplestyles }
 import BusySpinner from '../../BusySpinner/BusySpinner'
 import './TaskMap.scss'
 
+const shortcutGroup = 'layers'
+
 /**
  * TaskMap renders a map (and controls) appropriate for the given task,
  * including the various map-related features and configuration options set on
@@ -63,11 +65,16 @@ export class TaskMap extends Component {
 
   /** Process keyboard shortcuts for the layers */
   handleKeyboardShortcuts = event => {
+    // Ignore if shortcut group is not active
+    if (_isEmpty(this.props.activeKeyboardShortcuts[shortcutGroup])) {
+      return
+    }
+
     if (this.props.textInputActive(event)) { // ignore typing in inputs
       return
     }
 
-    const layerShortcuts = this.props.keyboardShortcutGroups.layers
+    const layerShortcuts = this.props.keyboardShortcutGroups[shortcutGroup]
     switch(event.key) {
       case layerShortcuts.layerOSMData.key:
         this.toggleOSMDataVisibility()
@@ -153,7 +160,7 @@ export class TaskMap extends Component {
 
   componentDidMount() {
     this.props.activateKeyboardShortcutGroup(
-      _pick(this.props.keyboardShortcutGroups, 'layers'),
+      _pick(this.props.keyboardShortcutGroups, shortcutGroup),
       this.handleKeyboardShortcuts)
 
     this.loadMapillaryIfNeeded()
@@ -233,11 +240,15 @@ export class TaskMap extends Component {
       return true
     }
 
+    if (!_isEqual(nextProps.activeKeyboardShortcuts, this.props.activeKeyboardShortcuts)) {
+      return true
+    }
+
     return false
   }
 
   componentWillUnmount() {
-    this.props.deactivateKeyboardShortcutGroup('layers',
+    this.props.deactivateKeyboardShortcutGroup(shortcutGroup,
                                                this.handleKeyboardShortcuts)
   }
 

--- a/src/services/KeyboardShortcuts/KeyMappings.js
+++ b/src/services/KeyboardShortcuts/KeyMappings.js
@@ -36,10 +36,13 @@ export default {
     fixed: {key: 'f', label: messages.fixed},
     tooHard: {key: 'd', label: messages.tooHard},
     alreadyFixed: {key: 'x', label: messages.alreadyFixed},
-    confirmSubmit: {key: 'Enter', label: messages.confirmSubmit},
   },
   taskInspect: {
     nextTask: {key: 'l', label: messages.nextTask},
     prevTask: {key: 'h', label: messages.prevTask},
+  },
+  taskConfirmation: {
+    confirmSubmit: {key: 'Enter', label: messages.confirmSubmit},
+    cancel: {key: 'Escape', label: messages.cancel, keyLabel: messages.escapeLabel},
   },
 }

--- a/src/services/KeyboardShortcuts/KeyboardShortcuts.js
+++ b/src/services/KeyboardShortcuts/KeyboardShortcuts.js
@@ -7,6 +7,8 @@ export const ADD_KEYBOARD_SHORTCUT_GROUP = 'ADD_KEYBOARD_SHORTCUT_GROUP'
 export const REMOVE_KEYBOARD_SHORTCUT_GROUP = 'REMOVE_KEYBOARD_SHORTCUT_GROUP'
 export const ADD_KEYBOARD_SHORTCUT = 'ADD_KEYBOARD_SHORTCUT'
 export const REMOVE_KEYBOARD_SHORTCUT = 'REMOVE_KEYBOARD_SHORTCUT'
+export const PAUSE_KEYBOARD_SHORTCUTS = 'PAUSE_KEYBOARD_SHORTCUTS'
+export const RESUME_KEYBOARD_SHORTCUTS = 'RESUME_KEYBOARD_SHORTCUTS'
 export const CLEAR_KEYBOARD_SHORTCUTS = 'CLEAR_KEYBOARD_SHORTCUTS'
 
 // redux action creators
@@ -37,6 +39,18 @@ export const removeKeyboardShortcut = function(groupName, shortcutName) {
     type: REMOVE_KEYBOARD_SHORTCUT,
     groupName,
     shortcutName,
+  }
+}
+
+export const pauseKeyboardShortcuts = function() {
+  return {
+    type: PAUSE_KEYBOARD_SHORTCUTS,
+  }
+}
+
+export const resumeKeyboardShortcuts = function() {
+  return {
+    type: RESUME_KEYBOARD_SHORTCUTS,
   }
 }
 
@@ -86,6 +100,27 @@ export const currentKeyboardShortcuts = function(state={}, action) {
     }
 
     return mergedState
+  }
+  else if (action.type === PAUSE_KEYBOARD_SHORTCUTS) {
+    // If we're already paused, ignore
+    if (!_isEmpty(state.paused)) {
+      return state
+    }
+
+    return {
+      paused: state.groups,
+      groups: {},
+    }
+  }
+  else if (action.type === RESUME_KEYBOARD_SHORTCUTS) {
+    // If nothing is paused, ignore
+    if (_isEmpty(state.paused)) {
+      return state
+    }
+
+    return {
+      groups: Object.assign({}, state.paused)
+    }
   }
   else if (action.type === CLEAR_KEYBOARD_SHORTCUTS) {
     return {groups: {}}


### PR DESCRIPTION
* Add support for pausing and resuming active keyboard shortcuts

* Update existing keyboard shortcut handlers to check that that their
shortcut group is still active before honoring shortcut key

* Pause keyboard shortcuts when task-confirmation modal is displayed,
and resume them after it is dismissed

* Change task-confirmation modal shortcut group so that its own keyboard
shortcuts can be activated despite pausing the task-completion shortcuts

* Add ESC keyboard shortcut for canceling the task-confirmation modal