### PR TITLE
Send active imagery layer to editors

### DIFF
--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -16,9 +16,13 @@ import { allowedStatusProgressions, isCompletionStatus,
 import { TaskReviewStatus } from '../../../../services/Task/TaskReview/TaskReviewStatus'
 import { TaskReviewLoadMethod } from '../../../../services/Task/TaskReview/TaskReviewLoadMethod'
 import { Editor } from '../../../../services/Editor/Editor'
+import { OPEN_STREET_MAP } from '../../../../services/VisibleLayer/LayerSources'
 import AsCooperativeWork from '../../../../interactions/Task/AsCooperativeWork'
 import SignInButton from '../../../SignInButton/SignInButton'
 import WithSearch from '../../../HOCs/WithSearch/WithSearch'
+import WithChallengePreferences
+       from '../../../HOCs/WithChallengePreferences/WithChallengePreferences'
+import WithVisibleLayer from '../../../HOCs/WithVisibleLayer/WithVisibleLayer'
 import WithTaskReview from '../../../HOCs/WithTaskReview/WithTaskReview'
 import WithTaskTags from '../../../HOCs/WithTaskTags/WithTaskTags'
 import WithKeyboardShortcuts
@@ -90,7 +94,10 @@ export class ActiveTaskControls extends Component {
       value,
       this.props.task,
       this.props.mapBounds,
-      {photoOverlay: this.props.showMapillaryLayer ? 'mapillary' : null},
+      {
+        imagery: this.props.source.id !== OPEN_STREET_MAP ? this.props.source : undefined,
+        photoOverlay: this.props.showMapillaryLayer ? 'mapillary' : null,
+      },
       this.props.taskBundle
     )
   }
@@ -381,10 +388,14 @@ ActiveTaskControls.defaultProps = {
 }
 
 export default WithSearch(
-  WithTaskTags(
-    WithTaskReview(
-      WithKeyboardShortcuts(
-        injectIntl(ActiveTaskControls)
+  WithChallengePreferences(
+    WithVisibleLayer(
+      WithTaskTags(
+        WithTaskReview(
+          WithKeyboardShortcuts(
+            injectIntl(ActiveTaskControls)
+          )
+        )
       )
     )
   ),

--- a/src/components/Widgets/TaskCompletionWidget/TaskCompletionWidget.js
+++ b/src/components/Widgets/TaskCompletionWidget/TaskCompletionWidget.js
@@ -35,7 +35,10 @@ export default class TaskCompletionWidget extends Component {
     let taskControls =
       this.props.inspectTask ?
       <InspectTaskControls {...this.props} /> :
-      <ActiveTaskControls {...this.props} />
+      <ActiveTaskControls
+        challenge={_get(this.props, 'task.parent')}
+        {...this.props}
+      />
 
     let taskCount = _get(this.props, 'taskBundle.taskIds.length', 0)
 

--- a/src/services/VisibleLayer/LayerSources.js
+++ b/src/services/VisibleLayer/LayerSources.js
@@ -142,7 +142,7 @@ export const layerSourceWithId = function(id) {
 export const createDynamicLayerSource = function(layerId, url) {
   return {
     id: layerId,
-    name: 'Custom',
+    name: 'Custom Imagery',
     url,
     isDynamic: true,
   }


### PR DESCRIPTION
* Send the current active imagery layer to iD, RapiD, or JOSM when
editing a task

* Closes #1151, #1230