### PR TITLE
Update username colors

### DIFF
--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -398,11 +398,14 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
     filterable: true,
     exportable: t => _get(t.completedBy, 'username') || t.completedBy,
     maxWidth: 180,
-    Cell: ({row}) =>
-      <div className={classNames("row-user-column",
-                      mapColors(_get(row._original.completedBy, 'username') || row._original.completedBy))}>
-        {_get(row._original.completedBy, 'username') || row._original.completedBy }
+    Cell: ({row}) => (
+      <div
+        className="row-user-column"
+        style={{color: mapColors(_get(row._original.completedBy, 'username') || row._original.completedBy)}}
+      >
+        {_get(row._original.completedBy, 'username') || row._original.completedBy}
       </div>
+    )
   }
 
   columns.reviewedAt = {
@@ -454,11 +457,14 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
     exportable: t => _get(t.reviewedBy, 'username') || t.reviewedBy,
     maxWidth: 180,
     Cell: ({row}) => (
-      !row._original.reviewedBy ? null :
-        <div className={classNames("row-user-column",
-                        mapColors(row._original.reviewedBy.username || row._original.reviewedBy))}>
-          {row._original.reviewedBy.username || row._original.reviewedBy}
-        </div>
+      !row._original.reviewedBy ?
+      null :
+      <div
+        className="row-user-column"
+        style={{color: mapColors(row._original.reviewedBy.username || row._original.reviewedBy)}}
+      >
+        {row._original.reviewedBy.username || row._original.reviewedBy}
+      </div>
     )
   }
 

--- a/src/components/TaskHistoryList/TaskHistoryList.js
+++ b/src/components/TaskHistoryList/TaskHistoryList.js
@@ -104,7 +104,10 @@ export default class TaskHistoryList extends Component {
                               entry: [
                                 <li className="mr-mb-4" key={"start-" + index}>
                                   <div>
-                                    <span className={classNames("mr-mr-2", mapColors(username))}>
+                                    <span
+                                      className="mr-mr-2"
+                                      style={{color: mapColors(username)}}
+                                    >
                                       {username}
                                     </span> <FormattedMessage {...messages.startedOnLabel} />
                                   </div>
@@ -178,7 +181,9 @@ export default class TaskHistoryList extends Component {
             {(log.username || log.status) &&
               <li className="mr-mb-4">
                 <div className="mr-flex mr-justify-between">
-                  <span className={mapColors(log.username)}>{log.username}</span>
+                  <span style={{color: mapColors(log.username)}}>
+                    {log.username}
+                  </span>
                   {log.status}
                 </div>
               </li>

--- a/src/interactions/User/AsEndUser.js
+++ b/src/interactions/User/AsEndUser.js
@@ -4,17 +4,28 @@ import { GROUP_TYPE_SUPERUSER }
 import _find from 'lodash/find'
 import _isObject from 'lodash/isObject'
 import _isNumber from 'lodash/isNumber'
-import _get from 'lodash/get'
 
-const USER_COLORS = ["mr-text-indigo-300", "mr-text-indigo-500", "mr-text-indigo-700",
-                     "mr-text-ocean-300", "mr-text-ocean-500", "mr-text-ocean-700",
-                     "mr-text-forest-300", "mr-text-forest-500", "mr-text-forest-700",
-                     "mr-text-cranberry-300", "mr-text-cranberry-500", "mr-text-cranberry-700",
-                     "mr-text-aqua-300", "mr-text-aqua-500", "mr-text-aqua-700",
-                     "mr-text-tangerine-300", "mr-text-tangerine-500",
-                     "mr-text-banana-500", "mr-text-banana-700",
-                     "mr-text-mint-300", "mr-text-mint-500",
-                     "mr-text-cotton-candy-500", "mr-text-cotton-candy-700"]
+// A hand-culled subset of contrasting colors from:
+// http://godsnotwheregodsnot.blogspot.com/2013/11/kmeans-color-quantization-seeding.html
+const CONTRASTING_COLORS = [
+  "#FFFF00", "#1CE6FF", "#FF34FF", "#FFDBE5", "#63FFAC", "#B79762", "#8FB0FF",
+  "#809693", "#FEFFE6", "#4FC601", "#FF2F80", "#00C2A0", "#FFAA92", "#FF90C9",
+  "#D16100", "#DDEFFF", "#A1C299", "#0AA6D8", "#FFB500", "#C2FFED", "#A079BF",
+  "#C0B9B2", "#C2FF99", "#0CBD66", "#EEC3FF", "#B77B68", "#FAD09F", "#FF8A9A",
+  "#D157A0", "#BEC459", "#0086ED", "#B4A8BD", "#00A6AA", "#A3C8C9", "#FF913F",
+  "#00FECF", "#8CD0FF", "#04F757", "#C8A1A1", "#D790FF", "#9B9700", "#549E79",
+  "#FFF69F", "#99ADC0", "#FDE8DC", "#CB7E98", "#A4E804", "#83AB58", "#D1F7CE",
+  "#C8D0F6", "#A3A489", "#8ADBB4", "#C895C5", "#FF6832", "#66E1D3", "#CFCDAC",
+  "#D0AC94", "#7ED379", "#D68E01", "#78AFA1", "#FEB2C6", "#B5F4FF", "#D2DCD5",
+  "#0AA3F7", "#E98176", "#DBD5DD", "#5EBCD1", "#9695C5", "#E773CE", "#D86A78",
+  "#CA834E", "#FF5DA7", "#F7C9BF", "#6B94AA", "#51A058", "#E7AB63", "#97979E",
+  "#F4D749", "#DDB6D0", "#9FB2A4", "#00D891", "#BC65E9", "#C6DC99", "#F5E1FF",
+  "#FFA0F2", "#CCAA35", "#8BB400", "#C86240", "#CCB87C", "#B88183", "#B5D6C3",
+  "#A38469", "#9F94F0", "#B894A6", "#71BB8C", "#00B433", "#789EC9", "#6D80BA",
+  "#5EFF03", "#E4FFFC", "#1BE177", "#BCB1E5", "#A76F42", "#A88C85", "#F4ABAA",
+  "#A3F3AB", "#00C6C8", "#EA8B66", "#BDC9D2", "#9FA064", "#DFFB71", "#98D058",
+  "#D7BFC2", "#D25B88", "#00B57F", "#00CCFF", "#92896B"
+]
 
 /**
  * Provides basic methods for interacting with users.
@@ -62,22 +73,15 @@ export class AsEndUser {
     return this.isLoggedIn() &&
            !!_find(this.user.notifications, {isRead: false})
   }
-
-  /**
-   * Returns a mr-text-* color for the user's displayName
-   */
-  colorCode() {
-    return mapColors(_get(this.user, 'osmProfile.displayName'))
-  }
 }
 
 /**
- * Returns a mr-text-* color based off a hash of the username.
+ * Returns a hex color based off a hash of the username
  */
 export function mapColors(username) {
   if (!username) return ""
 
-  return USER_COLORS[Math.abs(hashCode(username)) % USER_COLORS.length]
+  return CONTRASTING_COLORS[Math.abs(hashCode(username)) % CONTRASTING_COLORS.length]
 }
 
 export function hashCode(s) {

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -413,10 +413,14 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
     sortable: false,
     exportable: t => _get(t.reviewRequestedBy, 'username'),
     maxWidth: 180,
-    Cell: ({row}) =>
-      <div className={classNames("row-user-column", mapColors(_get(row._original.reviewRequestedBy, 'username')))}>
+    Cell: ({row}) => (
+      <div
+        className="row-user-column"
+        style={{color: mapColors(_get(row._original.reviewRequestedBy, 'username'))}}
+      >
         {_get(row._original.reviewRequestedBy, 'username')}
       </div>
+    )
   }
 
   columns.challenge = {
@@ -513,10 +517,14 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
     sortable: false,
     exportable: t => _get(t.reviewedBy, 'username'),
     maxWidth: 180,
-    Cell: ({row}) =>
-      <div className={classNames("row-user-column", mapColors(_get(row._original.reviewedBy, 'username')))}>
+    Cell: ({row}) => (
+      <div
+        className="row-user-column"
+        style={{color: mapColors(_get(row._original.reviewedBy, 'username'))}}
+      >
         {row._original.reviewedBy ? row._original.reviewedBy.username : "N/A"}
       </div>
+    )
   }
 
   columns.reviewStatus = {

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -73,31 +73,6 @@ module.exports = {
       'matisse-blue-50': 'rgba(26,104,139, 0.5)',
       'yellow-sand': '#CCB186',
       'wild-strawberry': '#FF349C',
-
-      // Username colors
-      'indigo-300': 'hsl(272, 49%, 53%)', //'#8B40CD',
-      'indigo-500': 'hsl(272, 59%, 53%)', //'#8B40CD',
-      'indigo-700': 'hsl(272, 79%, 53%)', //'#8B40CD',
-      'ocean-300': 'hsl(219, 70%, 77%)', //'#517ED3',
-      'ocean-500': 'hsl(219, 60%, 57%)', //'#517ED3',
-      'ocean-700': 'hsl(219, 80%, 57%)', //'#517ED3',
-      'forest-300': 'hsl(105, 41%, 33%)', //'#3E7D29',
-      'forest-500': 'hsl(105, 51%, 33%)', //'#3E7D29',
-      'forest-700': 'hsl(105, 61%, 43%)', //'#3E7D29',
-      'cranberry-300': 'hsl(336, 62%, 61%)', //'#E3558E',
-      'cranberry-500': 'hsl(336, 72%, 61%)', //'#E3558E',
-      'cranberry-700': 'hsl(336, 92%, 61%)', //'#E3558E',
-      'aqua-300': 'hsl(185, 47%, 47%)', //'#34B2BE',
-      'aqua-500': 'hsl(185, 57%, 47%)', //'#34B2BE',
-      'aqua-700': 'hsl(185, 77%, 47%)', //'#34B2BE',
-      'tangerine-300': 'hsl(40, 97%, 64%)', //'#FBAE17',
-      'tangerine-500': 'hsl(40, 97%, 54%)', //'#FBAE17',
-      'banana-500': 'hsl(51, 100%, 63%)', //'#FFE441'
-      'banana-700': 'hsl(51, 90%, 53%)', //'#FFE441'
-      'mint-300': 'hsl(131, 58%, 71%)', //'#7DEF91',
-      'mint-500': 'hsl(131, 78%, 71%)', //'#7DEF91',
-      'cotton-candy-500': 'hsl(312, 100%, 85%)', //'#FFB2F0'
-      'cotton-candy-700': 'hsl(312, 90%, 80%)', //'#FFB2F0'
     },
 
     screens: {


### PR DESCRIPTION
* Update username colors to a new set of contrasting colors,
culled of colors that were hard to read on our dark-mode
backgrounds

* Username colors are now simple hex codes instead of tailwind CSS
classes, so update components to set username colors as a style rather
than a className

* Remove unused `colorCode` method from `AsEndUser`