### PR TITLE
Fix priority location rules schema

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step3Schema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Step3Schema.js
@@ -109,7 +109,7 @@ export const jsSchema = intl => {
                     type: "string",
                     enum: ["contains", "not_contains"],
                     enumNames: ["inside bounds", "outside bounds"],
-                    default: "inside bounds",
+                    default: "contains",
                   },
                   value: {
                     title: "Bounds Value",

--- a/src/components/BoundsSelectorModal/BoundsSelectorModal.js
+++ b/src/components/BoundsSelectorModal/BoundsSelectorModal.js
@@ -45,7 +45,7 @@ export default class BoundsSelectorModal extends Component {
   render() {
     const boundingBox =
       toLatLngBounds(
-        this.props.value ?
+        this.props.value && _split(this.props.value, ',').length === 4 ?
           _split(this.props.value, ',') :
           this.props.bounding ? bbox(this.props.bounding) : DEFAULT_MAP_BOUNDS
       )


### PR DESCRIPTION
* Priority location rule broke with new js schema. Found
  mistake in schema where 'default' referenced the enumNames
  value instead of the enum value.

* Possible when you change between types (ex. integer -> location)
  the value in the search box was throwing an error since it wasn't
  valid map bounds.