### PR TITLE
Fix funky scrollbar when picking custom dates and limit custom dates

### DIFF
--- a/src/components/IntlDatePicker/IntlDatePicker.js
+++ b/src/components/IntlDatePicker/IntlDatePicker.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import DatePicker from 'react-datepicker'
+import subYears from 'date-fns/sub_years'
 
 
 /**
@@ -25,6 +26,11 @@ export default class IntlDatePicker extends Component {
   }
 
   render() {
+    const extraProps = {}
+    if (this.props.limitDate) {
+      extraProps.minDate = subYears(new Date(), 1)
+    }
+
     return (
       <DatePicker
           dateFormat={this.extractDateFormat()}
@@ -42,6 +48,7 @@ export default class IntlDatePicker extends Component {
                 enabled: false // turn off since needs preventOverflow to be enabled
               }
           }}
+          {...extraProps}
       />
     )
   }

--- a/src/components/PastDurationSelector/PastDurationSelector.js
+++ b/src/components/PastDurationSelector/PastDurationSelector.js
@@ -71,6 +71,7 @@ export class PastDurationSelector extends Component {
                     selected={this.startDate()}
                     onChange={(value) => this.setState({customStartDate: value})}
                     intl={this.props.intl}
+                    limitDate
                   />
                 </div>
                 <div className="mr-pb-2 mr-text-grey">
@@ -81,6 +82,7 @@ export class PastDurationSelector extends Component {
                     selected={this.endDate()}
                     onChange={(value) => this.setState({customEndDate: value})}
                     intl={this.props.intl}
+                    limitDate
                   />
                 </div>
                 {this.startDate() && this.endDate() &&

--- a/src/components/PastDurationSelector/PastDurationSelector.js
+++ b/src/components/PastDurationSelector/PastDurationSelector.js
@@ -54,7 +54,7 @@ export class PastDurationSelector extends Component {
         dropdownContent={dropdown => {
           if (this.state.showChooseCustomDates) {
             return (
-              <div className="mr-pt-2 mr-min-w-72">
+              <div className="mr-pt-2 mr-min-w-72 mr-overflow-hidden">
                 <div className="mr-text-green-lighter mr-w-full">
                   <button className="mr-absolute mr-right-0 mr-top-0 mr-mt-2"
                     onClick={() => this.setState({showChooseCustomDates: false})}>


### PR DESCRIPTION
* In firefox, a scroll bar would appear briefly in the box to pick custom dates.

* Limit custom dates to no more than one year prior.