### PR TITLE
Add note that user metrics avg time excludes skipped tasks

### DIFF
--- a/src/components/ChallengeProgress/ChallengeProgress.js
+++ b/src/components/ChallengeProgress/ChallengeProgress.js
@@ -249,6 +249,11 @@ export class ChallengeProgress extends Component {
           <span className="mr-pl-2">
             {Math.floor(seconds / 60)}m {Math.floor(seconds) % 60}s
           </span>
+          {this.props.noteAvgExcludesSkip &&
+            <span className="mr-pl-2">
+              <FormattedMessage {...messages.excludesSkip} />
+            </span>
+          }
         </div>
     }
 

--- a/src/components/ChallengeProgress/Messages.js
+++ b/src/components/ChallengeProgress/Messages.js
@@ -43,4 +43,9 @@ export default defineMessages({
     id: "ChallengeProgress.metrics.averageTime.label",
     defaultMessage: "Avg time per task:"
   },
+
+  excludesSkip: {
+    id: "ChallengeProgress.metrics.excludesSkip.label",
+    defaultMessage: "(excluding skipped tasks)"
+  },
 })

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -344,6 +344,7 @@
   "ChallengeProgress.priority.label": "{priority} Priority Tasks",
   "ChallengeProgress.reviewStatus.label": "Review Status",
   "ChallengeProgress.metrics.averageTime.label": "Avg time per task:",
+  "ChallengeProgress.metrics.excludesSkip.label": "(excluding skipped tasks)",
   "CommentList.controls.viewTask.label": "View Task",
   "CommentList.noComments.label": "No Comments",
   "ConfigureColumnsModal.header": "Choose Columns to Display",

--- a/src/pages/Metrics/blocks/TaskStats.js
+++ b/src/pages/Metrics/blocks/TaskStats.js
@@ -34,6 +34,7 @@ export default class TaskStats extends Component {
            listClassName="mr-mt-3"
            taskMetrics={this.props.taskMetrics}
            prominentCounts
+           noteAvgExcludesSkip
          />
         }
       </QuickWidget>


### PR DESCRIPTION
Add note "(excluding skipped tasks)" to indicate that user metrics task stats average time excludes skipped tasks (after back-end PR maproulette/maproulette2#775)