### PR TITLE
Prepare for v3.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [v3.6.9] - 2020-08-06
+### Fixed
+- Tasks sometimes don't open in JOSM if editor imagery is disabled
+
+
 ## [v3.6.8] - 2020-08-05
 ### Added
 - Updated community translations (huge thanks to all the translators!)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maproulette3",
-  "version": "3.6.8",
+  "version": "3.6.9",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.1.1",

--- a/src/services/Editor/Editor.js
+++ b/src/services/Editor/Editor.js
@@ -140,7 +140,7 @@ export const editTask = function(editor, task, mapBounds, options, taskBundle) {
         }
       }
 
-      if (options.imagery) {
+      if (options && options.imagery) {
         josmCommands.push(() => sendJOSMCommand(josmImageryURI(options.imagery)))
       }
 


### PR DESCRIPTION
### Fixed
- Tasks sometimes don't open in JOSM if editor imagery is disabled
