### PR TITLE
Generate error for unsupported GeoJSON geometries

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
@@ -9,7 +9,6 @@ import _isUndefined from 'lodash/isUndefined'
 import _isFinite from 'lodash/isFinite'
 import _omit from 'lodash/omit'
 import _filter from 'lodash/filter'
-import _first from 'lodash/first'
 import _difference from 'lodash/difference'
 import _get from 'lodash/get'
 import _remove from 'lodash/remove'
@@ -171,7 +170,11 @@ export class EditChallenge extends Component {
     }
     else {
       response.errors = {
-        localGeoJSON: {__errors: _map(lintErrors, e => `GeoJSON error: ${e.message}`)}
+        localGeoJSON: {
+          __errors: _map(lintErrors, e =>
+            _isObject(e.message) ? this.props.intl.formatMessage(e.message) : `GeoJSON error: ${e.message}`
+          )
+        }
       }
     }
 
@@ -188,7 +191,7 @@ export class EditChallenge extends Component {
 
     if (lintErrors.length > 0) {
       response.errors = {
-        overpassQL: this.props.intl.formatMessage(_first(lintErrors).message)
+        overpassQL: {__errors: [this.props.intl.formatMessage(lintErrors[0].message)]}
       }
     }
 
@@ -205,8 +208,8 @@ export class EditChallenge extends Component {
       if (!_isEmpty(this.state.extraErrors)) {
         this.setState({extraErrors: {}})
       }
-    }).catch(errors => {
-      this.setState({extraErrors: errors})
+    }).catch(dataSourceErrors => {
+      this.setState({extraErrors: dataSourceErrors})
     }).finally(() => {
       this.validationPromise = null
     })

--- a/src/interactions/GeoJSON/Messages.js
+++ b/src/interactions/GeoJSON/Messages.js
@@ -1,0 +1,16 @@
+import { defineMessages } from 'react-intl'
+
+/**
+ * Internationalized messages for use with GeoJSON interactions
+ */
+export default defineMessages({
+  noZCoordinates: {
+    id: "Admin.EditChallenge.geojson.errors.noZCoordinates",
+    defaultMessage: "MapRoulette does not support Z coordinates in Points. Please remove any Z coordinates.",
+  },
+
+  noNullGeometry: {
+    id: "Admin.EditChallenge.geojson.errors.noNullGeometry",
+    defaultMessage: "MapRoulette does not support null geometries. Please remove any features with null geometries.",
+  },
+})

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -193,6 +193,8 @@
   "Admin.EditChallenge.form.updateTasks.label": "Remove Stale Tasks",
   "Admin.EditChallenge.form.visible.description": "Allow your challenge to be easily discoverable by other users via Find Challenges (subject to project discoverability). Note that all challenges are considered public and, even when Discoverable is off, users can still view your challenge if they have a direct link to it.",
   "Admin.EditChallenge.form.visible.label": "Discoverable",
+  "Admin.EditChallenge.geojson.errors.noNullGeometry": "MapRoulette does not support null geometries. Please remove any features with null geometries.",
+  "Admin.EditChallenge.geojson.errors.noZCoordinates": "MapRoulette does not support Z coordinates in Points. Please remove any Z coordinates.",
   "Admin.EditChallenge.lineNumber": "Line {line, number}: ",
   "Admin.EditChallenge.new.header": "New Challenge",
   "Admin.EditChallenge.overpass.errors.noTurboShortcuts": "Overpass Turbo shortcuts are not supported. If you wish to use them, please visit Overpass Turbo and test your query, then choose Export -> Query -> Standalone -> Copy and then paste that here.",


### PR DESCRIPTION
* Generate errors if challenge creator tries to upload technically
legal, but unsupported, GeoJSON when creating a challenge

* Error on inclusion of Z coordinates in Points (fixes #1034)

* Error on inclusion of null geometries (fixes #551)

* Properly surface error when Overpass Turbo shortcuts are detected