### PR TITLE
Don't let live feed accumulate unlimited entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.6.6",
   "private": true,
   "dependencies": {
-    "@apollo/client": "3.0.0-rc.7",
+    "@apollo/client": "3.0.0-rc.10",
     "@formatjs/intl-relativetimeformat": "^6.0.2",
     "@mapbox/geo-viewport": "^0.4.0",
     "@mapbox/geojsonhint": "^3.0.0",

--- a/src/components/ActivityListing/ActivityTime.js
+++ b/src/components/ActivityListing/ActivityTime.js
@@ -19,6 +19,13 @@ import parse from 'date-fns/parse'
 export const ActivityTime = props => {
   const timestamp = parse(props.entry.created)
   const created = `${props.intl.formatDate(timestamp)} ${props.intl.formatTime(timestamp)}`
+  const selectedUnit = selectUnit(timestamp)
+  if (selectedUnit.unit === "second" ||
+      selectedUnit.unit === "minute" ||
+      selectedUnit.unit === "hour") {
+    selectedUnit.updateIntervalInSeconds = 30
+  }
+
   return (
     <div
       className={classNames(
@@ -31,7 +38,7 @@ export const ActivityTime = props => {
        <span>
          <FormattedDate value={props.entry.created} /> <FormattedTime value={props.entry.created} />
        </span> :
-       <FormattedRelativeTime {...selectUnit(timestamp)} />
+       <FormattedRelativeTime {...selectedUnit} numeric="auto" />
       }
     </div>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@apollo/client@3.0.0-rc.7":
-  version "3.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.0.0-rc.7.tgz#f57b297bd92f06c9bb6a8e0ec71ddfdd3fc2fca0"
-  integrity sha512-pS68924tMZFBlC+Rbqy9rMqvqNHNKL2Jx/lw45aSCclpmk7GuIEFZCXAZihKG3PRYVZGG8p7DTQrdfC8XH51/w==
+"@apollo/client@3.0.0-rc.10":
+  version "3.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.0.0-rc.10.tgz#5af7efd98166657f0446e4a3185af69ef12709c9"
+  integrity sha512-iE7w3HS3iVLVfENaZBGqlQrUEWQa7ZwhNfXzaYuxMVgnbzT9MCkklq/xWHy8xsuaK3rgHOlTN3AyTF+InV5xpQ==
   dependencies:
     "@types/zen-observable" "^0.8.0"
     "@wry/equality" "^0.1.9"


### PR DESCRIPTION
* Limit the accumulation of live global activity entries to a single
page's worth before starting fresh

* Ensure relative timestamps on activity entries update periodically so
they don't get too stale