### PR TITLE
Add ability to edit completion responses after task complete

### DIFF
--- a/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
+++ b/src/components/HOCs/WithCurrentTask/WithCurrentTask.js
@@ -19,7 +19,8 @@ import { taskDenormalizationSchema,
          addTaskBundleComment,
          completeTask,
          completeTaskBundle,
-         updateTaskTags } from '../../../services/Task/Task'
+         updateTaskTags,
+         updateCompletionResponses } from '../../../services/Task/Task'
 import { fetchTaskForReview } from '../../../services/Task/TaskReview/TaskReview'
 import { fetchChallenge, fetchParentProject }
        from '../../../services/Challenge/Challenge'
@@ -264,6 +265,10 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
       else {
         dispatch(updateTaskTags(task.id, tags))
       }
+    },
+
+    saveCompletionResponses: (task, completionResponses) => {
+      dispatch(updateCompletionResponses(task.id, completionResponses))
     },
 
     fetchOSMUser,

--- a/src/components/MarkdownContent/MarkdownTemplate.js
+++ b/src/components/MarkdownContent/MarkdownTemplate.js
@@ -66,7 +66,7 @@ export default class MarkdownTemplate extends Component {
    * a select input field which can be rendered in form later.
    **/
   selectHandler = (text, options) => {
-    const propertyName = options.hash.name
+    const propertyName = options.hash.name || `select`
     const body = this.compileTemplate(text, this.props.properties)
 
     const select =

--- a/src/components/TaskPane/Messages.js
+++ b/src/components/TaskPane/Messages.js
@@ -53,4 +53,9 @@ export default defineMessages({
     id: "Task.pane.lockFailedDialog.prompt",
     defaultMessage: "Task lock could not be acquired. A read-only preview is available."
   },
+
+  saveChangesLabel: {
+    id: "Task.pane.controls.saveChanges.label",
+    defaultMessage: "Save Changes",
+  },
 })

--- a/src/components/TaskPane/TaskInstructions/TaskInstructions.js
+++ b/src/components/TaskPane/TaskInstructions/TaskInstructions.js
@@ -1,9 +1,12 @@
 import React, { Component } from 'react'
+import { FormattedMessage } from 'react-intl'
 import PropTypes from 'prop-types'
 import _get from 'lodash/get'
 import _isEmpty from 'lodash/isEmpty'
+import Button from '../../Button/Button'
 import MarkdownTemplate from '../../MarkdownContent/MarkdownTemplate'
 import AsMappableTask from '../../../interactions/Task/AsMappableTask'
+import messages from '../Messages'
 
 
 /**
@@ -14,6 +17,10 @@ import AsMappableTask from '../../../interactions/Task/AsMappableTask'
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default class TaskInstructions extends Component {
+  state = {
+    responsesChanged: false
+  }
+
   render() {
     const taskInstructions =
         !_isEmpty(this.props.task.instruction) ?
@@ -30,8 +37,21 @@ export default class TaskInstructions extends Component {
         <MarkdownTemplate content={taskInstructions}
                           properties={taskProperties}
                           completionResponses={this.props.completionResponses}
-                          setCompletionResponse={this.props.setCompletionResponse}
-                          disableTemplate={this.props.disableTemplate}/>
+                          setCompletionResponse={(propName, value) => {
+                            this.props.setCompletionResponse(propName, value)
+                            this.setState({responsesChanged: true})
+                          }} />
+        {this.props.disableTemplate && this.state.responsesChanged &&
+          <Button
+            className="mr-button--blue-fill mr-button--small"
+            onClick={() => {
+              this.props.saveCompletionResponses(this.props.task, this.props.completionResponses)
+              this.setState({responsesChanged: false})
+            }}
+          >
+            <FormattedMessage {...messages.saveChangesLabel} />
+          </Button>
+        }
       </div>
     )
   }

--- a/src/components/TaskPane/TaskPane.js
+++ b/src/components/TaskPane/TaskPane.js
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom'
 import _get from 'lodash/get'
 import { generateWidgetId, WidgetDataTarget, widgetDescriptor }
        from '../../services/Widget/Widget'
-import { isFinalStatus }
+import { isCompletionStatus }
        from '../../services/Task/TaskStatus/TaskStatus'
 import WithWidgetWorkspaces
        from '../HOCs/WithWidgetWorkspaces/WithWidgetWorkspaces'
@@ -267,7 +267,7 @@ export class TaskPane extends Component {
             completingTask={this.state.completingTask}
             setCompletionResponse={this.setCompletionResponse}
             completionResponses={completionResponses}
-            disableTemplate={isFinalStatus(this.props.task.status)}
+            disableTemplate={isCompletionStatus(this.props.task.status)}
           />
           {this.state.completingTask && this.state.completingTask === this.props.task.id &&
            <div

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -804,6 +804,7 @@
   "Task.pane.controls.retryLock.label": "Retry Lock",
   "Task.pane.lockFailedDialog.title": "Unable to Lock Task",
   "Task.pane.lockFailedDialog.prompt": "Task lock could not be acquired. A read-only preview is available.",
+  "Task.pane.controls.saveChanges.label": "Save Changes",
   "MobileTask.subheading.instructions": "Instructions",
   "Task.management.heading": "Management Options",
   "Task.management.controls.inspect.label": "Inspect",

--- a/src/services/Server/APIRoutes.js
+++ b/src/services/Server/APIRoutes.js
@@ -119,6 +119,7 @@ const apiRoutes = factory => {
       'testTagFix': factory.post('/change/tag/test'),
       'testCooperativeWork': factory.post('/change/test'),
       'applyTagFix': factory.post('/task/:id/fix/apply'),
+      'updateCompletionResponses': factory.put('/task/:id/responses'),
     },
     'keywords': {
       'find': factory.get('/keywords'),

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -325,6 +325,32 @@ export const bulkTaskStatusChange = function(newStatus, challengeId, criteria) {
 }
 
 /**
+ * Updates the completion responses on a task.
+ */
+export const updateCompletionResponses = function(taskId, completionResponses) {
+  return function(dispatch) {
+    return new Endpoint(
+      api.task.updateCompletionResponses,
+      {variables: {id: taskId},
+       json: completionResponses
+      }
+    ).execute().then(() => {
+      fetchTask(taskId)(dispatch) // Refresh task data
+    }).catch(error => {
+      if (isSecurityError(error)) {
+        dispatch(ensureUserLoggedIn()).then(() =>
+          dispatch(addError(AppErrors.user.unauthorized))
+        )
+      }
+      else {
+        dispatch(addError(AppErrors.task.updateFailure))
+        console.log(error.response || error)
+      }
+    })
+  }
+}
+
+/**
  * Add a comment to the given task, associating the given task status if
  * provided.
  */


### PR DESCRIPTION
- If task has been completed then allow the instruction
template completion responses to be changed and offer a
'save changes' button if they have been.

- If a {{select}} in instruction template does not provide a name value, 
then 'select' will be used as the name (before it was undefined).

Relies on maproulette/maproulette2#782