### PR TITLE
When rendering instruction form bug with ' and mustache tags

### DIFF
--- a/src/components/MarkdownContent/MarkdownTemplate.js
+++ b/src/components/MarkdownContent/MarkdownTemplate.js
@@ -69,6 +69,13 @@ export default class MarkdownTemplate extends Component {
     const propertyName = options.hash.name || `select`
     const body = this.compileTemplate(text, this.props.properties)
 
+    // Quotes get turned into html entities by markdown compiler
+    const quoted_entities = {
+      '&#039;': "'",
+      '&#x27;': "'",
+      '&quot;': '"'
+    };
+
     const select =
       <li key={_uniqueId(propertyName)} className="mr-pb-1">
         <select onChange={(e) => this.selectResponse(propertyName, e.target.value)}
@@ -78,10 +85,12 @@ export default class MarkdownTemplate extends Component {
           <option key="0" value=""></option>
           {
             _map(_split(options.hash.values, ','), (value, index) =>
-              <option key={index} value={value}>{value}</option>)
+              <option key={index} value={value}>
+                {value.replace(/&#?\w+;/, match => quoted_entities[match])}
+              </option>)
           }
         </select>
-        <label className="mr-pl-2">{body}</label>
+        <label className="mr-pl-2" dangerouslySetInnerHTML={{__html:body}} />
       </li>
 
     const questions = this.state.questions


### PR DESCRIPTION
* Mustache tags inside a {{select "..."}} were being rendered
  as html

* Select values with a ' (eg. it's) were being shown as html
  entities.

closes #1239 