### PR TITLE
Take extra care around editor imagery checks

### DIFF
--- a/src/services/Editor/Editor.js
+++ b/src/services/Editor/Editor.js
@@ -140,7 +140,7 @@ export const editTask = function(editor, task, mapBounds, options, taskBundle) {
         }
       }
 
-      if (options.imagery) {
+      if (options && options.imagery) {
         josmCommands.push(() => sendJOSMCommand(josmImageryURI(options.imagery)))
       }
 


### PR DESCRIPTION
* Be particularly careful around checks for editor imagery in case
imagery has been disabled in the env settings