### PR TITLE
Fix creation of small virtual challenges

### DIFF
--- a/src/services/VirtualChallenge/VirtualChallenge.js
+++ b/src/services/VirtualChallenge/VirtualChallenge.js
@@ -88,7 +88,7 @@ export const createVirtualChallenge = function(name, taskIds, expiration, cluste
       taskIdList: taskIds,
       expiry: expiration ? expiration :
               addHours(new Date(), DEFAULT_EXPIRATION_DURATION).getTime(),
-      searchParameters
+      searchParameters: searchParameters || {},
     }
 
     return saveVirtualChallenge(


### PR DESCRIPTION
* Pass an empty object for searchParameters to backend instead of null
when creating a small virtual challenge where no clusters are included
(only individual tasks)

* Fixes #1373