### PR TITLE
Back button hangs after task completion

### DIFF
--- a/src/components/TaskPane/TaskPane.js
+++ b/src/components/TaskPane/TaskPane.js
@@ -123,7 +123,10 @@ export class TaskPane extends Component {
                   needsReview, requestedNextTask, osmComment, tagEdits, taskBundle) => {
     this.setState({completingTask: task.id})
     this.props.completeTask(task, challengeId, taskStatus, comment, tags, taskLoadBy, userId,
-                            needsReview, requestedNextTask, osmComment, tagEdits, this.state.completionResponses, taskBundle)
+                            needsReview, requestedNextTask, osmComment, tagEdits,
+                            this.state.completionResponses, taskBundle).then(() => {
+      this.clearCompletingTask()
+    })
     this.props.clearActiveTaskBundle()
   }
 


### PR DESCRIPTION
TaskPane completingTask needs to be cleared after completing
task so that when going 'back' the state isn't still registered