### PR TITLE
Switch from react-table to react-table-6

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-scripts": "3.4.1",
     "react-share": "^4.2.0",
     "react-syntax-highlighter": "^12.2.1",
-    "react-table": "^6.7.6",
+    "react-table-6": "^6.11.0",
     "react-tagsinput": "^3.19.0",
     "redux": "^4.0.5",
     "redux-thunk": "^2.2.0",

--- a/src/components/AdminPane/Manage/ChallengeAnalysisTable/ChallengeAnalysisTable.js
+++ b/src/components/AdminPane/Manage/ChallengeAnalysisTable/ChallengeAnalysisTable.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import ReactTable from 'react-table'
+import ReactTable from 'react-table-6'
 import { FormattedMessage, FormattedDate, injectIntl } from 'react-intl'
 import { Link } from 'react-router-dom'
 import _isEmpty from 'lodash/isEmpty'

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import ReactTable from 'react-table'
+import ReactTable from 'react-table-6'
 import { FormattedMessage, FormattedDate,
          FormattedTime, injectIntl } from 'react-intl'
 import { Link } from 'react-router-dom'
@@ -46,7 +46,6 @@ import ConfigureColumnsModal
 import InTableTagFilter
       from '../../components/KeywordAutosuggestInput/InTableTagFilter'
 import messages from './Messages'
-import 'react-table/react-table.css'
 import './TaskAnalysisTable.scss'
 import TaskAnalysisTableHeader from './TaskAnalysisTableHeader'
 import { ViewCommentsButton, StatusLabel, makeInvertable }

--- a/src/pages/Inbox/Inbox.js
+++ b/src/pages/Inbox/Inbox.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import ReactTable from 'react-table'
+import ReactTable from 'react-table-6'
 import classNames from 'classnames'
 import Fuse from 'fuse.js'
 import { FormattedMessage, FormattedDate, FormattedTime, injectIntl }

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -39,7 +39,7 @@ import messages from './Messages'
 import { ViewCommentsButton, StatusLabel, makeInvertable }
   from '../../../components/TaskAnalysisTable/TaskTableHelpers'
 import { Link } from 'react-router-dom'
-import ReactTable from 'react-table'
+import ReactTable from 'react-table-6'
 
 
 /**

--- a/src/styles/vendor/react-table.css
+++ b/src/styles/vendor/react-table.css
@@ -1,4 +1,4 @@
-@import 'react-table/react-table';
+@import 'react-table-6/react-table';
 
 .ReactTable {
   @apply mr-border-none mr-text-white;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11768,9 +11768,10 @@ react-syntax-highlighter@^12.2.1:
     prismjs "^1.8.4"
     refractor "^2.4.1"
 
-react-table@^6.7.6:
-  version "6.10.3"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-6.10.3.tgz#d085487a5a1b18b76486b71cf1d388d87c8c7362"
+react-table-6@^6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/react-table-6/-/react-table-6-6.11.0.tgz#727de5d9f0357a35816a1bbc2e9c9868f8c5b2c4"
+  integrity sha512-zO24J+1Qg2AHxtSNMfHeGW1dxFcmLJQrAeLJyCAENdNdwJt+YolDDtJEBdZlukon7rZeAdB3d5gUH6eb9Dn5Ug==
   dependencies:
     classnames "^2.2.5"
 


### PR DESCRIPTION
* Switching to react-table-6 makes it possible to integrate v7 (the
current react-table) in stages over time