### PR TITLE
Fix challenge leaderboard flashing global leaderboard on load

### DIFF
--- a/src/components/HOCs/WithLeaderboard/WithLeaderboard.js
+++ b/src/components/HOCs/WithLeaderboard/WithLeaderboard.js
@@ -30,8 +30,10 @@ const WithLeaderboard = function(WrappedComponent, initialMonthsPast=1, initialO
     mergeInUserLeaderboard = userLeaderboard => {
       if (userLeaderboard && userLeaderboard.length > 0) {
         const merged = _clone(this.state.leaderboard)
-        merged.splice(userLeaderboard[0].rank - 1, userLeaderboard.length, ...userLeaderboard)
-        this.setState({leaderboard: merged})
+        if (merged) {
+          merged.splice(userLeaderboard[0].rank - 1, userLeaderboard.length, ...userLeaderboard)
+          this.setState({leaderboard: merged})
+        }
       }
     }
 

--- a/src/pages/Leaderboard/ChallengeLeaderboard.js
+++ b/src/pages/Leaderboard/ChallengeLeaderboard.js
@@ -6,7 +6,7 @@ import Leaderboard from './Leaderboard'
 export class ChallengeLeaderboard extends Component {
   render() {
     if (!this.props.challenge) {
-      return <Leaderboard />
+      return null 
     }
 
     const challengeNameLink = (


### PR DESCRIPTION
Challenge leaderboard first showing global leaderboard results before loading challenge results.