### PR TITLE
Inform user if logged out when trying to lock task

### DIFF
--- a/src/components/HOCs/WithLockedTask/WithLockedTask.js
+++ b/src/components/HOCs/WithLockedTask/WithLockedTask.js
@@ -44,7 +44,7 @@ const WithLockedTask = function(WrappedComponent) {
         return Promise.reject("Invalid task")
       }
 
-      return this.props.releaseTask(task.id)
+      return this.props.releaseTask(task.id).catch(err => null)
     }
 
     /**

--- a/src/components/TaskPane/TaskPane.js
+++ b/src/components/TaskPane/TaskPane.js
@@ -18,6 +18,7 @@ import WidgetWorkspace from '../WidgetWorkspace/WidgetWorkspace'
 import WithCooperativeWork from '../HOCs/WithCooperativeWork/WithCooperativeWork'
 import WithTaskBundle from '../HOCs/WithTaskBundle/WithTaskBundle'
 import WithLockedTask from '../HOCs/WithLockedTask/WithLockedTask'
+import SignIn from '../../pages/SignIn/SignIn'
 import MapPane from '../EnhancedMap/MapPane/MapPane'
 import TaskMap from './TaskMap/TaskMap'
 import VirtualChallengeNameLink
@@ -173,6 +174,16 @@ export class TaskPane extends Component {
   }
 
   render() {
+    if (!this.props.user) {
+      return (
+        this.props.checkingLoginStatus ?
+        <div className="mr-flex mr-justify-center mr-py-8 mr-w-full mr-bg-blue">
+          <BusySpinner />
+        </div> :
+        <SignIn {...this.props} />
+      )
+    }
+
     if (!_get(this.props, 'task.parent.parent')) {
       return (
         <div className="pane-loading full-screen-height">

--- a/src/services/Error/AppErrors.js
+++ b/src/services/Error/AppErrors.js
@@ -31,6 +31,7 @@ export default {
     locked: messages.taskLocked,
     lockRefreshFailure: messages.taskLockRefreshFailure,
     bundleFailure: messages.taskBundleFailure,
+    lockReleaseFailure: messages.taskLockReleaseFailure,
   },
 
   osm: {

--- a/src/services/Error/Messages.js
+++ b/src/services/Error/Messages.js
@@ -74,6 +74,10 @@ export default defineMessages({
     id: 'Errors.task.lockRefreshFailure',
     defaultMessage: "Unable to extend your task lock. Your lock may have expired. We recommend refreshing the page to try establishing a fresh lock.",
   },
+  taskLockReleaseFailure: {
+    id: 'Errors.task.lockReleaseFailure',
+    defaultMessage: "Failed to release task lock. Your lock or your session may have expired.",
+  },
   taskBundleFailure: {
     id: 'Errors.task.bundleFailure',
     defaultMessage: "Unable to bundling tasks together",


### PR DESCRIPTION
* If user fails to lock a task because they are logged out, inform them
of that and prompt them to sign in, rather than continuing to offer to
try locking the task again

* Fixes #1233