### PR TITLE
Enlarge busy spinner on maps

### DIFF
--- a/src/components/BusySpinner/BusySpinner.js
+++ b/src/components/BusySpinner/BusySpinner.js
@@ -20,8 +20,10 @@ export default class BusySpinner extends Component {
         <SvgSymbol
           sym="spinner-icon"
           className={classNames(
-            this.props.big ? "mr-w-10 mr-h-10" : "mr-w-5 mr-h-5",
             {
+              "mr-w-5 mr-h-5": !this.props.big && !this.props.xlarge,
+              "mr-w-10 mr-h-10": this.props.big,
+              "mr-w-16 mr-h-16": this.props.xlarge,
               "mr-fill-green-lighter": !this.props.lightMode && !this.props.mapMode,
               "mr-fill-green-light": this.props.lightMode,
               "mr-fill-grey": this.props.mapMode,

--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -458,7 +458,7 @@ export class TaskClusterMap extends Component {
           </div>
         }
         {map}
-        {(!!this.props.loading || this.state.locatingToUser || !!this.props.loadingChallenge) && <BusySpinner mapMode />}
+        {(!!this.props.loading || this.state.locatingToUser || !!this.props.loadingChallenge) && <BusySpinner mapMode xlarge />}
       </div>
     )
   }

--- a/src/components/TaskPane/TaskNearbyList/TaskNearbyMap.js
+++ b/src/components/TaskPane/TaskNearbyList/TaskNearbyMap.js
@@ -184,7 +184,7 @@ export class TaskNearbyMap extends Component {
           }
         </EnhancedMap>
 
-        {!!this.props.tasksLoading && <BusySpinner mapMode />}
+        {!!this.props.tasksLoading && <BusySpinner mapMode big />}
       </div>
     )
   }


### PR DESCRIPTION
* Enlarge the busy spinner on the challenge discovery map and the
task-nearby map to make it easier to see

* Closes #1343