### PR TITLE
Highlight selected tasks on Task Analysis map

### DIFF
--- a/src/components/HOCs/WithTaskClusterMarkers/WithTaskClusterMarkers.js
+++ b/src/components/HOCs/WithTaskClusterMarkers/WithTaskClusterMarkers.js
@@ -22,7 +22,7 @@ export const WithTaskClusterMarkers = function(WrappedComponent) {
 
     componentDidUpdate(prevProps) {
       if (!_isEqual(this.props.taskClusters, prevProps.taskClusters) ||
-          !_isEqual(this.props.chosenTasks, prevProps.chosenTasks)) {
+          !_isEqual(this.props.selectedTasks, prevProps.selectedTasks)) {
         this.updateMapMarkers()
       }
     }
@@ -34,8 +34,9 @@ export const WithTaskClusterMarkers = function(WrappedComponent) {
       const markers = _map(this.props.taskClusters, cluster => {
         return AsMappableCluster(cluster).mapMarker(
           this.props.monochromaticClusters,
-          this.props.chosenTasks,
-          this.props.highlightPrimaryTask
+          this.props.selectedTasks,
+          this.props.highlightPrimaryTask,
+          this.props.allTasksAreSelected && this.props.allTasksAreSelected(),
         )
       })
 

--- a/src/components/TaskPane/TaskNearbyList/TaskNearbyMap.js
+++ b/src/components/TaskPane/TaskNearbyList/TaskNearbyMap.js
@@ -49,19 +49,19 @@ const starIconSvg = L.vectorIcon({
   },
 })
 
-const markerIconSvg = (fillColor=colors['blue-leaflet'], priority) => L.vectorIcon({
+const markerIconSvg = (priority, styleOptions={}) => L.vectorIcon({
   viewBox: '0 0 20 20',
-  svgHeight: 40 - (priority * 10),
+  svgHeight: 45 - (priority * 10),
   svgWidth: 40 - (priority * 10),
   type: 'path',
   shape: { // zondicons "location" icon
     d: "M10 20S3 10.87 3 7a7 7 0 1 1 14 0c0 3.87-7 13-7 13zm0-11a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"
   },
-  style: {
-    fill: fillColor,
+  style: Object.assign({
+    fill: colors['blue-leaflet'],
     stroke: colors['grey-leaflet'],
     strokeWidth: 0.5,
-  },
+  }, styleOptions),
   iconAnchor: [5, 15], // render tip of SVG near marker location
 })
 
@@ -116,14 +116,17 @@ export class TaskNearbyMap extends Component {
         const isRequestedMarker = marker.options.taskId === this.props.requestedNextTask
         const markerData = _cloneDeep(marker)
         markerData.options.title = `Task ${marker.options.taskId}`
+        const markerStyle = {
+          fill: TaskStatusColors[_get(marker.options, 'status', 0)],
+          stroke: isRequestedMarker ? colors.yellow : colors['grey-leaflet'],
+          strokeWidth: isRequestedMarker ? 2 : 0.5,
+        }
 
         return (
           <Marker
             key={marker.options.taskId}
             {...markerData}
-            icon={markerIconSvg(isRequestedMarker ? colors.yellow :
-              TaskStatusColors[_get(marker.options, 'status', 0)],
-              _get(marker.options, 'priority', 0))}
+            icon={markerIconSvg(_get(marker.options, 'priority', 0), markerStyle)}
             zIndexOffset={isRequestedMarker ? 1000 : undefined}
             onClick={() => this.markerClicked(markerData)}
           >

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -293,7 +293,7 @@ const BuildBundle = props => {
       loadingTasks={props.loadingTasks}
       showMarkerPopup={showMarkerPopup}
       highlightPrimaryTask={props.task.id}
-      chosenTasks={selectedTasks}
+      selectedTasks={selectedTasks}
       boundingBox={_get(props, 'criteria.boundingBox')}
       onBulkTaskSelection={props.selectTasksById}
       allowClusterToggle={false}

--- a/src/interactions/TaskCluster/AsMappableCluster.js
+++ b/src/interactions/TaskCluster/AsMappableCluster.js
@@ -52,14 +52,14 @@ export class AsMappableCluster {
    * Generates a map marker object suitable for use with a Leaflet map, with
    * optionally customized appearance for the given map layer
    */
-  mapMarker(monochromatic, selectedTasks, highlightPrimaryTask) {
+  mapMarker(monochromatic, selectedTasks, highlightPrimaryTask, allTasksSelected) {
     return {
       position: [this.point.lat, this.point.lng],
       options: {...(_merge(this.rawData, {taskStatus: this.rawData.status,
                                           taskPriority: this.rawData.priority,
                                           name: this.rawData.title,
                                           taskId: this.rawData.id}))},
-      icon: this.leafletMarkerIcon(monochromatic, selectedTasks, highlightPrimaryTask),
+      icon: this.leafletMarkerIcon(monochromatic, selectedTasks, highlightPrimaryTask, allTasksSelected),
     }
   }
 
@@ -67,7 +67,7 @@ export class AsMappableCluster {
    * Generates a Leaflet Icon object appropriate for the given cluster based on
    * its size, including using a standard marker for a single point
    */
-  leafletMarkerIcon(monochromatic=false, selectedTasks, highlightPrimaryTask) {
+  leafletMarkerIcon(monochromatic=false, selectedTasks, highlightPrimaryTask=false, allTasksSelected=false) {
     const count = _isFunction(this.rawData.getChildCount) ?
                   this.rawData.getChildCount() :
                   _get(this.options, 'numberOfPoints', this.numberOfPoints)
@@ -102,9 +102,10 @@ export class AsMappableCluster {
         icon.options.style.fill = colors.yellow
         icon.options.iconAnchor = [5, 25] // adjust position of marker tip for larger size
       }
-      else if (selectedTasks && selectedTasks.has(markerData.taskId)) {
+      else if (allTasksSelected || (selectedTasks && selectedTasks.has(markerData.taskId))) {
         icon = _cloneDeep(selectedTaskStatusIcons[markerData.taskStatus])
-        icon.options.style.fill = colors.yellow
+        icon.options.style.stroke = colors.yellow
+        icon.options.style.strokeWidth = 2
       }
       icon.options.taskData = markerData
 


### PR DESCRIPTION
* Highlight selected tasks on Task Analysis map for challenge managers

* Change all task-highlighting on maps from using a solid yellow fill to
using a thick yellow stroke, thereby preserving the task status fill
color

* Fix handling of highlighting when all tasks have been selected via
tri-state checkbox toggle in tasks table