### PR TITLE
Don't show empty extra challenge-card options

### DIFF
--- a/src/components/AdminPane/Manage/ChallengeCard/ChallengeCard.js
+++ b/src/components/AdminPane/Manage/ChallengeCard/ChallengeCard.js
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import _get from 'lodash/get'
 import _isFinite from 'lodash/isFinite'
+import _isObject from 'lodash/isObject'
 import AsManageableChallenge
        from '../../../../interactions/Challenge/AsManageableChallenge'
 import WithChallengeManagement
@@ -29,6 +30,15 @@ export class ChallengeCard extends Component {
   render() {
     if (this.props.challenge.deleted) {
       return null
+    }
+
+    let parent = null
+    if (_isObject(this.props.challenge.parent)) {
+      parent = this.props.challenge.parent
+    }
+    else if (_isFinite(this.props.challenge.parent) &&
+             this.props.challenge.parent === _get(this.props, 'project.id')) {
+      parent = this.props.project
     }
 
     const hasActions = _isFinite(_get(this.props.challenge, 'actions.total'))
@@ -61,7 +71,7 @@ export class ChallengeCard extends Component {
               </Link>
               {this.props.showProjectName &&
                 <div className="mr-text-xs mr-text-grey-light">
-                  {_get(this.props.challenge, 'parent.displayName')}
+                  {_get(parent, 'displayName')}
                 </div>
               }
               {hasActions &&
@@ -115,29 +125,31 @@ export class ChallengeCard extends Component {
             </div>
           }
 
-          <Dropdown
-            className="mr-ml-4 mr-dropdown--right mr-mt-1.5"
-            dropdownButton={dropdown => (
-              <button
-                onClick={dropdown.toggleDropdownVisible}
-                className="mr-flex mr-items-center mr-text-white"
-              >
-                <SvgSymbol
-                  sym="navigation-more-icon"
-                  viewBox="0 0 20 20"
-                  className="mr-fill-current mr-w-5 mr-h-5"
-                />
-              </button>
-            )}
-            dropdownContent={dropdown =>
-              <ChallengeControls
-                {...this.props}
-                className="mr-flex mr-flex-col mr-links-green-lighter"
-                controlClassName="mr-my-1"
-                onControlComplete={() => dropdown.closeDropdown()}
-              />
-            }
-          />
+          {parent &&
+           <Dropdown
+             className="mr-ml-4 mr-dropdown--right mr-mt-1.5"
+             dropdownButton={dropdown => (
+               <button
+                 onClick={dropdown.toggleDropdownVisible}
+                 className="mr-flex mr-items-center mr-text-white"
+               >
+                 <SvgSymbol
+                   sym="navigation-more-icon"
+                   viewBox="0 0 20 20"
+                   className="mr-fill-current mr-w-5 mr-h-5"
+                 />
+               </button>
+             )}
+             dropdownContent={dropdown =>
+               <ChallengeControls
+                 {...this.props}
+                 className="mr-flex mr-flex-col mr-links-green-lighter"
+                 controlClassName="mr-my-1"
+                 onControlComplete={() => dropdown.closeDropdown()}
+               />
+             }
+           />
+          }
         </div>
       </div>
     )

--- a/src/components/AdminPane/Manage/ChallengeList/ChallengeList.js
+++ b/src/components/AdminPane/Manage/ChallengeList/ChallengeList.js
@@ -40,7 +40,7 @@ export default class ChallengeList extends Component {
     )
 
     return (
-      <div className="mr-text-base mr-pb-1">
+      <div className="mr-text-base mr-pb-1 mr-pb-36">
 
         {!this.props.loadingChallenges && challengeCards.length === 0 ?
          <div className="mr-flex mr-justify-center mr-text-grey-light">

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -364,6 +364,7 @@ module.exports = {
       '20': '5rem',
       '24': '6rem',
       '32': '8rem',
+      '36': '9rem',
     },
 
     margin: {


### PR DESCRIPTION
* If ChallengeCard extra-options would result in an empty dropdown
because the parent project isn't available, don't offer the
extra-options

* In absence of denormalized challenge parent, check current project in
ChallengeCard and ChallengeControls to see if it's the parent

* Add some padding to bottom of ChallengeList so that extra-options
dropdown is more visible when opened on bottom-most challenge