### PR TITLE
Fix selected task count on bundle widget when using lasso

### DIFF
--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -184,6 +184,10 @@ export class TaskAnalysisTable extends Component {
       _filter([...this.props.selectedTasks.keys()],
                taskId => _find(data, task => task.id === taskId))
 
+    // If this is for bundling then we really do want to the full count of
+    // selected tasks since they could have used the "lasso" tool.
+    const selectedTaskCount = this.props.forBundling ?
+      this.props.selectedTasks.size : selectedDataTasks.length
 
     if (_get(this.props, 'criteria.filters')) {
       defaultFiltered = _map(this.props.criteria.filters,
@@ -203,6 +207,7 @@ export class TaskAnalysisTable extends Component {
                countShown={data.length}
                configureColumns={this.configureColumns.bind(this)}
                selectedTasks={selectedDataTasks}
+               selectedTaskCount={selectedTaskCount}
              />
            </header>
           }

--- a/src/components/TaskAnalysisTable/TaskAnalysisTableHeader.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTableHeader.js
@@ -45,7 +45,7 @@ export class TaskAnalysisTableHeader extends Component {
     render() {
         const {countShown, configureColumns} = this.props
 
-        const selectedCount = this.props.selectedTasks.length
+        const selectedCount = this.props.selectedTaskCount
         const totalTaskCount = _get(this.props, 'totalTaskCount') || countShown || 0
         const totalTasksInChallenge = _get(this.props, 'totalTasksInChallenge', 0)
         const percentShown = Math.round(totalTaskCount / totalTasksInChallenge * 100.0)
@@ -103,8 +103,8 @@ export class TaskAnalysisTableHeader extends Component {
                             title={this.props.intl.formatMessage(messages.bulkSelectionTooltip)}
                           >
                             <TriStateCheckbox
-                                checked={this.props.allTasksAreSelected()}
-                                indeterminate={this.props.someTasksAreSelected()}
+                                checked={this.props.allTasksAreSelected() || (selectedCount === totalTaskCount)}
+                                indeterminate={this.props.someTasksAreSelected() && (selectedCount !== totalTaskCount)}
                                 onClick={() => this.props.toggleAllTasksSelection()}
                                 onChange={_noop}
                             />

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -336,6 +336,7 @@ const BuildBundle = props => {
           showSelectionCount
           highlightPrimaryTask
           defaultPageSize={5}
+          forBundling
         />
       </div>
     </div>


### PR DESCRIPTION
When lasso-ing more tasks than shown on current 'page' of results in the bundle widget the selected task count would be wrong.