### PR TITLE
Incorporate grants on project objects

### DIFF
--- a/src/components/AdminPane/HOCs/WithManageableProjects/WithManageableProjects.js
+++ b/src/components/AdminPane/HOCs/WithManageableProjects/WithManageableProjects.js
@@ -117,7 +117,7 @@ const mapStateToProps = state => ({
   entities: state.entities
 })
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch, ownProps) => {
   const actions = bindActionCreators({
     fetchManageableProjects,
     fetchProject,
@@ -142,7 +142,7 @@ const mapDispatchToProps = dispatch => {
 
   actions.toggleProjectEnabled = project => {
     const updatedProject = Object.assign({}, project, {enabled: !project.enabled})
-    return dispatch(saveProject(updatedProject))
+    return dispatch(saveProject(updatedProject, ownProps.user))
   }
 
   return actions

--- a/src/components/AdminPane/Manage/EditProject/EditProject.js
+++ b/src/components/AdminPane/Manage/EditProject/EditProject.js
@@ -50,7 +50,7 @@ export class EditProject extends Component {
         formData.name = _snakeCase(formData.displayName).replace(/^home_/, 'project_')
       }
 
-      this.props.saveProject(formData).then(project => {
+      this.props.saveProject(formData, this.props.user).then(project => {
         if (project) {
           this.props.history.push(`/admin/project/${project.id}`)
         }


### PR DESCRIPTION
* When determining the roles a user has on a project, combine the
grants on both the user object and the project object to help prevent
erroneous security errors from stale data

* Refresh the user data after a new project is created, as that user's
grants have almost certainly changed

* Remove call to server assigning project creator an admin role after
project creation, as the server now does that automatically