### PR TITLE
Fix ReviewStatusMetrics widget showing wrong data

### DIFF
--- a/src/components/AdminPane/Manage/ChallengeDashboard/ChallengeDashboard.js
+++ b/src/components/AdminPane/Manage/ChallengeDashboard/ChallengeDashboard.js
@@ -19,8 +19,6 @@ import WithClusteredTasks
       from '../../../HOCs/WithClusteredTasks/WithClusteredTasks'
 import WithChallengeMetrics
        from '../../HOCs/WithChallengeMetrics/WithChallengeMetrics'
-import WithChallengeReviewMetrics
-      from '../../HOCs/WithChallengeReviewMetrics/WithChallengeReviewMetrics'
 import WithSearch from '../../../HOCs/WithSearch/WithSearch'
 import WidgetWorkspace from '../../../WidgetWorkspace/WidgetWorkspace'
 import TaskUploadingProgress
@@ -159,9 +157,7 @@ WithManageableProjects(
           WithClusteredTasks(
             WithFilteredClusteredTasks(
               WithChallengeMetrics(
-                WithChallengeReviewMetrics(
-                  injectIntl(ChallengeDashboard),
-                )
+                injectIntl(ChallengeDashboard),
               ),
               'clusteredTasks',
               'filteredClusteredTasks'

--- a/src/components/AdminPane/Manage/ProjectDashboard/ProjectDashboard.js
+++ b/src/components/AdminPane/Manage/ProjectDashboard/ProjectDashboard.js
@@ -15,8 +15,6 @@ import WithWidgetWorkspaces
        from '../../../HOCs/WithWidgetWorkspaces/WithWidgetWorkspaces'
 import WithDashboardEntityFilter
        from '../../HOCs/WithDashboardEntityFilter/WithDashboardEntityFilter'
-import WithProjectReviewMetrics
-      from '../../HOCs/WithProjectReviewMetrics/WithProjectReviewMetrics'
 import WidgetWorkspace from '../../../WidgetWorkspace/WidgetWorkspace'
 import ChallengeFilterGroup from '../ChallengeFilterGroup/ChallengeFilterGroup'
 import ConfirmAction from '../../../ConfirmAction/ConfirmAction'
@@ -159,8 +157,7 @@ WithManageableProjects(
   WithCurrentProject(
     WithWidgetWorkspaces(
       WithDashboardEntityFilter(
-        WithProjectReviewMetrics(
-          injectIntl(ProjectDashboard)),
+        injectIntl(ProjectDashboard),
         'challenge',
         'challenges',
         'pinnedChallenges',

--- a/src/pages/Review/Metrics/ReviewStatusMetrics.js
+++ b/src/pages/Review/Metrics/ReviewStatusMetrics.js
@@ -10,6 +10,7 @@ import { TaskPriority, keysByPriority, taskPriorityLabels }
 import { TaskStatus, keysByStatus, statusLabels }
       from '../../../services/Task/TaskStatus/TaskStatus'
 import SvgSymbol from '../../../components/SvgSymbol/SvgSymbol'
+import BusySpinner from '../../../components/BusySpinner/BusySpinner'
 
 
 /**
@@ -92,6 +93,8 @@ export default class ReviewStatusMetrics extends Component {
     )
   }
   render() {
+    if (this.props.loading) return <BusySpinner />
+
     const metrics = this.props.reviewMetrics
     const reviewMetricsByPriority = this.props.reviewMetricsByPriority
     const reviewMetricsByTaskStatus = this.props.reviewMetricsByTaskStatus


### PR DESCRIPTION
When switching between dashboards (project, challenge, review)
make sure ReviewStatusMetrics widget uses the correct HOC.