### PR TITLE
Adjust paging params for project API endpoints

### DIFF
--- a/src/components/AdminPane/Manage/Widgets/ProjectListWidget/ProjectListWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/ProjectListWidget/ProjectListWidget.js
@@ -140,13 +140,19 @@ const Widget =
       'resultProjects'
     ),
     'adminProjectList',
-    queryCriteria => {
+    (queryCriteria, resultsPerPage, props) => {
       // We only fetch all managed projects if we are not doing a query.
       if (queryCriteria.query) {
         return null
       }
-      return fetchManageableProjects(_get(queryCriteria, 'page.currentPage'),
-                                     _get(queryCriteria, 'page.resultsPerPage'))
+
+      const filters = _get(props, 'currentConfiguration.filters.projectFilters', {})
+      return fetchManageableProjects(
+        _get(queryCriteria, 'page.currentPage'),
+        _get(queryCriteria, 'page.resultsPerPage'),
+        filters.owner,
+        filters.visible
+       )
     },
   )
 

--- a/src/components/HOCs/WithSearch/WithSearch.js
+++ b/src/components/HOCs/WithSearch/WithSearch.js
@@ -42,7 +42,7 @@ const WithSearch = (WrappedComponent, searchGroup, searchFunction) => {
   // Debounce the search function so the server doesn't get hammered as a user
   // types in a query string
   const debouncedSearch = searchFunction ?
-    _debounce(props => props.performSearch(props.searchCriteria, searchFunction),
+    _debounce(props => props.performSearch(props.searchCriteria, searchFunction, props),
               1000, {leading: false}) : null
 
   return WithUserLocation(
@@ -119,8 +119,8 @@ export const mapStateToProps = (state, searchGroup) => {
 }
 
 export const mapDispatchToProps = (dispatch, ownProps, searchGroup) => ({
-  performSearch: (query, searchFunction) => {
-    return dispatch(performSearch(searchGroup, query, searchFunction))
+  performSearch: (query, searchFunction, props) => {
+    return dispatch(performSearch(searchGroup, query, searchFunction, props))
   },
 
   setSearch: (query, searchName) => {

--- a/src/components/HOCs/WithSearch/WithSearch.test.js
+++ b/src/components/HOCs/WithSearch/WithSearch.test.js
@@ -197,10 +197,11 @@ test("searchQueries.searchGroup is passed through to the wrapped component", () 
 test("mapDispatchToProps maps function performSearch", () => {
   const dispatch = jest.fn(() => Promise.resolve())
   const mappedProps = mapDispatchToProps(dispatch, {}, "searchGroup")
+  const someProps = {foo: "foo"}
 
-  mappedProps.performSearch("query", "searchProjects")
+  mappedProps.performSearch("query", "searchProjects", someProps)
   expect(dispatch).toBeCalled()
-  expect(performSearch).toBeCalledWith("searchGroup", "query", "searchProjects")
+  expect(performSearch).toBeCalledWith("searchGroup", "query", "searchProjects", someProps)
   expect(mappedProps).toMatchSnapshot()
 })
 

--- a/src/services/Project/Project.js
+++ b/src/services/Project/Project.js
@@ -82,7 +82,7 @@ export const fetchManageableProjects = function(page = null, limit = RESULTS_PER
     return new Endpoint(
       api.projects.managed, {
         schema: [ projectSchema() ],
-        params: {limit: limit, page: (pageToFetch * limit), onlyOwned, onlyEnabled}
+        params: {limit: limit, page: pageToFetch, onlyOwned, onlyEnabled}
       }
     ).execute().then(normalizedResults => {
       dispatch(receiveProjects(normalizedResults.entities))
@@ -174,7 +174,7 @@ export const searchProjects = function(searchCriteria, limit=RESULTS_PER_PAGE) {
         params: {
           q: `%${query}%`,
           onlyEnabled: onlyEnabled ? 'true' : 'false',
-          page: page * limit,
+          page,
           limit,
         }
     }).execute().then(normalizedResults => {

--- a/src/services/Search/Search.js
+++ b/src/services/Search/Search.js
@@ -403,7 +403,7 @@ export const receivedResults = function(searchName, fetchId) {
 }
 
 // async action creators
-export const performSearch = function(searchName, query, asyncSearchAction) {
+export const performSearch = function(searchName, query, asyncSearchAction, props) {
   return function(dispatch) {
     const fetchId = _uniqueId()
     if (!query || query.length < 2) {
@@ -411,7 +411,7 @@ export const performSearch = function(searchName, query, asyncSearchAction) {
     }
 
     const resultsPerPage = _get(query, 'page.resultsPerPage')
-    const actionToDo = asyncSearchAction(query, resultsPerPage)
+    const actionToDo = asyncSearchAction(query, resultsPerPage, props)
 
     if (actionToDo) {
       dispatch(fetchingResults(searchName, fetchId))


### PR DESCRIPTION
* Pass page instead of calculated offset to project APIs as that is what
is now expected by the server as of v4

* Update search framework to accept props that can be passed along to
search functions

* Honor active project filters when additional pages of results are
retrieved by ProjectListWidget