### PR TITLE
Add ability to invert review and admin tasks table filters

### DIFF
--- a/src/components/AdminPane/HOCs/WithChallengeMetrics/WithChallengeMetrics.js
+++ b/src/components/AdminPane/HOCs/WithChallengeMetrics/WithChallengeMetrics.js
@@ -41,6 +41,7 @@ const WithChallengeMetrics = function(WrappedComponent, applyFilters = false) {
       if (challengeId && props.fetchChallengeActions) {
         this.setState({loading: true})
         const criteria = {filters: _get(props.searchFilters, 'filters')}
+        criteria.invertFields = _get(props.searchCriteria, 'filters.invertFields')
 
         if (props.includeTaskStatuses && this.isFiltering(props.includeTaskStatuses)) {
           criteria.status = _keys(_pickBy(props.includeTaskStatuses)).join(',')
@@ -80,24 +81,29 @@ const WithChallengeMetrics = function(WrappedComponent, applyFilters = false) {
 
       if (challengeId) {
         if (challengeId !== _get(this.props.challenge, 'id')) {
-          this.updateMetrics(this.props)
+          return this.updateMetrics(this.props)
         }
 
         if (this.props.includeTaskStatuses !== prevProps.includeTaskStatuses) {
-          this.updateMetrics(this.props)
+          return this.updateMetrics(this.props)
         }
 
         if (this.props.includeTaskReviewStatuses !== prevProps.includeTaskReviewStatuses) {
-          this.updateMetrics(this.props)
+          return this.updateMetrics(this.props)
         }
 
         if (this.props.includeTaskPriorities !== prevProps.includeTaskPriorities) {
-          this.updateMetrics(this.props)
+          return this.updateMetrics(this.props)
         }
 
         if (!_isEqual(_get(this.props.searchFilters, 'filters'),
                       _get(prevProps.searchFilters, 'filters'))) {
-          this.updateMetrics(this.props)
+          return this.updateMetrics(this.props)
+        }
+
+        if (!_isEqual(_get(this.props.searchCriteria, 'filters.invertFields'),
+                      _get(prevProps.searchCriteria, 'filters.invertFields'))) {
+          return this.updateMetrics(this.props)
         }
       }
     }

--- a/src/components/AdminPane/HOCs/WithChallengeReviewMetrics/WithChallengeReviewMetrics.js
+++ b/src/components/AdminPane/HOCs/WithChallengeReviewMetrics/WithChallengeReviewMetrics.js
@@ -27,6 +27,7 @@ export const WithChallengeReviewMetrics = function(WrappedComponent) {
        _merge(filters, _get(props.searchFilters, 'filters'))
 
       const criteria = {filters}
+      criteria.invertFields = _get(props.searchCriteria, 'filters.invertFields')
 
       if (props.includeTaskStatuses) {
         criteria.filters.status = _keys(_pickBy(props.includeTaskStatuses)).join(',')
@@ -50,23 +51,23 @@ export const WithChallengeReviewMetrics = function(WrappedComponent) {
 
     componentDidUpdate(prevProps) {
       if (_get(prevProps.challenge, 'id') !== _get(this.props.challenge, 'id')) {
-        this.updateMetrics(this.props)
+        return this.updateMetrics(this.props)
       }
 
       if (this.props.includeTaskStatuses !== prevProps.includeTaskStatuses) {
-        this.updateMetrics(this.props)
+        return this.updateMetrics(this.props)
       }
 
       if (this.props.includeTaskReviewStatuses !== prevProps.includeTaskReviewStatuses) {
-        this.updateMetrics(this.props)
+        return this.updateMetrics(this.props)
       }
 
       if (this.props.includeTaskPriorities !== prevProps.includeTaskPriorities) {
-        this.updateMetrics(this.props)
+        return this.updateMetrics(this.props)
       }
 
       if (_get(this.props.searchFilters, 'filters') !== _get(prevProps.searchFilters, 'filters')) {
-        this.updateMetrics(this.props)
+        return this.updateMetrics(this.props)
       }
     }
 

--- a/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
+++ b/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
@@ -9,7 +9,8 @@ import { fromLatLngBounds, GLOBAL_MAPBOUNDS } from '../../../services/MapBounds/
 
 const DEFAULT_PAGE_SIZE = 20
 const DEFAULT_CRITERIA = {sortCriteria: {sortBy: 'name', direction: 'DESC'},
-                          pageSize: DEFAULT_PAGE_SIZE, filters:{}}
+                          pageSize: DEFAULT_PAGE_SIZE, filters:{},
+                          invertFields: {}}
 
 /**
  * WithFilterCriteria keeps track of the current criteria being used
@@ -59,6 +60,15 @@ export const WithFilterCriteria = function(WrappedComponent) {
        const criteria = _cloneDeep(this.state.criteria)
        criteria.filters.taskPropertySearch = propertySearch
        this.setState({criteria})
+     }
+
+     invertField = (fieldName) => {
+       const criteria = _cloneDeep(this.state.criteria)
+       criteria.invertFields[fieldName] = !criteria.invertFields[fieldName]
+       this.setState({criteria})
+       if (this.props.setSearchFilters) {
+         this.props.setSearchFilters(criteria)
+       }
      }
 
      clearTaskPropertyCriteria = () => {
@@ -182,6 +192,7 @@ export const WithFilterCriteria = function(WrappedComponent) {
                            updateReviewTasks={(criteria) => this.update(this.props, criteria)}
                            updateTaskPropertyCriteria={this.updateTaskPropertyCriteria}
                            clearTaskPropertyCriteria={this.clearTaskPropertyCriteria}
+                           invertField={this.invertField}
                            refresh={this.refresh}
                            criteria={criteria}
                            pageSize={criteria.pageSize}

--- a/src/components/TaskAnalysisTable/Messages.js
+++ b/src/components/TaskAnalysisTable/Messages.js
@@ -9,6 +9,16 @@ export default defineMessages({
     defaultMessage: "Actions",
   },
 
+  invertLabel: {
+    id: "TasksTable.invert.abel",
+    defaultMessage: "invert",
+  },
+
+  invertedLabel: {
+    id: "TasksTable.inverted.label",
+    defaultMessage: "inverted",
+  },
+
   idLabel: {
     id: "Task.fields.id.label",
     defaultMessage: "Internal Id",

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import ReactTable from 'react-table'
-import classNames from 'classnames'
 import { FormattedMessage, FormattedDate,
          FormattedTime, injectIntl } from 'react-intl'
 import { Link } from 'react-router-dom'
@@ -50,6 +49,8 @@ import messages from './Messages'
 import 'react-table/react-table.css'
 import './TaskAnalysisTable.scss'
 import TaskAnalysisTableHeader from './TaskAnalysisTableHeader'
+import { ViewCommentsButton, StatusLabel, makeInvertable, makeInputFilter }
+  from './TaskTableHelpers'
 
 // Setup child components with necessary HOCs
 const ViewTaskSubComponent = WithLoadedTask(ViewTask)
@@ -415,7 +416,10 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
 
   columns.reviewRequestedBy = {
     id: 'completedBy',
-    Header: props.intl.formatMessage(messages.reviewRequestedByLabel),
+    Header: makeInvertable(props.intl.formatMessage(messages.reviewRequestedByLabel),
+                           () => props.invertField('completedBy'),
+                           _get(props.criteria, 'invertFields.completedBy')),
+
     accessor: 'completedBy',
     sortable: true,
     filterable: true,
@@ -428,7 +432,8 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
       >
         {_get(row._original.completedBy, 'username') || row._original.completedBy}
       </div>
-    )
+    ),
+    Filter: makeInputFilter(_get(props.criteria, 'invertFields.completedBy')),
   }
 
   columns.reviewedAt = {
@@ -473,7 +478,9 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
 
   columns.reviewedBy = {
     id: 'reviewedBy',
-    Header: props.intl.formatMessage(messages.reviewedByLabel),
+    Header: makeInvertable(props.intl.formatMessage(messages.reviewedByLabel),
+                           () => props.invertField('reviewedBy'),
+                           _get(props.criteria, 'invertFields.reviewedBy')),
     accessor: 'reviewedBy',
     filterable: true,
     sortable: true,
@@ -488,7 +495,8 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
       >
         {row._original.reviewedBy.username || row._original.reviewedBy}
       </div>
-    )
+    ),
+    Filter: makeInputFilter(_get(props.criteria, 'invertFields.reviewedBy')),
   }
 
   columns.reviewStatus = {
@@ -582,32 +590,6 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
   }
 
   return columns
-}
-
-const StatusLabel = props => (
-  <span
-    className={classNames('mr-inline-flex mr-items-center', props.className)}
-  >
-    <span className="mr-w-2 mr-h-2 mr-rounded-full mr-bg-current" />
-    <span className="mr-ml-2 mr-text-xs mr-uppercase mr-tracking-wide">
-      <FormattedMessage {...props.intlMessage} />
-    </span>
-  </span>
-)
-
-const ViewCommentsButton = function(props) {
-  return (
-    <button
-      onClick={props.onClick}
-      className="mr-inline-flex mr-items-center mr-transition mr-text-green-light hover:mr-text-green"
-    >
-      <SvgSymbol
-        sym="comments-icon"
-        viewBox="0 0 20 20"
-        className="mr-fill-current mr-w-4 mr-h-4"
-      />
-    </button>
-  )
 }
 
 TaskAnalysisTable.propTypes = {

--- a/src/components/TaskAnalysisTable/TaskTableHelpers.js
+++ b/src/components/TaskAnalysisTable/TaskTableHelpers.js
@@ -1,0 +1,73 @@
+import React from 'react'
+import classNames from 'classnames'
+import { FormattedMessage } from 'react-intl'
+import SvgSymbol from '../SvgSymbol/SvgSymbol'
+import messages from './Messages'
+
+/**
+ * Helper functions for building components related to tables.
+ */
+
+
+ export const StatusLabel = props => (
+    <span
+      className={classNames('mr-inline-flex mr-items-center', props.className)}
+    >
+      <span className="mr-w-2 mr-h-2 mr-rounded-full mr-bg-current" />
+      <span className="mr-ml-2 mr-text-xs mr-uppercase mr-tracking-wide">
+        <FormattedMessage {...props.intlMessage} />
+      </span>
+    </span>
+  )
+
+ export const ViewCommentsButton = function(props) {
+   return (
+     <button
+       onClick={props.onClick}
+       className="mr-inline-flex mr-items-center mr-transition mr-text-green-lighter hover:mr-text-white"
+     >
+       <SvgSymbol
+         sym="comments-icon"
+         viewBox="0 0 20 20"
+         className="mr-fill-current mr-w-4 mr-h-4"
+       />
+     </button>
+   )
+ }
+
+ export const makeInvertable = function(column, invert, isInverted) {
+   return (
+     <div className="mr-w-full">
+       {column}
+       <div className="mr-pl-2">
+         <button
+           className={classNames("mr-text-current mr-justify-center",
+                                {"mr-text-white-40": !isInverted,
+                                 "mr-text-pink": isInverted})}
+           onClick={(e) => {
+             e.stopPropagation()
+             invert()
+           }}
+         >
+           {isInverted ?
+             <FormattedMessage {...messages.invertedLabel} /> :
+             <FormattedMessage {...messages.invertLabel} />
+           }
+         </button>
+       </div>
+     </div>
+   )
+ }
+
+ export const makeInputFilter = (inverted) => {
+   return (
+     ({filter, onChange}) => (
+         <input
+           onChange={event => onChange(event.target.value)}
+           value={filter ? filter.value : ''}
+           style={{width: '100%'}}
+           className={classNames({"mr-line-through": inverted})}
+         />
+       )
+   )
+ }

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -680,6 +680,8 @@
   "TagDiffVisualization.controls.restoreFix.tooltip": "Restore initial proposed tags",
   "TagDiffVisualization.controls.tagName.placeholder": "Tag Name",
   "Admin.TaskAnalysisTable.columnHeaders.actions": "Actions",
+  "TasksTable.invert.abel": "invert",
+  "TasksTable.inverted.label": "inverted",
   "Task.fields.id.label": "Internal Id",
   "Task.fields.featureId.label": "Feature Id",
   "Task.fields.status.label": "Status",

--- a/src/pages/Review/TasksReview/FilterSuggestTextBox.js
+++ b/src/pages/Review/TasksReview/FilterSuggestTextBox.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import classNames from 'classnames'
 import _filter from 'lodash/filter'
 import _toLower from 'lodash/toLower'
 import _find from 'lodash/find'
@@ -41,7 +42,10 @@ export default class FilterSuggestTextBox extends Component {
 
     return (
       <AutosuggestTextBox
-        inputClassName="mr-py-2 mr-px-4 mr-border-none mr-placeholder-white-50 mr-text-white mr-rounded mr-bg-black-15 mr-shadow-inner"
+        inputClassName={classNames(
+          "mr-py-2 mr-px-4 mr-border-none mr-placeholder-white-50 ",
+          "mr-text-white mr-rounded mr-bg-black-15 mr-shadow-inner",
+          this.props.className)}
         onChange={item => item ? this.props.onChange(item) : null}
         search={searchQuery => this.setState({searchQuery})}
         searchResults={this.searchResults()}

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -35,7 +35,8 @@ import WithConfigurableColumns from '../../../components/HOCs/WithConfigurableCo
 import WithCurrentUser from '../../../components/HOCs/WithCurrentUser/WithCurrentUser'
 import { mapColors } from '../../../interactions/User/AsEndUser'
 import messages from './Messages'
-
+import { ViewCommentsButton, StatusLabel, makeInvertable, makeInputFilter }
+  from '../../../components/TaskAnalysisTable/TaskTableHelpers'
 import { Link } from 'react-router-dom'
 import ReactTable from 'react-table'
 
@@ -405,7 +406,9 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
 
   columns.status = {
     id: 'status',
-    Header: props.intl.formatMessage(messages.statusLabel),
+    Header: makeInvertable(props.intl.formatMessage(messages.statusLabel),
+                           () => props.invertField('status'),
+                           _get(criteria, 'invertFields.status')),
     accessor: 'status',
     sortable: true,
     filterable: true,
@@ -438,6 +441,8 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
           onChange={event => onChange(event.target.value)}
           style={{ width: '100%' }}
           value={filter ? filter.value : 'all'}
+          className={classNames({"mr-line-through":
+            filter && filter.value !== 'all' && _get(criteria, 'invertFields.status')})}
         >
           {options}
         </select>
@@ -447,7 +452,9 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
 
   columns.priority = {
     id: 'priority',
-    Header: props.intl.formatMessage(messages.priorityLabel),
+    Header: makeInvertable(props.intl.formatMessage(messages.priorityLabel),
+                           () => props.invertField('priority'),
+                           _get(criteria, 'invertFields.priority')),
     accessor: 'priority',
     sortable: true,
     filterable: true,
@@ -478,6 +485,8 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
           onChange={event => onChange(event.target.value)}
           style={{ width: '100%' }}
           value={filter ? filter.value : 'all'}
+          className={classNames({"mr-line-through":
+            filter && filter.value !== 'all' && _get(criteria, 'invertFields.priority')})}
         >
           {options}
         </select>
@@ -487,7 +496,9 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
 
   columns.reviewRequestedBy = {
     id: 'reviewRequestedBy',
-    Header: props.intl.formatMessage(messages.reviewRequestedByLabel),
+    Header: makeInvertable(props.intl.formatMessage(messages.reviewRequestedByLabel),
+                           () => props.invertField('reviewRequestedBy'),
+                           _get(criteria, 'invertFields.reviewRequestedBy')),
     accessor: 'reviewRequestedBy',
     filterable: true,
     sortable: false,
@@ -500,12 +511,15 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
       >
         {_get(row._original.reviewRequestedBy, 'username')}
       </div>
-    )
+    ),
+    Filter: makeInputFilter(_get(criteria, 'invertFields.reviewRequestedBy')),
   }
 
   columns.challenge = {
     id: 'challenge',
-    Header: props.intl.formatMessage(messages.challengeLabel),
+    Header: makeInvertable(props.intl.formatMessage(messages.challengeLabel),
+                           () => props.invertField('challenge'),
+                           _get(criteria, 'invertFields.challenge')),
     accessor: 'parent',
     filterable: true,
     sortable: false,
@@ -527,6 +541,8 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
           onChange={onChange}
           value={filter ? filter.value : ""}
           itemList={props.reviewChallenges}
+          className={classNames({"mr-line-through":
+            filter && _get(criteria, 'invertFields.challenge')})}
         />
       )
     }
@@ -534,7 +550,9 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
 
   columns.project = {
     id: 'project',
-    Header: props.intl.formatMessage(messages.projectLabel),
+    Header: makeInvertable(props.intl.formatMessage(messages.projectLabel),
+                           () => props.invertField('project'),
+                           _get(criteria, 'invertFields.project')),
     filterable: true,
     sortable: false,
     exportable: t => _get(t.parent, 'parent.displayName'),
@@ -555,6 +573,8 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
           onChange={onChange}
           value={filter ? filter.value : ""}
           itemList={_map(props.reviewProjects, p => ({id: p.id, name: p.displayName}))}
+          className={classNames({"mr-line-through":
+            filter && _get(criteria, 'invertFields.project')})}
         />
       )
     }
@@ -615,7 +635,9 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
 
   columns.reviewedBy = {
     id: 'reviewedBy',
-    Header: props.intl.formatMessage(messages.reviewedByLabel),
+    Header: makeInvertable(props.intl.formatMessage(messages.reviewedByLabel),
+                           () => props.invertField('reviewedBy'),
+                           _get(criteria, 'invertFields.reviewedBy')),
     accessor: 'reviewedBy',
     filterable: true,
     sortable: false,
@@ -628,12 +650,15 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
       >
         {row._original.reviewedBy ? row._original.reviewedBy.username : "N/A"}
       </div>
-    )
+    ),
+    Filter: makeInputFilter(_get(criteria, 'invertFields.reviewedBy'))
   }
 
   columns.reviewStatus = {
     id: 'reviewStatus',
-    Header: props.intl.formatMessage(messages.reviewStatusLabel),
+    Header: makeInvertable(props.intl.formatMessage(messages.reviewStatusLabel),
+                           () => props.invertField('reviewStatus'),
+                           _get(criteria, 'invertFields.reviewStatus')),
     accessor: 'reviewStatus',
     sortable: true,
     filterable: true,
@@ -681,6 +706,8 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
           onChange={event => onChange(event.target.value)}
           style={{ width: '100%' }}
           value={filter ? filter.value : 'all'}
+          className={classNames({"mr-line-through":
+            filter && filter.value !== 'all' && _get(criteria, 'invertFields.reviewStatus')})}
         >
           {options}
         </select>
@@ -805,32 +832,6 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
   }
 
   return columns
-}
-
-const StatusLabel = props => (
-  <span
-    className={classNames('mr-inline-flex mr-items-center', props.className)}
-  >
-    <span className="mr-w-2 mr-h-2 mr-rounded-full mr-bg-current" />
-    <span className="mr-ml-2 mr-text-xs mr-uppercase mr-tracking-wide">
-      <FormattedMessage {...props.intlMessage} />
-    </span>
-  </span>
-)
-
-const ViewCommentsButton = function(props) {
-  return (
-    <button
-      onClick={props.onClick}
-      className="mr-inline-flex mr-items-center mr-transition mr-text-green-lighter hover:mr-text-white"
-    >
-      <SvgSymbol
-        sym="comments-icon"
-        viewBox="0 0 20 20"
-        className="mr-fill-current mr-w-4 mr-h-4"
-      />
-    </button>
-  )
 }
 
 export default WithCurrentUser(WithConfigurableColumns(

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -35,7 +35,7 @@ import { RECEIVE_CHALLENGES, REMOVE_CHALLENGE }
 import { ChallengeStatus } from './ChallengeStatus/ChallengeStatus'
 import { zeroTaskActions } from '../Task/TaskAction/TaskAction'
 import { parseQueryString, RESULTS_PER_PAGE, SortOptions,
-         generateSearchParametersString }
+         generateSearchParametersString, PARAMS_MAP }
        from '../Search/Search'
 import startOfDay from 'date-fns/start_of_day'
 
@@ -87,13 +87,18 @@ const buildQueryFilters = function(criteria) {
   const taskId = filters.id
   const reviewRequestedBy = filters.reviewRequestedBy
   const reviewedBy = filters.reviewedBy
+  const completedBy = filters.completedBy
+  const invf = _map(criteria.invertFields, (v, k) => v ? PARAMS_MAP[k] : undefined)
+
   return (
     `status=${_join(filters.status, ',')}&` +
     `priority=${_join(filters.priorities, ',')}&` +
     `reviewStatus=${_join(filters.reviewStatus, ',')}` +
     `${taskId ? `&tid=${taskId}` : ""}` +
+    `${completedBy ? `&m=${completedBy}` : ""}` +
     `${reviewRequestedBy ? `&o=${reviewRequestedBy}` : ""}` +
-    `${reviewedBy ? `&r=${reviewedBy}` : ""}`)
+    `${reviewedBy ? `&r=${reviewedBy}` : ""}` +
+    `&invf=${invf.join(',')}`)
 }
 
 /**
@@ -364,7 +369,9 @@ export const fetchChallengeActions = function(challengeId = null, suppressReceiv
   let searchParameters = {}
   if (criteria) {
     searchParameters = generateSearchParametersString(_get(criteria, 'filters', {}),
-                                                      criteria.boundingBox)
+                                                      criteria.boundingBox,
+                                                      false, false, null,
+                                                      _get(criteria, 'invertFields', {}))
   }
 
   return function(dispatch) {

--- a/src/services/Search/Search.js
+++ b/src/services/Search/Search.js
@@ -61,6 +61,24 @@ export const SortOptions = {
   default: SORT_DEFAULT,
 }
 
+// Map for the search parameters expected by server
+export const PARAMS_MAP = {
+  reviewRequestedBy: 'o',
+  reviewedBy: 'r',
+  completedBy: 'm',
+  challengeId: 'cid',
+  challenge: 'cs',
+  projectId: 'pid',
+  project: 'ps',
+  status: 'tStatus',
+  priority: 'tp',
+  priorities: 'priorities',
+  reviewStatus: 'trStatus',
+  id: 'tid',
+  difficulty: 'cd',
+  tags: 'tt'
+}
+
 
 /** Returns object containing localized labels  */
 export const sortLabels = intl => _fromPairs(
@@ -113,77 +131,108 @@ export const parseQueryString = function(rawQueryText) {
  * server accepts for various API endpoints
  */
 export const generateSearchParametersString = (filters, boundingBox, savedChallengesOnly,
-                                               excludeOtherReviewers, queryString) => {
+                                               excludeOtherReviewers, queryString,
+                                               invertFields = {}) => {
   const searchParameters = {}
+  const invf = []
+
   if (filters.reviewRequestedBy) {
-    searchParameters.o = filters.reviewRequestedBy
+    searchParameters[PARAMS_MAP.reviewRequestedBy] = filters.reviewRequestedBy
+    if (invertFields.reviewRequestedBy) {
+      invf.push(PARAMS_MAP.reviewRequestedBy)
+    }
   }
   if (filters.reviewedBy) {
-    searchParameters.r = filters.reviewedBy
+    searchParameters[PARAMS_MAP.reviewedBy] = filters.reviewedBy
+    if (invertFields.reviewedBy) {
+      invf.push(PARAMS_MAP.reviewedBy)
+    }
   }
   if (filters.completedBy) {
-    searchParameters.m = filters.completedBy
+    searchParameters[PARAMS_MAP.completedBy] = filters.completedBy
+    if (invertFields.completedBy) {
+      invf.push(PARAMS_MAP.completedBy)
+    }
   }
 
   if (filters.challengeId) {
-    searchParameters.cid = filters.challengeId
+    searchParameters.cid = !_isArray(filters.challengeId) ?
+      filters.challengeId :
+      searchParameters[PARAMS_MAP.challengeId] = filters.challengeId.join(',')
+
+    if (invertFields.challenge) {
+      invf.push(PARAMS_MAP.challengeId)
+    }
   }
   else if (filters.challenge) {
-    searchParameters.cs = filters.challenge
+    searchParameters[PARAMS_MAP.challenge] = filters.challenge
+    if (invertFields.challenge) {
+      invf.push(PARAMS_MAP.challenge)
+    }
   }
 
   if (filters.projectId) {
-    searchParameters.pid = filters.projectId
+    searchParameters[PARAMS_MAP.projectId] = filters.projectId
+    if (invertFields.project) {
+      invf.push(PARAMS_MAP.projectId)
+    }
   }
   else if (filters.project) {
-    searchParameters.ps = filters.project
+    searchParameters[PARAMS_MAP.project] = filters.project
+    if (invertFields.project) {
+      invf.push(PARAMS_MAP.project)
+    }
   }
   if (filters.status && filters.status !== "all") {
     if (Array.isArray(filters.status)){
-      searchParameters.tStatus = filters.status.join(',')
+      searchParameters[PARAMS_MAP.status] = filters.status.join(',')
     }
     else {
-      searchParameters.tStatus = filters.status
+      searchParameters[PARAMS_MAP.status] = filters.status
+    }
+    if (invertFields.status) {
+      invf.push(PARAMS_MAP.status)
     }
   }
   if (filters.priority && filters.priority !== "all") {
-    searchParameters.tp = filters.priority
+    searchParameters[PARAMS_MAP.priority] = filters.priority
+    if (invertFields.priority) {
+      invf.push(PARAMS_MAP.priority)
+    }
   }
   if (filters.priorities && filters.priorities !== "all") {
     if (Array.isArray(filters.priorities)){
-      searchParameters.priorities = filters.priorities.join(',')
+      searchParameters[PARAMS_MAP.priorities] = filters.priorities.join(',')
     }
     else {
-      searchParameters.priorities = filters.priorities
+      searchParameters[PARAMS_MAP.priorities] = filters.priorities
+    }
+    if (invertFields.priorities) {
+      invf.push(PARAMS_MAP.priorities)
     }
   }
   if (filters.reviewStatus && filters.reviewStatus !== "all") {
     if (Array.isArray(filters.reviewStatus)){
-      searchParameters.trStatus = filters.reviewStatus.join(',')
+      searchParameters[PARAMS_MAP.reviewStatus] = filters.reviewStatus.join(',')
     }
     else {
-      searchParameters.trStatus = filters.reviewStatus
+      searchParameters[PARAMS_MAP.reviewStatus] = filters.reviewStatus
+    }
+    if (invertFields.reviewStatus) {
+      invf.push(PARAMS_MAP.reviewStatus)
     }
   }
   if (filters.reviewedAt) {
     searchParameters.startDate = format(filters.reviewedAt, 'YYYY-MM-DD')
     searchParameters.endDate = format(filters.reviewedAt, 'YYYY-MM-DD')
   }
-  if (filters.challengeId) {
-    if (!_isArray(filters.challengeId)) {
-      searchParameters.cid = filters.challengeId
-    }
-    else {
-      searchParameters.cid = filters.challengeId.join(',')
-    }
-  }
 
   if (filters.id) {
-    searchParameters.tid = filters.id
+    searchParameters[PARAMS_MAP.id] = filters.id
   }
 
   if (_isFinite(filters.difficulty)) {
-    searchParameters.cd = filters.difficulty
+    searchParameters[PARAMS_MAP.difficulty] = filters.difficulty
   }
 
   if (boundingBox) {
@@ -229,14 +278,15 @@ export const generateSearchParametersString = (filters, boundingBox, savedChalle
     }
 
     if (queryParts.query.length > 0) {
-      searchParameters.cs = queryParts.query
+      searchParameters[PARAMS_MAP.challenge] = queryParts.query
     }
   }
 
   if (filters.tags) {
-    searchParameters.tt = filters.tags
+    searchParameters[PARAMS_MAP.tags] = filters.tags
   }
 
+  searchParameters.invf = invf.join(',')
   return searchParameters
 }
 

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -73,7 +73,8 @@ export const fetchBoundedTasks = function(criteria, limit=50, skipDispatch=false
     const searchParameters = generateSearchParametersString(filters,
                                                             null,
                                                             _get(criteria, 'savedChallengesOnly'),
-                                                            null)
+                                                            null, null,
+                                                            _get(criteria, 'invertFields'))
     const includeTags = _get(criteria, 'includeTags', false)
 
     // If we don't have a challenge Id then we need to do some limiting.

--- a/src/services/Task/Task.js
+++ b/src/services/Task/Task.js
@@ -302,7 +302,8 @@ export const bulkTaskStatusChange = function(newStatus, challengeId, criteria) {
                                                             criteria.boundingBox,
                                                             _get(criteria, 'savedChallengesOnly'),
                                                             null,
-                                                            criteria.searchQuery)
+                                                            criteria.searchQuery,
+                                                            _get(criteria, 'invertFields'))
     searchParameters.cid = challengeId
 
     return new Endpoint(

--- a/src/services/Task/TaskClusters.js
+++ b/src/services/Task/TaskClusters.js
@@ -59,7 +59,8 @@ export const fetchTaskClusters = function(challengeId, criteria, points=25) {
                                                             criteria.boundingBox,
                                                             _get(criteria, 'savedChallengesOnly'),
                                                             null,
-                                                            criteria.searchQuery)
+                                                            criteria.searchQuery,
+                                                            _get(criteria, 'invertFields'))
     searchParameters.cid = challengeId
 
     // If we don't have a challenge Id then we need to do some limiting.

--- a/src/services/Task/TaskReview/TaskReview.js
+++ b/src/services/Task/TaskReview/TaskReview.js
@@ -119,7 +119,9 @@ const generateReviewSearch = function(criteria, reviewTasksType = ReviewTasksTyp
   const searchParameters = generateSearchParametersString(_get(criteria, 'filters', {}),
                                                        criteria.boundingBox,
                                                        _get(criteria, 'savedChallengesOnly'),
-                                                       _get(criteria, 'excludeOtherReviewers'))
+                                                       _get(criteria, 'excludeOtherReviewers'),
+                                                       null,
+                                                       _get(criteria, 'invertFields', {}))
 
   const mappers = (reviewTasksType === ReviewTasksType.myReviewedTasks) ? [userId] : []
   const reviewers = (reviewTasksType === ReviewTasksType.reviewedByMe) ? [userId] : []
@@ -158,7 +160,9 @@ export const fetchClusteredReviewTasks = function(reviewTasksType, criteria={}) 
   const searchParameters = generateSearchParametersString(_get(criteria, 'filters', {}),
                                                           criteria.boundingBox,
                                                           _get(criteria, 'savedChallengesOnly'),
-                                                          _get(criteria, 'excludeOtherReviewers'))
+                                                          _get(criteria, 'excludeOtherReviewers'),
+                                                          null,
+                                                          _get(criteria, 'invertFields', {}))
   return function(dispatch) {
     const type = determineType(reviewTasksType)
     const fetchId = uuidv1()
@@ -208,7 +212,9 @@ export const loadNextReviewTask = function(criteria={}, lastTaskId) {
   const searchParameters = generateSearchParametersString(_get(criteria, 'filters', {}),
                                                        criteria.boundingBox,
                                                        _get(criteria, 'savedChallengesOnly'),
-                                                       _get(criteria, 'excludeOtherReviewers'))
+                                                       _get(criteria, 'excludeOtherReviewers'),
+                                                       null,
+                                                       _get(criteria, 'invertFields', {}))
 
   return function(dispatch) {
     const params = {sort, order, ...searchParameters}
@@ -282,7 +288,8 @@ export const removeReviewRequest = function(challengeId, taskIds, criteria = nul
                                      criteria.boundingBox,
                                      null,
                                      null,
-                                     criteria.searchQuery)
+                                     criteria.searchQuery,
+                                     criteria.invertFields)
     searchParameters.cid = challengeId
     searchParameters.ids = taskIds ? taskIds.join(',') : null
 

--- a/src/services/Task/TaskReview/TaskReviewNeeded.js
+++ b/src/services/Task/TaskReview/TaskReviewNeeded.js
@@ -42,7 +42,9 @@ export const fetchReviewNeededTasks = function(criteria, limit=50) {
   const searchParameters = generateSearchParametersString(_get(criteria, 'filters', {}),
                                                           criteria.boundingBox,
                                                           _get(criteria, 'savedChallengesOnly'),
-                                                          _get(criteria, 'excludeOtherReviewers'))
+                                                          _get(criteria, 'excludeOtherReviewers'),
+                                                          null,
+                                                          _get(criteria, 'invertFields', {}))
   const includeTags = criteria.includeTags
 
   return function(dispatch) {

--- a/src/services/Task/TaskReview/TaskReviewed.js
+++ b/src/services/Task/TaskReview/TaskReviewed.js
@@ -43,7 +43,11 @@ export const fetchReviewedTasks = function(userId, criteria, asReviewer=false, a
   const sort = sortBy ? _snakeCase(sortBy) : null
   const page = _get(criteria, 'page', 0)
 
-  const searchParameters = generateSearchParametersString(_get(criteria, 'filters', {}), criteria.boundingBox)
+  const searchParameters =
+    generateSearchParametersString(_get(criteria, 'filters', {}),
+                                   criteria.boundingBox,
+                                   false, false, null,
+                                   _get(criteria, 'invertFields', {}))
   const mappers = asMapper ? [userId] : []
   const reviewers = asReviewer ? [userId] : []
 


### PR DESCRIPTION
* For review add ability to invert search filters:
  reviewStatus, status, priority, reviewRequestedBy, reviewedBy,
  challenge, project

* For admin tasks table add ability to filter by reviewedBy
  and mapper

* Added new constant Search.PARAMS_MAP to map between front end filters and the parameters the server is expecting (eg. challengeId: 'cid') 

* Created new TableHelper and moved shared methods between AdminTasksTable and TasksReviewTable