### PR TITLE
Fix average time spent on projects page

### DIFF
--- a/src/components/AdminPane/HOCs/WithComputedMetrics/WithComputedMetrics.js
+++ b/src/components/AdminPane/HOCs/WithComputedMetrics/WithComputedMetrics.js
@@ -4,7 +4,7 @@ import _get from 'lodash/get'
 import _isEmpty from 'lodash/isEmpty'
 import _isArray from 'lodash/isArray'
 import _isObject from 'lodash/isObject'
-import _isNumber from 'lodash/isNumber'
+import _isFinite from 'lodash/isFinite'
 import _each from 'lodash/each'
 import _fromPairs from 'lodash/fromPairs'
 import _map from 'lodash/map'
@@ -26,17 +26,17 @@ export default function(WrappedComponent) {
     updateTotals = (actions, totalTasks, taskMetrics) => {
       _each(actions, (value, label) => {
         if (label === "avgTimeSpent") {
-          taskMetrics.totalTimeSpent = _isNumber(taskMetrics.totalTimeSpent) ?
+          taskMetrics.totalTimeSpent = _isFinite(taskMetrics.totalTimeSpent) ?
             taskMetrics.totalTimeSpent + (value * actions.tasksWithTime) :
             value * actions.tasksWithTime
         }
         else {
-          taskMetrics[label] = _isNumber(taskMetrics[label]) ?
+          taskMetrics[label] = _isFinite(taskMetrics[label]) ?
                               taskMetrics[label] + value :
                               value
 
           const percentage = (1.0 * value / totalTasks) * 100.0
-          taskMetrics.percentages[label] =  _isNumber(taskMetrics.percentages[label]) ?
+          taskMetrics.percentages[label] =  _isFinite(taskMetrics.percentages[label]) ?
                                             taskMetrics.percentages[label] + percentage :
                                             percentage
         }

--- a/src/components/AdminPane/HOCs/WithComputedMetrics/WithComputedMetrics.js
+++ b/src/components/AdminPane/HOCs/WithComputedMetrics/WithComputedMetrics.js
@@ -25,14 +25,21 @@ export default function(WrappedComponent) {
 
     updateTotals = (actions, totalTasks, taskMetrics) => {
       _each(actions, (value, label) => {
-        taskMetrics[label] = _isNumber(taskMetrics[label]) ?
-                            taskMetrics[label] + value :
-                            value
+        if (label === "avgTimeSpent") {
+          taskMetrics.totalTimeSpent = _isNumber(taskMetrics.totalTimeSpent) ?
+            taskMetrics.totalTimeSpent + (value * actions.tasksWithTime) :
+            value * actions.tasksWithTime
+        }
+        else {
+          taskMetrics[label] = _isNumber(taskMetrics[label]) ?
+                              taskMetrics[label] + value :
+                              value
 
-        const percentage = (1.0 * value / totalTasks) * 100.0
-        taskMetrics.percentages[label] =  _isNumber(taskMetrics.percentages[label]) ?
-                                          taskMetrics.percentages[label] + percentage :
-                                          percentage
+          const percentage = (1.0 * value / totalTasks) * 100.0
+          taskMetrics.percentages[label] =  _isNumber(taskMetrics.percentages[label]) ?
+                                            taskMetrics.percentages[label] + percentage :
+                                            percentage
+        }
       })
     }
 

--- a/src/components/ChallengeProgress/ChallengeProgress.js
+++ b/src/components/ChallengeProgress/ChallengeProgress.js
@@ -240,14 +240,22 @@ export class ChallengeProgress extends Component {
       return null
     }
 
+    let calculatedSeconds = null
     let averageTime = null
-    if (_get(taskActions, 'avgTimeSpent', 0) > 0) {
-      const seconds = taskActions.avgTimeSpent / 1000
+    if (_get(taskActions, 'tasksWithTime', 0) > 0 &&
+        _get(taskActions, 'totalTimeSpent', 0) > 0) {
+      calculatedSeconds = taskActions.totalTimeSpent / taskActions.tasksWithTime / 1000
+    }
+    else if (_get(taskActions, 'avgTimeSpent', 0) > 0) {
+      calculatedSeconds = taskActions.avgTimeSpent / 1000
+    }
+
+    if (calculatedSeconds) {
       averageTime =
         <div className="">
           <FormattedMessage {...messages.avgTimeSpent} />
           <span className="mr-pl-2">
-            {Math.floor(seconds / 60)}m {Math.floor(seconds) % 60}s
+            {Math.floor(calculatedSeconds / 60)}m {Math.floor(calculatedSeconds) % 60}s
           </span>
           {this.props.noteAvgExcludesSkip &&
             <span className="mr-pl-2">


### PR DESCRIPTION
Project admin page was adding the avgTimeSpent of each challenge instead of calculating a weighted average.