### PR TITLE
Tighten up OSM element short-code test

### DIFF
--- a/src/services/ShortCodes/Handlers/OSMElementHandler.js
+++ b/src/services/ShortCodes/Handlers/OSMElementHandler.js
@@ -28,7 +28,8 @@ const OSMElementHandler = {
   },
 
   handlesShortCode(shortCode) {
-    return new RegExp(this.osmElementRegex).test(shortCode)
+    // Add opening short-code bracket to test to help prevent false positives
+    return new RegExp("\\[" + this.osmElementRegex).test(shortCode)
   },
 
   expandShortCode(shortCode) {


### PR DESCRIPTION
* Tighten up the test when determining if a short-code matches an OSM
element reference, to avoid potentially matching username short codes
that happen to contain an embedded match (e.g. `@foobar5` matching due
to the `r5` and erroneously getting turned into a link to relation 5)