### PR TITLE
Make longform challenge-form groups collapsible

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
@@ -16,6 +16,7 @@ import _remove from 'lodash/remove'
 import _isEqual from 'lodash/isEqual'
 import _merge from 'lodash/merge'
 import _map from 'lodash/map'
+import _without from 'lodash/without'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import { Link } from 'react-router-dom'
 import External from '../../../../External/External'
@@ -131,6 +132,30 @@ export class EditChallenge extends Component {
     this.props.user.id,
     {longFormChallenge: isLongForm}
   )
+
+  /**
+   * Returns the list of challenge form groups that are to be rendered as
+   * collapsed when in longform mode (does not affect stepped mode)
+   */
+  collapsedFormGroups = () =>
+    this.props.getUserAppSetting(this.props.user, 'collapsedChallengeFormGroups') || []
+
+  /**
+   * Update the current user's preferences as to which challenge form groups
+   * are expanded and collapsed when displayed in longform mode (does not
+   * affect stepped mode)
+   */
+  toggleCollapsedFormGroup = groupId => {
+    const collapsed = this.collapsedFormGroups()
+    const updated =
+      collapsed.indexOf(groupId) === -1 ?
+      collapsed.concat([groupId]) :
+      _without(collapsed, groupId)
+
+    this.props.updateUserAppSetting(this.props.user.id, {
+      collapsedChallengeFormGroups: updated,
+    })
+  }
 
   /**
    * Validate GeoJSON data
@@ -731,6 +756,8 @@ export class EditChallenge extends Component {
                   uiSchema={activeStep.uiSchema(
                     this.props.intl, this.props.user, challengeData, this.state.extraErrors, {
                       longForm: this.isLongForm(),
+                      collapsedGroups: this.collapsedFormGroups(),
+                      toggleCollapsed: this.toggleCollapsedFormGroup,
                     }
                   )}
                   className="form"

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/BasemapSchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/BasemapSchema.js
@@ -7,6 +7,8 @@ import _map from 'lodash/map'
 import _filter from 'lodash/filter'
 import messages from '../Messages'
 
+const STEP_ID = "Basemap"
+
 /**
  * Generates a JSON Schema describing Basemap fields of Edit Challenge
  * workflow intended for consumption by react-jsonschema-form
@@ -80,14 +82,23 @@ export const jsSchema = (intl, user, challengeData, extraErrors, options={}) => 
  * > the form configuration will help the RJSFFormFieldAdapter generate the
  * > proper markup
  */
-export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => ({
-  defaultBasemap: {
-    "ui:widget": "select",
-    "ui:help": intl.formatMessage(messages.defaultBasemapDescription),
-    "ui:groupHeader": options.longForm ? intl.formatMessage(messages.basemapStepHeader) : undefined,
-  },
-  customBasemap: {
-    "ui:emptyValue": "",
-    "ui:help": intl.formatMessage(messages.customBasemapDescription),
-  },
-})
+export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => {
+  const isCollapsed = (options.collapsedGroups || []).indexOf(STEP_ID) !== -1
+  const toggleCollapsed = options.toggleCollapsed ? () => options.toggleCollapsed(STEP_ID) : undefined
+
+  return {
+    "ui:order": ["defaultBasemap", "customBasemap"],
+    defaultBasemap: {
+      "ui:widget": "select",
+      "ui:help": intl.formatMessage(messages.defaultBasemapDescription),
+      "ui:collapsed": isCollapsed,
+      "ui:toggleCollapsed": toggleCollapsed,
+      "ui:groupHeader": options.longForm ? intl.formatMessage(messages.basemapStepHeader) : undefined,
+    },
+    customBasemap: {
+      "ui:emptyValue": "",
+      "ui:help": intl.formatMessage(messages.customBasemapDescription),
+      "ui:collapsed": isCollapsed,
+    },
+  }
+}

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/DiscoverabilitySchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/DiscoverabilitySchema.js
@@ -1,6 +1,8 @@
 import AsManager from '../../../../../../interactions/User/AsManager'
 import messages from '../Messages'
 
+const STEP_ID = "Discoverability"
+
 /**
  * Generates a JSON Schema describing discoverability fields of Edit Challenge
  * workflow intended for consumption by react-jsonschema-form
@@ -59,6 +61,9 @@ export const jsSchema = (intl, user, challengeData, extraErrors, options={}) => 
  * > proper markup
  */
 export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => {
+  const isCollapsed = (options.collapsedGroups || []).indexOf(STEP_ID) !== -1
+  const toggleCollapsed = options.toggleCollapsed ? () => options.toggleCollapsed(STEP_ID) : undefined
+
   const uiSchemaFields = {
     "ui:order": [
       "featured", "enabled", "additionalKeywords", "requiresLocal",
@@ -66,19 +71,24 @@ export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => 
     featured: {
       "ui:widget": "radio",
       "ui:help": intl.formatMessage(messages.featuredDescription),
+      "ui:collapsed": isCollapsed,
+      "ui:toggleCollapsed": toggleCollapsed,
       "ui:groupHeader": options.longForm ? intl.formatMessage(messages.discoverabilityStepHeader) : undefined,
     },
     enabled: {
       "ui:widget": "radio",
       "ui:help": intl.formatMessage(messages.visibleDescription),
+      "ui:collapsed": isCollapsed,
     },
     additionalKeywords: {
       "ui:field": "tags",
       "ui:help": intl.formatMessage(messages.additionalKeywordsDescription),
+      "ui:collapsed": isCollapsed,
     },
     requiresLocal: {
       "ui:widget": "radio",
       "ui:help": intl.formatMessage(messages.requiresLocalDescription),
+      "ui:collapsed": isCollapsed,
     }
   }
 

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/OSMCommitSchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/OSMCommitSchema.js
@@ -2,6 +2,8 @@ import AsEditableChallenge
        from '../../../../../../interactions/Challenge/AsEditableChallenge'
 import messages from '../Messages'
 
+const STEP_ID = "OSMCommit"
+
 /**
  * Generates a JSON Schema describing OSM commit fields of Edit Challenge
  * workflow intended for consumption by react-jsonschema-form
@@ -60,6 +62,9 @@ export const jsSchema = (intl, user, challengeData, extraErrors, options={}) => 
  * > proper markup
  */
 export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => {
+  const isCollapsed = (options.collapsedGroups || []).indexOf(STEP_ID) !== -1
+  const toggleCollapsed = options.toggleCollapsed ? () => options.toggleCollapsed(STEP_ID) : undefined
+
   const uiSchemaFields = {
     "ui:order": [
       "checkinComment", "includeCheckinHashtag", "checkinSource",
@@ -67,14 +72,18 @@ export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => 
     checkinComment: {
       "ui:emptyValue": "",
       "ui:help": intl.formatMessage(messages.checkinCommentDescription),
+      "ui:collapsed": isCollapsed,
+      "ui:toggleCollapsed": toggleCollapsed,
       "ui:groupHeader": options.longForm ? intl.formatMessage(messages.osmCommitStepHeader) : undefined,
     },
     checkinSource: {
       "ui:help": intl.formatMessage(messages.checkinSourceDescription),
+      "ui:collapsed": isCollapsed,
     },
     includeCheckinHashtag: {
       "ui:field": "columnRadio",
       "ui:help": intl.formatMessage(messages.includeCheckinHashtagDescription),
+      "ui:collapsed": isCollapsed,
     },
   }
 

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/PrioritiesSchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/PrioritiesSchema.js
@@ -5,6 +5,8 @@ import _map from 'lodash/map'
 import _values from 'lodash/values'
 import messages from '../Messages'
 
+const STEP_ID = "Priorities"
+
 /**
  * Generates a JSON Schema describing priority fields of Edit
  * Challenge workflow intended for consumption by react-jsonschema-form
@@ -177,7 +179,7 @@ export const jsSchema = (intl, user, challengeData, extraErrors, options={}) => 
  *
  * @private
  */
-const priorityRuleGroupUISchema = {
+const priorityRuleGroupUISchema = (isCollapsed) => ({
   classNames: "priority-rule-group",
   condition: {
     "ui:widget": "select",
@@ -189,22 +191,27 @@ const priorityRuleGroupUISchema = {
       keyType: {
         "ui:widget": "select",
         "ui:displayLabel": false,
+        "ui:collapsed": isCollapsed,
       },
       valueType: {
         "ui:widget": "select",
         "ui:displayLabel": false,
+        "ui:collapsed": isCollapsed,
       },
       key: {
         "ui:placeholder": "Property Name",
         "ui:displayLabel": false,
+        "ui:collapsed": isCollapsed,
       },
       operator: {
         "ui:widget": "select",
         "ui:displayLabel": false,
+        "ui:collapsed": isCollapsed,
       },
       value: {
         "ui:placeholder": "Property Value",
         "ui:displayLabel": false,
+        "ui:collapsed": isCollapsed,
       },
       ruleGroup: {
         classNames: "nested-rule-group mr-border mr-border-white-25 mr-p-2 mr-mt-4 mr-flex mr-w-full",
@@ -213,10 +220,12 @@ const priorityRuleGroupUISchema = {
             key: {
               "ui:placeholder": "Property Name",
               "ui:displayLabel": false,
+              "ui:collapsed": isCollapsed,
             },
             value: {
               "ui:placeholder": "Property Value",
               "ui:displayLabel": false,
+              "ui:collapsed": isCollapsed,
             },
             ruleGroup: {
               classNames: "nested-rule-group mr-border mr-border-white-25 mr-p-2 mr-mt-4 mr-flex mr-w-full",
@@ -225,10 +234,12 @@ const priorityRuleGroupUISchema = {
                   key: {
                     "ui:placeholder": "Property Name",
                     "ui:displayLabel": false,
+                    "ui:collapsed": isCollapsed,
                   },
                   value: {
                     "ui:placeholder": "Property Value",
                     "ui:displayLabel": false,
+                    "ui:collapsed": isCollapsed,
                   },
                 },
               },
@@ -239,7 +250,7 @@ const priorityRuleGroupUISchema = {
       "ui:order": [ "valueType", "key", "operator", "value", "*" ],
     },
   },
-}
+})
 
 /**
  * uiSchema configuration to assist react-jsonschema-form in determining
@@ -251,19 +262,29 @@ const priorityRuleGroupUISchema = {
  * > in the form configuration will help the RJSFFormFieldAdapter generate the
  * > proper markup
  */
-export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => ({
-  defaultPriority: {
-    "ui:widget": "select",
-    "ui:help": intl.formatMessage(messages.defaultPriorityDescription),
-    "ui:groupHeader": options.longForm ? intl.formatMessage(messages.prioritiesStepHeader) : undefined,
-  },
-  highPriorityRules: {
-    ruleGroup: priorityRuleGroupUISchema,
-  },
-  mediumPriorityRules: {
-    ruleGroup: priorityRuleGroupUISchema,
-  },
-  lowPriorityRules: {
-    ruleGroup: priorityRuleGroupUISchema,
-  },
-})
+export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => {
+  const isCollapsed = (options.collapsedGroups || []).indexOf(STEP_ID) !== -1
+  const toggleCollapsed = options.toggleCollapsed ? () => options.toggleCollapsed(STEP_ID) : undefined
+
+  return {
+    defaultPriority: {
+      "ui:widget": "select",
+      "ui:help": intl.formatMessage(messages.defaultPriorityDescription),
+      "ui:collapsed": isCollapsed,
+      "ui:toggleCollapsed": toggleCollapsed,
+      "ui:groupHeader": options.longForm ? intl.formatMessage(messages.prioritiesStepHeader) : undefined,
+    },
+    highPriorityRules: {
+      ruleGroup: priorityRuleGroupUISchema(isCollapsed),
+      "ui:collapsed": isCollapsed,
+    },
+    mediumPriorityRules: {
+      ruleGroup: priorityRuleGroupUISchema(isCollapsed),
+      "ui:collapsed": isCollapsed,
+    },
+    lowPriorityRules: {
+      ruleGroup: priorityRuleGroupUISchema(isCollapsed),
+      "ui:collapsed": isCollapsed,
+    },
+  }
+}

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/PropertiesSchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/PropertiesSchema.js
@@ -1,5 +1,7 @@
 import messages from '../Messages'
 
+const STEP_ID = "Properties"
+
 /**
  * Generates a JSON Schema describing property fields of Edit Challenge
  * workflow intended for consumption by react-jsonschema-form
@@ -45,18 +47,27 @@ export const jsSchema = (intl, user, challengeData, extraErrors, options={}) => 
  * > the form configuration will help the RJSFFormFieldAdapter generate the
  * > proper markup
  */
-export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => ({
-  osmIdProperty: {
-    "ui:emptyValue": "",
-    "ui:help": intl.formatMessage(messages.osmIdPropertyDescription),
-    "ui:groupHeader": options.longForm ? intl.formatMessage(messages.propertiesStepHeader) : undefined,
-  },
-  customTaskStyles: {
-    "ui:field": "configureCustomTaskStyles",
-    "ui:help": intl.formatMessage(messages.customTaskStylesDescription),
-  },
-  exportableProperties: {
-    "ui:emptyValue": "",
-    "ui:help": intl.formatMessage(messages.exportablePropertiesDescription),
-  },
-})
+export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => {
+  const isCollapsed = (options.collapsedGroups || []).indexOf(STEP_ID) !== -1
+  const toggleCollapsed = options.toggleCollapsed ? () => options.toggleCollapsed(STEP_ID) : undefined
+
+  return {
+    osmIdProperty: {
+      "ui:emptyValue": "",
+      "ui:help": intl.formatMessage(messages.osmIdPropertyDescription),
+      "ui:collapsed": isCollapsed,
+      "ui:toggleCollapsed": toggleCollapsed,
+      "ui:groupHeader": options.longForm ? intl.formatMessage(messages.propertiesStepHeader) : undefined,
+    },
+    customTaskStyles: {
+      "ui:field": "configureCustomTaskStyles",
+      "ui:help": intl.formatMessage(messages.customTaskStylesDescription),
+      "ui:collapsed": isCollapsed,
+    },
+    exportableProperties: {
+      "ui:emptyValue": "",
+      "ui:help": intl.formatMessage(messages.exportablePropertiesDescription),
+      "ui:collapsed": isCollapsed,
+    },
+  }
+}

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/TagsSchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/TagsSchema.js
@@ -1,5 +1,7 @@
 import messages from '../Messages'
 
+const STEP_ID = "Tags"
+
 /**
  * Generates a JSON Schema describing MR tag fields of Edit Challenge
  * workflow intended for consumption by react-jsonschema-form
@@ -51,25 +53,33 @@ export const jsSchema = (intl, user, challengeData, extraErrors, options={}) => 
  * > proper markup
  */
 export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => {
+  const isCollapsed = (options.collapsedGroups || []).indexOf(STEP_ID) !== -1
+  const toggleCollapsed = options.toggleCollapsed ? () => options.toggleCollapsed(STEP_ID) : undefined
+
   const uiSchemaFields = {
     taskTags: {
       "ui:field": "taskTags",
       "ui:help": intl.formatMessage(messages.preferredTagsDescription),
+      "ui:collapsed": isCollapsed,
+      "ui:toggleCollapsed": toggleCollapsed,
       "ui:groupHeader": options.longForm ? intl.formatMessage(messages.tagsStepHeader) : undefined,
       "tagType": "tasks",
     },
     limitTags: {
       "ui:field": "limitTags",
       "ui:help": intl.formatMessage(messages.limitTagsDescription),
+      "ui:collapsed": isCollapsed,
     },
     reviewTaskTags: {
       "ui:field": "taskTags",
       "ui:help": intl.formatMessage(messages.preferredReviewTagsDescription),
-      "tagType": "review"
+      "tagType": "review",
+      "ui:collapsed": isCollapsed,
     },
     limitReviewTags: {
       "ui:field": "limitTags",
       "ui:help": intl.formatMessage(messages.limitReviewTagsDescription),
+      "ui:collapsed": isCollapsed,
     },
   }
 

--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/ZoomSchema.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/Schemas/ZoomSchema.js
@@ -4,6 +4,8 @@ import _get from 'lodash/get'
 import _isString from 'lodash/isString'
 import messages from '../Messages'
 
+const STEP_ID = "Zoom"
+
 /**
  * Generates a JSON Schema describing zoom fields of Edit Challenge
  * workflow intended for consumption by react-jsonschema-form
@@ -60,21 +62,30 @@ export const jsSchema = (intl, user, challengeData, extraErrors, options={}) => 
  * > the form configuration will help the RJSFFormFieldAdapter generate the
  * > proper markup
  */
-export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => ({
-  defaultZoom: {
-    "ui:widget": "select",
-    "ui:help": intl.formatMessage(messages.defaultZoomDescription),
-    "ui:groupHeader": options.longForm ? intl.formatMessage(messages.zoomStepHeader) : undefined,
-  },
-  minZoom: {
-    "ui:widget": "select",
-    "ui:help": intl.formatMessage(messages.minZoomDescription),
-  },
-  maxZoom: {
-    "ui:widget": "select",
-    "ui:help": intl.formatMessage(messages.maxZoomDescription),
-  },
-})
+export const uiSchema = (intl, user, challengeData, extraErrors, options={}) => {
+  const isCollapsed = (options.collapsedGroups || []).indexOf(STEP_ID) !== -1
+  const toggleCollapsed = options.toggleCollapsed ? () => options.toggleCollapsed(STEP_ID) : undefined
+
+  return {
+    defaultZoom: {
+      "ui:widget": "select",
+      "ui:help": intl.formatMessage(messages.defaultZoomDescription),
+      "ui:collapsed": isCollapsed,
+      "ui:toggleCollapsed": toggleCollapsed,
+      "ui:groupHeader": options.longForm ? intl.formatMessage(messages.zoomStepHeader) : undefined,
+    },
+    minZoom: {
+      "ui:widget": "select",
+      "ui:help": intl.formatMessage(messages.minZoomDescription),
+      "ui:collapsed": isCollapsed,
+    },
+    maxZoom: {
+      "ui:widget": "select",
+      "ui:help": intl.formatMessage(messages.maxZoomDescription),
+      "ui:collapsed": isCollapsed,
+    },
+  }
+}
 
 /**
  * Returns a numeric .env file setting as a numeric, converting from string if

--- a/src/components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
+++ b/src/components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
@@ -100,17 +100,31 @@ export const CustomArrayFieldTemplate = props => {
 
 export const CustomFieldTemplate = function(props) {
   const {classNames, children, description, uiSchema, errors} = props
+  const isCollapsed = _get(uiSchema, "ui:collapsed", false)
   return (
     <div className={classNames}>
       {uiSchema && uiSchema["ui:groupHeader"] &&
        <div className="mr-flex mr-justify-end mr-text-teal mr-text-lg mr-pt-4 mr-my-4 mr-border-t mr-border-teal-40">
-         {uiSchema["ui:groupHeader"]}
+         <span>{uiSchema["ui:groupHeader"]}</span>
+         {uiSchema && uiSchema["ui:toggleCollapsed"] &&
+           <button type="button" onClick={() => uiSchema["ui:toggleCollapsed"]()}>
+             <SvgSymbol
+               sym={isCollapsed ? "icon-cheveron-right" : "icon-cheveron-down"}
+               viewBox="0 0 20 20"
+               className="mr-fill-green-lighter mr-w-6 mr-h-6 mr-ml-2"
+             />
+           </button>
+         }
        </div>
       }
-      <LabelWithHelp {...props} />
-      {children}
-      {errors}
-      {description}
+      {!isCollapsed &&
+       <React.Fragment>
+         <LabelWithHelp {...props} />
+         {children}
+         {errors}
+         {description}
+       </React.Fragment>
+      }
     </div>
   )
 }


### PR DESCRIPTION
* Allow challenge creation/editing form groups containing purely
optional fields to be collapsed when shown in longform mode

* Save which groups user has collapsed so that they'll remain collapsed
by default going forward