### PR TITLE
Offer lasso tool on admin task analysis map

### DIFF
--- a/src/components/AdminPane/Manage/ViewChallengeTasks/ViewChallengeTasks.js
+++ b/src/components/AdminPane/Manage/ViewChallengeTasks/ViewChallengeTasks.js
@@ -208,7 +208,9 @@ export class ViewChallengeTasks extends Component {
 
     const map =
         <ClusterMap
+          showLasso
           updateBounds={this.mapBoundsUpdated}
+          onBulkTaskSelection={this.props.selectTasksById}
           loadingTasks={this.props.loadingTasks}
           showMarkerPopup={this.showMarkerPopup}
           togglePriorityBounds={() => this.setState({showPriorityBounds: !this.state.showPriorityBounds})}

--- a/src/components/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
+++ b/src/components/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
@@ -228,7 +228,9 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
      * Select multiple tasks matching the given task ids
      */
     selectTasksById = (taskIds, allTasks) => {
-      if (_isEmpty(taskIds)) {
+      // No need to select if nothing to select, or if everything's already
+      // been selected
+      if (_isEmpty(taskIds) || this.state.allSelected) {
         return
       }
 

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -19,7 +19,6 @@ import _reverse from 'lodash/reverse'
 import _keys from 'lodash/keys'
 import _concat from 'lodash/concat'
 import _filter from 'lodash/filter'
-import _find from 'lodash/find'
 import _cloneDeep from 'lodash/cloneDeep'
 import _split from 'lodash/split'
 import _isEmpty from 'lodash/isEmpty'
@@ -194,18 +193,8 @@ export class TaskAnalysisTable extends Component {
       }
     }
 
-    // It's possible for the props.selectedTasks (which comes from WithFilteredClusteredTasks)
-    // to contain tasks not in our data as our data has been filtered by
-    // bounds and paging also --- so we make sure here to only include tasks
-    // visible on our current page.
-    const selectedDataTasks =
-      _filter([...this.props.selectedTasks.keys()],
-               taskId => _find(data, task => task.id === taskId))
-
-    // If this is for bundling then we really do want to the full count of
-    // selected tasks since they could have used the "lasso" tool.
-    const selectedTaskCount = this.props.forBundling ?
-      this.props.selectedTasks.size : selectedDataTasks.length
+    const selectedDataTasks = [...this.props.selectedTasks.keys()]
+    const selectedTaskCount = this.props.selectedTasks.size
 
     if (_get(this.props, 'criteria.filters')) {
       defaultFiltered = _map(this.props.criteria.filters,


### PR DESCRIPTION
* Offer lasso tool on task analysis map for challenge managers when
tasks are unclustered

* Stop restricting TaskAnalysisTable task selections to only visible
page of task results, allowing results on other pages to be selected via
lasso