### PR TITLE
Allow project CSV export from projects dashboard

### DIFF
--- a/src/components/AdminPane/Manage/ProjectCard/Messages.js
+++ b/src/components/AdminPane/Manage/ProjectCard/Messages.js
@@ -67,5 +67,10 @@ export default defineMessages({
   virtualHeader: {
     id: "Admin.Project.headers.virtual",
     defaultMessage: "Virtual",
-  }
+  },
+
+  exportCSVLabel: {
+    id: "Admin.Project.controls.export.label",
+    defaultMessage: "Export CSV",
+  },
 })

--- a/src/components/AdminPane/Manage/ProjectCard/ProjectCard.js
+++ b/src/components/AdminPane/Manage/ProjectCard/ProjectCard.js
@@ -109,6 +109,15 @@ export class ProjectCard extends Component {
                   }
                 </li>
               }
+              <li>
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={`${process.env.REACT_APP_MAP_ROULETTE_SERVER_URL}/api/v2/project/${this.props.project.id}/tasks/extract`}
+                >
+                  <FormattedMessage {...messages.exportCSVLabel} />
+                </a>
+              </li>
             </ul>
           }
         />

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -165,6 +165,7 @@
   "Admin.Project.controls.manageChallengeList.label": "Manage Challenge List",
   "Admin.Project.headers.challengePreview": "Challenge Matches",
   "Admin.Project.headers.virtual": "Virtual",
+  "Admin.Project.controls.export.label": "Export CSV",
   "Admin.ProjectDashboard.controls.edit.label": "Edit Project",
   "Admin.ProjectDashboard.controls.delete.label": "Delete Project",
   "Admin.ProjectDashboard.controls.addChallenge.label": "Add Challenge",


### PR DESCRIPTION
* Add option to export a project CSV directly from projects dashboard so
that manager does not have to click into the project to perform a basic
export