### PR TITLE
Suspend clickouts while ConfirmAction is active

### DIFF
--- a/src/components/ConfirmAction/ConfirmAction.js
+++ b/src/components/ConfirmAction/ConfirmAction.js
@@ -6,6 +6,7 @@ import _cloneDeep from 'lodash/cloneDeep'
 import Modal from '../Modal/Modal'
 import External from '../External/External'
 import SvgSymbol from '../SvgSymbol/SvgSymbol'
+import { ExternalContext } from '../External/External'
 import messages from './Messages'
 import './ConfirmAction.scss'
 
@@ -21,6 +22,8 @@ import './ConfirmAction.scss'
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default class ConfirmAction extends Component {
+  static contextType = ExternalContext
+
   originalAction = null
 
   state = {
@@ -34,15 +37,21 @@ export default class ConfirmAction extends Component {
       }
     }
     else {
+      // Suspend clickout so that users can interact with our modal
+      this.context.suspendClickout(true)
       this.setState({confirming: true, originalEvent: _cloneDeep(e)})
     }
   }
 
-  cancel = () => this.setState({confirming: false})
+  cancel = () => {
+    this.context.suspendClickout(false)
+    this.setState({confirming: false})
+  }
 
   proceed = () => {
     const event = this.state.originalEvent
 
+    this.context.suspendClickout(false)
     this.setState({confirming: false, originalEvent: null})
     if (this.originalAction) {
       this.originalAction(event)
@@ -115,7 +124,7 @@ export default class ConfirmAction extends Component {
     return (
       <React.Fragment>
         {ControlWithConfirmation}
-        {this.modal()}
+        {this.state.confirming && this.modal()}
       </React.Fragment>
     )
   }

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -3,8 +3,11 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import wrapWithClickout from 'react-clickout'
 import SvgSymbol from '../SvgSymbol/SvgSymbol'
+import { ExternalContext } from '../External/External'
 
 class Dropdown extends Component {
+  static contextType = ExternalContext
+
   state = {
     isVisible: false,
   }
@@ -18,7 +21,9 @@ class Dropdown extends Component {
   }
 
   handleClickout() {
-    this.closeDropdown()
+    if (!this.context.clickoutSuspended) {
+      this.closeDropdown()
+    }
   }
 
   render() {

--- a/src/components/External/External.js
+++ b/src/components/External/External.js
@@ -1,10 +1,24 @@
-import { Component } from 'react'
+import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 
 const modalRoot = document.getElementById('external-root')
 
-class External extends Component {
+/**
+ * Context that can be used to temporarily suspend clickouts for components
+ * making use of External (which aren't otherwise detected as proper children
+ * by react-clickout since they've been moved around in the DOM). Components
+ * making use of react-clickout should check this context to see if any child
+ * components wish to temporarily suspend clickouts
+ */
+export const ExternalContext = React.createContext({
+  clickoutSuspended: false,
+  suspendClickout(isSuspended) {
+    this.clickoutSuspended = isSuspended
+  }
+})
+
+export default class External extends Component {
   el = document.createElement('div')
 
   componentDidMount() {
@@ -23,5 +37,3 @@ class External extends Component {
 External.propTypes = {
   children: PropTypes.node.isRequired,
 }
-
-export default External


### PR DESCRIPTION
* Allow active clickouts to be temporarily suspended via a React.Context

* Suspend clickouts in ConfirmAction so that users can interact with its
modal without triggering a clickout