### PR TITLE
Offer control over element types in OSM Data Layer

### DIFF
--- a/src/components/EnhancedMap/EnhancedMap.js
+++ b/src/components/EnhancedMap/EnhancedMap.js
@@ -26,6 +26,7 @@ import PropertyList from './PropertyList/PropertyList'
 export default class EnhancedMap extends Map {
   currentFeatures = null
   animationHandle = null
+  mapMoved = false
 
   /**
    * Invoked after the user is finished altering the map bounds, either by
@@ -36,12 +37,14 @@ export default class EnhancedMap extends Map {
    */
   onZoomOrMoveEnd = () => {
     if (this.props.onBoundsChange) {
-      // This method can get called a few times when things are first rendering,
-      // so we make sure the map has actually moved from its initial center or
-      // zoom before recording a bounds change.
-
-      if (!this.leafletElement.getCenter().equals(this.props.center) ||
+      // This method can get called a few times when things are first
+      // rendering, so -- if the map hasn't been moved yet (panned or
+      // zoomed) -- we make sure the map has actually moved from its
+      // initial center or zoom before recording a bounds change
+      if (this.mapMoved ||
+          !this.leafletElement.getCenter().equals(this.props.center) ||
           this.leafletElement.getZoom() !== this.props.zoom) {
+        this.mapMoved = true
         this.props.onBoundsChange(this.leafletElement.getBounds(),
                                   this.leafletElement.getZoom(),
                                   this.leafletElement.getSize())

--- a/src/components/EnhancedMap/FitBoundsControl/FitBoundsControl.js
+++ b/src/components/EnhancedMap/FitBoundsControl/FitBoundsControl.js
@@ -68,8 +68,16 @@ const FitBoundsLeafletControl = Control.extend({
 
     // build the control button, render it, and return it
     const controlContent = (
-      <button onClick={() => this.fitFeatures(map)} className="mr-leading-none mr-p-2 mr-bg-black-50 mr-text-white mr-w-8 mr-h-8 mr-flex mr-items-center mr-shadow mr-rounded-sm mr-transition-normal-in-out-quad hover:mr-text-green-lighter">
-        <SvgSymbol title={this.options.intl.formatMessage(messages.tooltip)} sym="target-icon" className="mr-w-4 mr-h-4 mr-fill-current" viewBox="0 0 20 20" />
+      <button
+        onClick={event => this.fitFeatures(map, event)}
+        className="mr-leading-none mr-p-2 mr-bg-black-50 mr-text-white mr-w-8 mr-h-8 mr-flex mr-items-center mr-shadow mr-rounded-sm mr-transition-normal-in-out-quad hover:mr-text-green-lighter"
+      >
+        <SvgSymbol
+          title={this.options.intl.formatMessage(messages.tooltip)}
+          sym="target-icon"
+          className="mr-w-4 mr-h-4 mr-fill-current"
+          viewBox="0 0 20 20"
+        />
       </button>
     )
 

--- a/src/components/EnhancedMap/LayerToggle/LayerToggle.js
+++ b/src/components/EnhancedMap/LayerToggle/LayerToggle.js
@@ -43,7 +43,10 @@ export class LayerToggle extends Component {
 
     const overlayToggles = _map(this.props.intersectingOverlays, layer => (
       <div key={layer.id} className="layer-toggle__option-controls">
-        <div className="mr-flex mr-items-center" onClick={e => this.toggleOverlay(layer.id)}>
+        <div
+          className="mr-flex mr-items-center mr-leading-none"
+          onClick={e => this.toggleOverlay(layer.id)}
+        >
           <input
             type="checkbox"
             className="mr-checkbox-toggle"
@@ -74,63 +77,95 @@ export class LayerToggle extends Component {
             }
             {overlayToggles}
             {this.props.toggleTaskFeatures &&
-                <div className="mr-my-4 mr-flex mr-items-center" onClick={this.props.toggleTaskFeatures}>
-                  <input
-                    type="checkbox"
-                    className="mr-checkbox-toggle"
-                    checked={this.props.showTaskFeatures}
-                    onChange={_noop}
-                  />
-                  <label className="mr-ml-3 mr-text-orange">
-                    <FormattedMessage {...messages.showTaskFeaturesLabel} />
-                  </label>
-                </div>
-              }
-              {this.props.toggleOSMData &&
-                <div className="mr-my-4 mr-flex mr-items-center" onClick={this.props.toggleOSMData}>
-                  <input
-                    type="checkbox"
-                    className="mr-checkbox-toggle"
-                    checked={this.props.showOSMData}
-                    onChange={_noop}
-                  />
-                  <label className="mr-ml-3 mr-text-orange">
-                    <FormattedMessage
-                      {...messages.showOSMDataLabel}
-                    /> {this.props.osmDataLoading && <FormattedMessage {...messages.loading} />}
-                  </label>
-                </div>
-              }
-              {this.props.toggleMapillary &&
-                <div className="mr-my-4 mr-flex mr-items-center" onClick={e => this.props.toggleMapillary()}>
-                  <input
-                    type="checkbox"
-                    className="mr-checkbox-toggle"
-                    checked={this.props.showMapillary || false}
-                    onChange={_noop}
-                  />
-                  <label className="mr-ml-3 mr-text-orange">
-                    <FormattedMessage
-                      {...messages.showMapillaryLabel}
-                    /> {(this.props.showMapillary && !this.props.mapillaryLoading) &&
-                        <FormattedMessage {...messages.imageCount}
-                                          values={{count: this.props.mapillaryCount}} />
-                    } {this.props.mapillaryLoading && <FormattedMessage {...messages.loading} />
-                    } {this.props.showMapillary && this.props.hasMoreMapillaryImagery && !this.props.mapillaryLoading &&
-                      <button
-                        className="mr-button mr-button--xsmall mr-ml-2"
-                        onClick={e => {
-                          e.stopPropagation()
-                          this.props.fetchMoreMapillaryImagery()
-                        }}
-                      >
-                        <FormattedMessage {...messages.moreMapillaryLabel} />
-                      </button>
-                    }
+             <div
+               className="mr-my-4 mr-flex mr-items-center mr-leading-none"
+               onClick={this.props.toggleTaskFeatures}
+             >
+               <input
+                 type="checkbox"
+                 className="mr-checkbox-toggle"
+                 checked={this.props.showTaskFeatures}
+                 onChange={_noop}
+               />
+               <label className="mr-ml-3 mr-text-orange">
+                 <FormattedMessage {...messages.showTaskFeaturesLabel} />
+               </label>
+             </div>
+            }
+            {this.props.toggleOSMData &&
+             <React.Fragment>
+               <div
+                 className="mr-my-4 mr-flex mr-items-center mr-leading-none"
+                 onClick={this.props.toggleOSMData}
+               >
+                 <input
+                   type="checkbox"
+                   className="mr-checkbox-toggle"
+                   checked={this.props.showOSMData}
+                   onChange={_noop}
+                 />
+                 <label className="mr-ml-3 mr-text-orange">
+                   <FormattedMessage
+                     {...messages.showOSMDataLabel}
+                   /> {this.props.osmDataLoading && <FormattedMessage {...messages.loading} />}
+                 </label>
+               </div>
+               {this.props.showOSMData && !this.props.osmDataLoading && this.props.toggleOSMElements &&
+                <React.Fragment>
+                  {['nodes', 'ways', 'areas'].map(element => (
+                   <div
+                     key={element}
+                     className="mr-my-2 mr-ml-4 mr-flex mr-items-center mr-leading-none"
+                     onClick={() => this.props.toggleOSMElements(element)}
+                   >
+                     <input
+                       type="checkbox"
+                       className="mr-checkbox-toggle"
+                       checked={this.props.showOSMElements[element]}
+                       onChange={_noop}
+                     />
+                     <label className="mr-ml-3 mr-text-orange mr-capitalize">
+                       {element}
+                     </label>
+                   </div>
+                  ))}
+                </React.Fragment>
+               }
+             </React.Fragment>
+            }
+            {this.props.toggleMapillary &&
+             <div
+               className="mr-my-4 mr-flex mr-items-center mr-leading-none"
+               onClick={e => this.props.toggleMapillary()}
+             >
+               <input
+                 type="checkbox"
+                 className="mr-checkbox-toggle"
+                 checked={this.props.showMapillary || false}
+                 onChange={_noop}
+               />
+               <label className="mr-ml-3 mr-text-orange">
+                 <FormattedMessage
+                   {...messages.showMapillaryLabel}
+                 /> {(this.props.showMapillary && !this.props.mapillaryLoading) &&
+                     <FormattedMessage {...messages.imageCount}
+                                       values={{count: this.props.mapillaryCount}} />
+                 } {this.props.mapillaryLoading && <FormattedMessage {...messages.loading} />
+                 } {this.props.showMapillary && this.props.hasMoreMapillaryImagery && !this.props.mapillaryLoading &&
+                   <button
+                     className="mr-button mr-button--xsmall mr-ml-2"
+                     onClick={e => {
+                       e.stopPropagation()
+                       this.props.fetchMoreMapillaryImagery()
+                     }}
+                   >
+                     <FormattedMessage {...messages.moreMapillaryLabel} />
+                   </button>
+                 }
 
-                  </label>
-                </div>
-              }
+               </label>
+             </div>
+            }
           </React.Fragment>
         }
       />

--- a/src/components/EnhancedMap/OSMDataLayer/OSMDataLayer.js
+++ b/src/components/EnhancedMap/OSMDataLayer/OSMDataLayer.js
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { Path, withLeaflet } from 'react-leaflet'
 import L from 'leaflet'
+import _isEqual from 'lodash/isEqual'
 import PropertyList from '../PropertyList/PropertyList'
 import resolveConfig from 'tailwindcss/resolveConfig'
 import tailwindConfig from '../../../tailwind.config.js'
@@ -12,6 +13,8 @@ const colors = resolveConfig(tailwindConfig).theme.colors
  * Serves as a react-leaflet adapter for the leaflet-osm package
  */
 export class OSMDataLayer extends Path {
+  lastZoom = null
+
   popupContent(layer) {
     const header = (
       <a target="_blank"
@@ -36,13 +39,47 @@ export class OSMDataLayer extends Path {
   }
 
   createLeafletElement(props) {
+    this.lastZoom = props.zoom
+    const osmLayerGroup = this.generateLayer(props)
+    osmLayerGroup.on('add', () => osmLayerGroup.bringToBack())
+    return osmLayerGroup
+  }
+
+  updateLeafletElement(fromProps, toProps) {
+    if (toProps.zoom !== this.lastZoom ||
+        !_isEqual(fromProps.showOSMElements, toProps.showOSMElements)) {
+      this.leafletElement.clearLayers()
+      const newLayers = this.generateLayer(toProps)
+      newLayers.eachLayer(layer => this.leafletElement.addLayer(layer))
+      this.lastZoom = toProps.zoom
+    }
+    this.leafletElement.bringToBack()
+  }
+
+  generateElementStyles(props) {
+    const globalStyleOptions = {
+      // Set stroke weight to 3px when zoomed way in, then 2px and
+      // finally down to 1px at zoom 15
+      weight: props.zoom >= 18 ? 3 : (props.zoom > 15 ? 2 : 1),
+    }
+
+    return {
+      way: Object.assign({}, globalStyleOptions, { color: colors['orange-jaffa'] }),
+      area: Object.assign({}, globalStyleOptions, { color: colors['pink-light'] }),
+      node: Object.assign({}, globalStyleOptions, {
+        color: '#C20534',
+        radius: props.zoom >= 18 ? 10 : 5, // shrink size when zoomed out
+      }),
+      changeset: Object.assign({}, globalStyleOptions, { color: colors.red }),
+    }
+  }
+
+  generateLayer(props) {
     const layerGroup = new L.OSM.DataLayer(props.xmlData, {
-      styles: {
-        way: { color: colors['orange-jaffa'] },
-        area: { color: colors.purple },
-        node: { color: colors.green },
-        changeset: { color: colors.pink },
-      },
+      styles: this.generateElementStyles(props),
+      showNodes: props.showOSMElements.nodes,
+      showWays: props.showOSMElements.ways,
+      showAreas: props.showOSMElements.areas,
     })
 
     layerGroup.eachLayer(layer => layer.options.fill = false)
@@ -64,6 +101,10 @@ export default withLeaflet(OSMDataLayer)
 L.OSM = {};
 L.OSM.DataLayer = L.FeatureGroup.extend({
   options: {
+    showNodes: true,
+    showWays: true,
+    showAreas: true,
+    showChangesets: true,
     areaTags: ['area', 'building', 'leisure', 'tourism', 'ruins', 'historic', 'landuse', 'military', 'natural', 'sport'],
     uninterestingTags: ['source', 'source_ref', 'source:ref', 'history', 'attribution', 'created_by', 'tiger:county', 'tiger:tlid', 'tiger:upload_uuid'],
     styles: {}
@@ -88,9 +129,13 @@ L.OSM.DataLayer = L.FeatureGroup.extend({
       var feature = features[i], layer;
 
       if (feature.type === "changeset") {
-        layer = L.rectangle(feature.latLngBounds, this.options.styles.changeset);
+        if (this.options.showChangesets) {
+          layer = L.rectangle(feature.latLngBounds, this.options.styles.changeset);
+        }
       } else if (feature.type === "node") {
-        layer = L.circleMarker(feature.latLng, this.options.styles.node);
+        if (this.options.showNodes) {
+          layer = L.circleMarker(feature.latLng, this.options.styles.node);
+        }
       } else {
         var latLngs = new Array(feature.nodes.length);
 
@@ -99,15 +144,21 @@ L.OSM.DataLayer = L.FeatureGroup.extend({
         }
 
         if (this.isWayArea(feature)) {
-          latLngs.pop(); // Remove last == first.
-          layer = L.polygon(latLngs, this.options.styles.area);
+          if (this.options.showAreas) {
+            latLngs.pop(); // Remove last == first.
+            layer = L.polygon(latLngs, this.options.styles.area);
+          }
         } else {
-          layer = L.polyline(latLngs, this.options.styles.way);
+          if (this.options.showWays) {
+            layer = L.polyline(latLngs, this.options.styles.way);
+          }
         }
       }
 
-      layer.addTo(this);
-      layer.feature = feature;
+      if (layer) {
+        layer.addTo(this);
+        layer.feature = feature;
+      }
     }
   },
 


### PR DESCRIPTION
* Add layer sub-toggles that allow user to control visibility of nodes,
ways, and areas when viewing the OSM Data Layer

* Adjust OSM Data Layer colors

* Shrink down rendered OSM Data Layer line weights and circle radii at
intervals as user zooms out to make rendering less busy and obfuscating

* Fix onBoundsChange not being invoked by EnhancedMap when map entered
same zoom level as it was originally

* Send OSM Data Layer to back of Leaflet layers on each render, removing
need to remove and re-add task features layer when OSM Data Layer is
activated

* Prevent refit to map bounds when task features layer toggled off and
on

* Fix missing event argument when fit-bounds control was clicked