### PR TITLE
Add admin update actions to task history

### DIFF
--- a/src/components/TaskHistoryList/Messages.js
+++ b/src/components/TaskHistoryList/Messages.js
@@ -13,4 +13,9 @@ export default defineMessages({
     id: "TaskHistory.controls.viewAttic.label",
     defaultMessage: "View Attic",
   },
+
+  taskUpdatedLabel: {
+    id: "TaskHistory.fields.taskUpdated.label",
+    defaultMessage: "Task updated by challenge manager",
+  }
 })

--- a/src/components/TaskHistoryList/TaskHistoryList.js
+++ b/src/components/TaskHistoryList/TaskHistoryList.js
@@ -92,6 +92,10 @@ export default class TaskHistoryList extends Component {
             }
           }
           break
+        case TaskHistoryAction.update:
+          logEntry = updateEntry(log, this.props, index)
+          username = _get(log, 'user.username')
+          break
         case TaskHistoryAction.status:
         default:
           logEntry = null
@@ -234,6 +238,14 @@ const statusEntry = (entry, props, index) => {
       intlMessage={messagesByStatus[entry.status]}
       className={`mr-status-${_kebabCase(keysByStatus[entry.status])}`}
     />
+  )
+}
+
+const updateEntry = (entry, props, index) => {
+  return (
+    <li key={index} className="mr-flex">
+      <FormattedMessage {...messages.taskUpdatedLabel} />
+    </li>
   )
 }
 

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -732,6 +732,7 @@
   "TaskReviewStatusFilter.label": "Filter by Review Status",
   "TaskHistory.fields.startedOn.label": "Started on task",
   "TaskHistory.controls.viewAttic.label": "View Attic",
+  "TaskHistory.fields.taskUpdated.label": "Task updated by challenge manager",
   "Task.markedAs.label": "Task marked as",
   "Task.requestReview.label": "request review?",
   "Task.awaitingReview.label": "Task is awaiting review.",

--- a/src/services/Task/TaskHistory/TaskHistory.js
+++ b/src/services/Task/TaskHistory/TaskHistory.js
@@ -2,9 +2,11 @@
 export const TASK_ACTION_COMMENT = 0
 export const TASK_ACTION_STATUS = 1
 export const TASK_ACTION_REVIEW = 2
+export const TASK_ACTION_UPDATE = 3
 
 export const TaskHistoryAction = Object.freeze({
   comment: TASK_ACTION_COMMENT,
   status: TASK_ACTION_STATUS,
   review: TASK_ACTION_REVIEW,
+  update: TASK_ACTION_UPDATE,
 })


### PR DESCRIPTION
In task history show when an admin has updated a task.

Relies on maproulette/maproulette2#729