### PR TITLE
Timezone needs to be encoded on export CSV uri

### DIFF
--- a/src/components/AdminPane/Manage/Widgets/ChallengeListWidget/ChallengeListWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/ChallengeListWidget/ChallengeListWidget.js
@@ -145,7 +145,9 @@ export default class ChallengeListWidget extends Component {
                     href={`${process.env.REACT_APP_MAP_ROULETTE_SERVER_URL}` +
                           `/api/v2/project/${_get(this.props, 'project.id')}` +
                           `/tasks/extract?${cId}&timezone=` +
-                          `${_get(this.props.widgetConfiguration, 'timezoneOffset', '')}`}
+                          `${encodeURIComponent(
+                              _get(this.props.widgetConfiguration, 'timezoneOffset', '')
+                             )}`}
                     className="mr-flex mr-items-center"
                   >
                     <SvgSymbol

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -71,7 +71,7 @@ export const challengeDenormalizationSchema = function() {
 export const buildLinkToExportCSV = function(challengeId, criteria, timezone = null) {
   const queryFilters = buildQueryFilters(criteria)
   return `${process.env.REACT_APP_MAP_ROULETTE_SERVER_URL}/api/v2/challenge/` +
-         `${challengeId}/tasks/extract?${queryFilters}&timezone=${timezone}`
+         `${challengeId}/tasks/extract?${queryFilters}&timezone=${encodeURIComponent(timezone)}`
 }
 
 /**
@@ -80,7 +80,7 @@ export const buildLinkToExportCSV = function(challengeId, criteria, timezone = n
 export const buildLinkToExportGeoJSON = function(challengeId, criteria, timezone = "") {
   const queryFilters = buildQueryFilters(criteria)
   return `${process.env.REACT_APP_MAP_ROULETTE_SERVER_URL}/api/v2/challenge/view/` +
-         `${challengeId}?${queryFilters}&timezone=${timezone}`
+         `${challengeId}?${queryFilters}&timezone=${encodeURIComponent(timezone)}`
 }
 
 // Helper function to build query filters for export links


### PR DESCRIPTION
When constructing the export CSV with timezone, the
timezone needs to be encoded because of the '+' part

* Fixes maproulette/maproulette2#822