### PR TITLE
Remove stale markdown note about mustache tags

### DIFF
--- a/src/components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
+++ b/src/components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter.js
@@ -203,7 +203,6 @@ export const ColumnRadioField = function(props) {
  */
 export const MarkdownEditField = props => {
   const [showingPreview, setShowingPreview] = useState(false)
-  const showMustacheNote = /{{/.test(props.formData) // tags present
 
   return (
     <React.Fragment>
@@ -246,11 +245,6 @@ export const MarkdownEditField = props => {
            }
          >
            <MarkdownTemplate
-             header={showMustacheNote &&
-               <div className="mr-italic mr-text-xs">
-                 <FormattedMessage {...messages.addMustachePreviewNote} />
-               </div>
-             }
              content={props.formData || ""}
              properties={{}}
              completionResponses={{}}


### PR DESCRIPTION
* Remove stale note from RJSFFormFieldAdapter that is now displayed by
the EditChallenge workflow steps

* Fixes inability to preview challenge instructions when creating/editing a challenge