### PR TITLE
Various minor Teams fixes

### DIFF
--- a/src/components/HOCs/WithWidgetWorkspaces/WithWidgetWorkspaces.js
+++ b/src/components/HOCs/WithWidgetWorkspaces/WithWidgetWorkspaces.js
@@ -130,6 +130,10 @@ export const WithWidgetWorkspaces = function(WrappedComponent,
         // current minimums, fill them in from the widget descriptors
         _each(configuration.layout, (widgetLayout, index) => {
           const descriptor = widgetDescriptor(configuration.widgets[index].widgetKey)
+          if (!descriptor) {
+            return
+          }
+
           if (!_isFinite(widgetLayout.w)) {
             widgetLayout.w = descriptor.defaultWidth
           }

--- a/src/components/Teams/EditTeam/EditTeam.js
+++ b/src/components/Teams/EditTeam/EditTeam.js
@@ -4,6 +4,7 @@ import { useMutation } from '@apollo/client'
 import Form from 'react-jsonschema-form'
 import { FormattedMessage } from 'react-intl'
 import _isFinite from 'lodash/isFinite'
+import _isEmpty from 'lodash/isEmpty'
 import AppErrors from '../../../services/Error/AppErrors'
 import { jsSchema, uiSchema } from './TeamSchema'
 import BusySpinner from '../../BusySpinner/BusySpinner'
@@ -49,17 +50,19 @@ export const EditTeam = props => {
            type="button"
            className="mr-button mr-button--green-lighter mr-ml-4"
            onClick={() => {
-             if (_isFinite(teamFields.id)) {
-               updateTeam({variables: teamFields})
-             }
-             else {
-              createTeam({
-                variables: teamFields,
-                refetchQueries: ['MyTeams'],
-              })
-              .catch(error => {
-                  props.addErrorWithDetails(AppErrors.team.failure, error.message)
-              })
+             if (!_isEmpty(teamFields)) {
+               if (_isFinite(teamFields.id)) {
+                 updateTeam({variables: teamFields})
+               }
+               else {
+                 createTeam({
+                   variables: teamFields,
+                   refetchQueries: ['MyTeams'],
+                 })
+                 .catch(error => {
+                     props.addErrorWithDetails(AppErrors.team.failure, error.message)
+                 })
+               }
              }
              props.finish()
            }}

--- a/src/components/Widgets/TeamsWidget/TeamsWidget.js
+++ b/src/components/Widgets/TeamsWidget/TeamsWidget.js
@@ -16,7 +16,8 @@ const descriptor = {
   label: messages.title,
   targets: [WidgetDataTarget.user],
   minWidth: 3,
-  defaultWidth: 4,
+  minHeight: 3,
+  defaultWidth: 6,
   defaultHeight: 10,
 }
 


### PR DESCRIPTION
* Don't submit update if team hasn't been edited. Fixes #1240

* Adjust default and minimum widget layout

* Handle missing descriptor (due to removed widget) when attempting to
honor any updated layout minimums