### PR TITLE
Don't save removed keywords from a new challenge

### DIFF
--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -893,6 +893,11 @@ export const findKeyword = function(keywordPrefix, tagType = null) {
  * @returns a Promise
  */
 const removeChallengeKeywords = function(challengeId, oldKeywords=[]) {
+  // If no challenge id, nothing to do
+  if (!_isFinite(challengeId)) {
+    return Promise.resolve()
+  }
+
   // strip empty tags
   const toRemove =
     _compact(_map(oldKeywords, tag => _isEmpty(tag) ? null : tag))


### PR DESCRIPTION
* Don't attempt to contact the server when keywords are removed from a
new challenge, (e.g. from a clone of a challenge with existing keywords)

* Fixes #1188