### PR TITLE
Fix inaccessible Teams page controls

### DIFF
--- a/src/components/Teams/EditTeam/EditTeam.js
+++ b/src/components/Teams/EditTeam/EditTeam.js
@@ -39,7 +39,7 @@ export const EditTeam = props => {
         <button
           type="button"
           className="mr-button mr-button--white"
-          onClick={props.finish}
+          onClick={() => props.finish(false)}
         >
           <FormattedMessage {...messages.cancelLabel} />
         </button>
@@ -64,7 +64,7 @@ export const EditTeam = props => {
                  })
                }
              }
-             props.finish()
+             props.finish(true)
            }}
          >
            <FormattedMessage {...messages.saveLabel} />

--- a/src/components/Teams/MyTeams/MyTeams.js
+++ b/src/components/Teams/MyTeams/MyTeams.js
@@ -20,7 +20,8 @@ import messages from './Messages'
  */
 export const MyTeams = function(props) {
   const { loading, error, data, refetch } = useQuery(MY_TEAMS, {
-    variables: { userId: props.user.id }
+    variables: { userId: props.user.id },
+    partialRefetch: true,
   })
 
   // Refresh the teams when this component updates to avoid stale data. It's

--- a/src/components/Teams/ViewTeam/ViewTeam.js
+++ b/src/components/Teams/ViewTeam/ViewTeam.js
@@ -15,7 +15,8 @@ import messages from './Messages'
 
 export const ViewTeam = props => {
   const { loading, error, data, refetch } = useQuery(TEAM_USERS, {
-    variables: { teamId: props.team.id }
+    variables: { teamId: props.team.id },
+    partialRefetch: true,
   })
 
   useEffect(() => {

--- a/src/pages/Teams/Teams.js
+++ b/src/pages/Teams/Teams.js
@@ -38,7 +38,12 @@ export const Teams = props => {
       <EditTeam
         {...props}
         team={editingTeam}
-        finish={() => setEditingTeam(null)}
+        finish={success => {
+          setEditingTeam(null)
+          if (success) {
+            setViewingTeam(null)
+          }
+        }}
       />
     )
 
@@ -119,7 +124,7 @@ export const Teams = props => {
             </div>
           </div>
         </div>
-        <div className="mr-mt-12 mr-cards-inverse mr-bg-black-10 mr-rounded mr-p-4 mr-pb-8">
+        <div className="mr-mt-12 mr-cards-inverse mr-bg-black-10 mr-rounded mr-p-4 mr-pb-8 mr-relative mr-z-5">
           <div className="mr-flex mr-justify-between mr-items-center mr-mb-4">
             <div className="mr-text-md mr-text-yellow">
               <FormattedMessage {...subheader} />


### PR DESCRIPTION
* Fix controls that weren't clickable because they were technically
obscured by a (transparent) portion of the header image

* If user is viewing a team when initiating creation of a new one, take
them to My Teams view after successful creation