### PR TITLE
Add config option to disable default map layers

### DIFF
--- a/.env
+++ b/.env
@@ -14,6 +14,8 @@ REACT_APP_FEATURE_LEADERBOARD='enabled'
 REACT_APP_FEATURE_CHALLENGE_ANALYSIS_TABLE='disabled'
 REACT_APP_FEATURE_MOBILE_DEVICES='disabled'
 REACT_APP_IMAGERY_OPENSTREETCAM='enabled'
+REACT_APP_DEFAULT_MAP_LAYERS='enabled'
+REACT_APP_OSM_DATA_OVERLAY='enabled'
 
 # Default locale to use if user has not set their locale. Note that this locale
 # must be supported by the app or the default en-US will be used.

--- a/package.json
+++ b/package.json
@@ -109,9 +109,10 @@
     "watch-postcss": "postcss src/styles/index.css -o src/index.css -w",
     "build-intl": "yarn run combine-messages -i './src/**/*.js' -o './src/lang/en-US.json'",
     "update-layers": "node scripts/update_layers.js",
+    "update-layers-prod": "NODE_ENV=production node scripts/update_layers.js",
     "start-js": "react-scripts start",
     "start": "npm-run-all -p update-layers watch-postcss start-js",
-    "build": "yarn run build-intl && yarn run update-layers && yarn run build-postcss && react-scripts build",
+    "build": "yarn run build-intl && yarn run update-layers-prod && yarn run build-postcss && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/src/components/EnhancedMap/LayerToggle/LayerToggle.js
+++ b/src/components/EnhancedMap/LayerToggle/LayerToggle.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl'
 import _map from 'lodash/map'
 import _noop from 'lodash/noop'
 import _filter from 'lodash/filter'
+import _get from 'lodash/get'
 import WithVisibleLayer from '../../HOCs/WithVisibleLayer/WithVisibleLayer'
 import WithLayerSources from '../../HOCs/WithLayerSources/WithLayerSources'
 import SvgSymbol from '../../SvgSymbol/SvgSymbol'
@@ -42,7 +43,7 @@ export class LayerToggle extends Component {
     ))
 
     const overlayToggles = _map(this.props.intersectingOverlays, layer => (
-      <div key={layer.id} className="layer-toggle__option-controls">
+      <div key={layer.id} className="mr-my-4">
         <div
           className="mr-flex mr-items-center mr-leading-none"
           onClick={e => this.toggleOverlay(layer.id)}
@@ -69,11 +70,11 @@ export class LayerToggle extends Component {
         }
         dropdownContent={() =>
           <React.Fragment>
-            <ol className="mr-o-2">
-              {layerListItems}            
-            </ol>
-            {(overlayToggles.length > 0 || this.props.toggleTaskFeatures) &&
-              <hr className="mr-h-px mr-my-4 mr-bg-blue" />
+            {layerListItems.length > 0 &&
+             <ol className="mr-o-2">{layerListItems}</ol>
+            }
+            {(overlayToggles.length > 0 || this.props.toggleTaskFeatures) && layerListItems.length > 0 &&
+             <hr className="mr-h-px mr-my-4 mr-bg-white-15" />
             }
             {overlayToggles}
             {this.props.toggleTaskFeatures &&
@@ -93,6 +94,7 @@ export class LayerToggle extends Component {
              </div>
             }
             {this.props.toggleOSMData &&
+             _get(process.env, 'REACT_APP_OSM_DATA_OVERLAY', 'enabled') !== 'disabled' &&
              <React.Fragment>
                <div
                  className="mr-my-4 mr-flex mr-items-center mr-leading-none"

--- a/src/components/EnhancedMap/SourcedTileLayer/SourcedTileLayer.js
+++ b/src/components/EnhancedMap/SourcedTileLayer/SourcedTileLayer.js
@@ -46,6 +46,10 @@ export class SourcedTileLayer extends Component {
   }
 
   render() {
+    if (!this.props.source) {
+      return null
+    }
+
     if (this.state.layerRenderFailed) {
       // Try rendering the default layer as a fallback. If we *are* the
       // fallback, just render an error message
@@ -89,7 +93,7 @@ export class SourcedTileLayer extends Component {
 
 SourcedTileLayer.propTypes = {
   /** LayerSource to use */
-  source: layerSourceShape.isRequired,
+  source: layerSourceShape,
   /** Set to true to suppress display of source attribution */
   skipAttribution: PropTypes.bool,
 }


### PR DESCRIPTION
* Add `REACT_APP_DEFAULT_MAP_LAYERS` .env config option that can be used
to disable the default map layers

* Add `REACT_APP_OSM_DATA_OVERLAY` .env config option that can be used
to disable the OSM Data overlay option during task completion

* Honor .env.production and .env.development.local configuration
override files in update_layers script