### PR TITLE
Nest CSV priority rule values with "OR"

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/PriorityRuleGroup.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/PriorityRuleGroup.js
@@ -25,6 +25,13 @@ export const preparePriorityRuleGroupForForm = (ruleObject, isNested=false) => {
       preparedGroup.ruleGroup.rules = combineRulesForForm(
         _map(ruleObject.rules, rule => preparePriorityRuleForForm(rule))
       )
+
+      if (isNested && ruleObject.rules.length !== preparedGroup.ruleGroup.rules &&
+          preparedGroup.ruleGroup.rules.length === 1) {
+        // We did some combining so let's submit the un-nested rule
+        return preparedGroup.ruleGroup.rules[0]
+      }
+
     }
   }
 
@@ -109,9 +116,13 @@ export const normalizeRuleForSaving = (rule, allowCSV=true) => {
   // If there are multiple, comma-separated values, split into separate rules
   // (ignoring commas in quoted strings)
   if (allowCSV && /,/.test(rule.value)) {
-    return _flatten(csvStringToArray(rule.value)).map(value =>
-      normalizeRuleForSaving(Object.assign({}, rule, {value}), false)
-    )
+    let csvRule = {
+      condition: "OR",
+      rules: _flatten(csvStringToArray(rule.value)).map(value =>
+        normalizeRuleForSaving(Object.assign({}, rule, {value}), false)
+      )
+    }
+    return csvRule
   }
 
   // Due to react-jsonschema-form bug #768, the default operator values

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/PriorityRuleGroup.test.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/PriorityRuleGroup.test.js
@@ -133,9 +133,11 @@ describe("preparePriorityRuleGroupForSaving", () => {
     const result =
       JSON.parse(preparePriorityRuleGroupForSaving(basicFormGroup))
 
-    expect(result.rules.length).toBe(2)
-    expect(result.rules[0].value).toEqual("firstTag.foo")
-    expect(result.rules[1].value).toEqual("firstTag.baz")
+    expect(result.rules.length).toBe(1)
+    expect(result.rules[0].rules.length).toBe(2)
+    expect(result.rules[0].condition).toEqual("OR")
+    expect(result.rules[0].rules[0].value).toEqual("firstTag.foo")
+    expect(result.rules[0].rules[1].value).toEqual("firstTag.baz")
   })
 
   test("commas are ignored in quoted strings when splitting comma-separated values", () => {
@@ -146,7 +148,8 @@ describe("preparePriorityRuleGroupForSaving", () => {
       JSON.parse(preparePriorityRuleGroupForSaving(basicFormGroup))
 
     expect(result.rules.length).toBe(1)
-    expect(result.rules[0].value).toEqual("firstTag.foo,baz")
+    expect(result.rules[0].condition).toEqual("OR")
+    expect(result.rules[0].rules[0].value).toEqual("firstTag.foo,baz")
   })
 })
 


### PR DESCRIPTION
CSV priority rule values were always using the
current condition selected. Since this defaults
to 'AND' it could be confusing. CSV priorities
only make sense with 'OR' so create a nested 'OR'
rule for the CSVs.