### PR TITLE
Rename confirm modal hide instructions button to be clearer

### DIFF
--- a/src/components/TaskConfirmationModal/InstructionsOverlay.js
+++ b/src/components/TaskConfirmationModal/InstructionsOverlay.js
@@ -24,7 +24,7 @@ export default class InstructionsOverlay extends Component {
             onClick={() => this.props.close()}
             className="mr-button mr-w-4/5 mr-mb-8"
           >
-            <FormattedMessage {...messages.doneLabel} />
+            <FormattedMessage {...messages.closeInstructionsLabel} />
           </button>
         </div>
       </div>

--- a/src/components/TaskConfirmationModal/Messages.js
+++ b/src/components/TaskConfirmationModal/Messages.js
@@ -154,4 +154,9 @@ export default defineMessages({
     defaultMessage: "View Task Instructions",
   },
 
+  closeInstructionsLabel: {
+    id: 'TaskConfirmationModal.closeInstructions.label',
+    defaultMessage: "Hide Instructions",
+  },
+
 })

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -1228,6 +1228,7 @@
   "TaskConfirmationModal.adjustFilters.label": "Adjust Filters",
   "TaskConfirmationModal.cancel.label": "Cancel",
   "TaskConfirmationModal.challenge.label": "Challenge:",
+  "TaskConfirmationModal.closeInstructions.label": "Hide Instructions",
   "TaskConfirmationModal.comment.header": "MapRoulette Comment (optional)",
   "TaskConfirmationModal.comment.label": "Leave optional comment",
   "TaskConfirmationModal.comment.placeholder": "Your comment (optional)",


### PR DESCRIPTION
Change confirm modal view instructions overlay 'done' to 'hide instructions' to be clearer.