### PR TITLE
Add 'view task instructions' to task confirmation modal

### DIFF
--- a/src/components/TaskConfirmationModal/InstructionsOverlay.js
+++ b/src/components/TaskConfirmationModal/InstructionsOverlay.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react'
+import { FormattedMessage } from 'react-intl'
+import TaskInstructions from '../TaskPane/TaskInstructions/TaskInstructions'
+import messages from './Messages'
+
+/**
+ * InstructionsOverlay shows a box with the task instructions and will
+ * record changes to the instructions form data
+ *
+ * @author [Kelli Rotstan](https://github.com/krotstan)
+ */
+export default class InstructionsOverlay extends Component {
+  render() {
+    return (
+      <div className="mr-absolute mr-bottom-0 mr-left-0 mr-bg-blue-darker mr-w-full mr-h-112 mr-mt-32">
+        <div className="mr-mt-4 mr-mx-4">
+          <h4 className="mr-text-yellow mr-mb-2">
+            <FormattedMessage {...messages.instructionsLabel} />
+          </h4>
+          <TaskInstructions {...this.props} inModal />
+        </div>
+        <div className="mr-w-full mr-text-center mr-absolute mr-bottom-0">
+          <button
+            onClick={() => this.props.close()}
+            className="mr-button mr-w-4/5 mr-mb-8"
+          >
+            <FormattedMessage {...messages.doneLabel} />
+          </button>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/components/TaskConfirmationModal/Messages.js
+++ b/src/components/TaskConfirmationModal/Messages.js
@@ -144,4 +144,14 @@ export default defineMessages({
     defaultMessage: "Mapper:",
   },
 
+  instructionsLabel: {
+    id: 'TaskConfirmationModal.instructions.label',
+    defaultMessage: "Task Instructions",
+  },
+
+  viewInstructions: {
+    id: 'TaskConfirmationModal.instructions.header',
+    defaultMessage: "View Task Instructions",
+  },
+
 })

--- a/src/components/TaskConfirmationModal/TaskConfirmationModal.js
+++ b/src/components/TaskConfirmationModal/TaskConfirmationModal.js
@@ -29,6 +29,7 @@ import KeywordAutosuggestInput
 import External from '../External/External'
 import Modal from '../Modal/Modal'
 import AdjustFiltersOverlay from './AdjustFiltersOverlay'
+import InstructionsOverlay from './InstructionsOverlay'
 import messages from './Messages'
 
 const shortcutGroup = 'taskConfirmation'
@@ -67,6 +68,10 @@ export class TaskConfirmationModal extends Component {
       this.props.keyboardShortcutGroups.taskConfirmation,
       this.handleKeyboardShortcuts
     )
+
+    if (this.props.needsResponses && _isEmpty(this.props.completionResponses)) {
+      this.setState({showInstructions: true})
+    }
   }
 
   componentWillUnmount() {
@@ -296,6 +301,11 @@ export class TaskConfirmationModal extends Component {
                           <FormattedMessage {...messagesByLoadMethod[TaskLoadMethod.proximity]} />
                         </label>
                       </div>
+                      <div className="mr-text-green-lighter mr-text-center mr-mt-4 hover:mr-text-white mr-cursor-pointer mr-text-xs">
+                        <div onClick={() => this.setState({showInstructions: true})}>
+                          <FormattedMessage {...messages.viewInstructions} />
+                        </div>
+                      </div>
                     </div>
                   }
 
@@ -427,6 +437,12 @@ export class TaskConfirmationModal extends Component {
               close={() => this.setState({showReviewFilters: false})}
               filterChange={this.filterChange}
               currentFilters={this.currentFilters()}
+            />
+          }
+          {!this.props.inReview && this.state.showInstructions && _isUndefined(this.props.needsRevised) &&
+            <InstructionsOverlay
+              {...this.props}
+              close={() => this.setState({showInstructions: false})}
             />
           }
         </Modal>

--- a/src/components/TaskPane/TaskInstructions/TaskInstructions.js
+++ b/src/components/TaskPane/TaskInstructions/TaskInstructions.js
@@ -40,7 +40,9 @@ export default class TaskInstructions extends Component {
                           setCompletionResponse={(propName, value) => {
                             this.props.setCompletionResponse(propName, value)
                             this.setState({responsesChanged: true})
-                          }} />
+                          }}
+                          setNeedsResponses={this.props.setNeedsResponses}
+                          inModal={this.props.inModal} />
         {this.props.disableTemplate && this.state.responsesChanged &&
           <Button
             className="mr-button--blue-fill mr-button--small"

--- a/src/components/TaskPane/TaskPane.js
+++ b/src/components/TaskPane/TaskPane.js
@@ -91,6 +91,7 @@ export class TaskPane extends Component {
     completingTask: null,
     completionResponses: null,
     showLockFailureDialog: false,
+    needsResponses: false,
   }
 
   tryLockingTask = () => {
@@ -142,6 +143,10 @@ export class TaskPane extends Component {
       JSON.parse(_get(this.props, 'task.completionResponses', null)) || {}
     responses[propertyName] = value
     this.setState({completionResponses: responses})
+  }
+
+  setNeedsResponses = (needsResponses) => {
+    this.setState({needsResponses})
   }
 
   componentDidMount() {
@@ -280,7 +285,9 @@ export class TaskPane extends Component {
             completeTask={this.completeTask}
             completingTask={this.state.completingTask}
             setCompletionResponse={this.setCompletionResponse}
+            setNeedsResponses={this.setNeedsResponses}
             completionResponses={completionResponses}
+            needsResponses={this.state.needsResponses}
             disableTemplate={isCompletionStatus(this.props.task.status)}
           />
           {this.state.completingTask && this.state.completingTask === this.props.task.id &&

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -1234,6 +1234,8 @@
   "TaskConfirmationModal.done.label": "Done",
   "TaskConfirmationModal.header": "Please Confirm",
   "TaskConfirmationModal.inReviewHeader": "Please Confirm Review",
+  "TaskConfirmationModal.instructions.header": "View Task Instructions",
+  "TaskConfirmationModal.instructions.label": "Task Instructions",
   "TaskConfirmationModal.invert.label": "invert",
   "TaskConfirmationModal.inverted.label": "inverted",
   "TaskConfirmationModal.loadBy.label": "Next task:",


### PR DESCRIPTION
* Add ability to view task instructions from task confirmation
  modal

* Show task instructions if completion responses are needed
  but not given

* In instructions overlay let text part of instructions scroll
  independently from template questions