### PR TITLE
Record initial map bounds for clear filters reset on cluster map

### DIFF
--- a/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
+++ b/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
@@ -191,6 +191,7 @@ export const WithFilterCriteria = function(WrappedComponent) {
                            updateCriteria={this.updateCriteria}
                            refreshTasks={this.refreshTasks}
                            clearAllFilters={this.clearAllFilters}
+                           setInitialBounds={bounds => this.setState({initialBounds: bounds})}
                            {..._omit(this.props, ['loadingChallenge', 'clearAllFilters'])} />)
      }
    }

--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -373,6 +373,7 @@ export class TaskClusterMap extends Component {
       )
       // We've calculated the bounds so we don't need to do the next bounds update
       this.skipNextBoundsUpdate = true
+      this.props.setInitialBounds && this.props.setInitialBounds(this.currentBounds)
     }
     else if (this.props.initialBounds) {
       this.currentBounds = this.props.initialBounds


### PR DESCRIPTION
* When clicking 'clear filters' on cluster map the intial map
  bounds were lost so it was resetting back to wrong map bounds