### PR TITLE
Add support for searching for challenges by id when adding to virtual projects

### DIFF
--- a/src/components/AdminPane/Manage/VirtualProjects/ManageChallengeList.js
+++ b/src/components/AdminPane/Manage/VirtualProjects/ManageChallengeList.js
@@ -9,6 +9,7 @@ import WithManageableProjects
 import WithCurrentProject from '../../HOCs/WithCurrentProject/WithCurrentProject'
 import WithSearch from '../../../HOCs/WithSearch/WithSearch'
 import WithSearchResults from '../../../HOCs/WithSearchResults/WithSearchResults'
+import WithCommandInterpreter from '../../../HOCs/WithCommandInterpreter/WithCommandInterpreter'
 import WithPermittedChallenges from '../../HOCs/WithPermittedChallenges/WithPermittedChallenges'
 import WithPagedChallenges from '../../../HOCs/WithPagedChallenges/WithPagedChallenges'
 import { extendedFind } from '../../../../services/Challenge/Challenge'
@@ -24,10 +25,18 @@ import messages from './Messages'
 
 // Setup child components with needed HOCs.
 const ChallengeSearch = WithSearch(
-  SearchBox,
+  WithCommandInterpreter(SearchBox, ['p', 'i']),
   'adminChallengeList',
-  searchCriteria =>
-    extendedFind({searchQuery: searchCriteria.query, onlyEnabled: false}, 1000),
+  searchCriteria => {
+    if (_get(searchCriteria, 'filters')) {
+      return extendedFind({filters: _get(searchCriteria, 'filters', {}),
+                           onlyEnabled: false}, 1000)
+    }
+    else {
+      return extendedFind({searchQuery: searchCriteria.query,
+                           onlyEnabled: false}, 1000)
+    }
+  },
 )
 
 const ChallengeSearchResults =

--- a/src/components/HOCs/WithSearchResults/WithSearchResults.js
+++ b/src/components/HOCs/WithSearchResults/WithSearchResults.js
@@ -62,7 +62,18 @@ export const WithSearchResults = function(WrappedComponent, searchName,
       let searchResults = this.props[itemsProp]
       let searchActive = false
 
-      if (_isString(query) && query.length > 0 &&
+      if (_get(this.props.searchCriteria, 'filters.challengeId')) {
+        const challengeIdFilter = _get(this.props.searchCriteria, 'filters.challengeId')
+        searchResults = _filter(items,
+          (item) => item.id.toString() === challengeIdFilter.toString()
+        )
+      }
+      else if (_get(this.props.searchCriteria, 'filters.project')) {
+        const projectFilter = _get(this.props.searchCriteria, 'filters.project', '').toLowerCase()
+        searchResults = _filter(items,
+          (item) => _get(item, 'parent.displayName', '').toLowerCase().indexOf(projectFilter) !== -1)
+      }
+      else if (_isString(query) && query.length > 0 &&
           _isArray(items) && items.length > 0) {
         const queryParts = parseQueryString(query)
 

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -727,6 +727,7 @@
   "Errors.reviewTask.alreadyClaimed": "This task is already being reviewed by someone else.",
   "Errors.reviewTask.fetchFailure": "Unable to fetch review needed tasks",
   "Errors.reviewTask.notClaimedByYou": "Unable to cancel review.",
+  "Errors.search.notSupported": "Short code search not supported{details}",
   "Errors.task.alreadyLocked": "Task has already been locked by someone else.",
   "Errors.task.bundleFailure": "Unable to bundle tasks together",
   "Errors.task.cooperativeFailure": "Failed to load cooperative task{details}",

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -317,6 +317,7 @@ export const extendedFind = function(criteria, limit=RESULTS_PER_PAGE) {
     // cs: query string
     // cd: challenge difficulty
     // ct: keywords/tags (comma-separated string)
+    // cid: challenge id
     const queryParams = {
       limit,
       ce: onlyEnabled ? 'true' : 'false',
@@ -331,6 +332,10 @@ export const extendedFind = function(criteria, limit=RESULTS_PER_PAGE) {
 
     if (_isString(filters.project)) {
       queryParams.ps = filters.project
+    }
+
+    if (_isString(filters.challengeId)) {
+      queryParams.cid = filters.challengeId
     }
 
     // Keywords/tags can come from both the the query and the filter, so we need to

--- a/src/services/Error/AppErrors.js
+++ b/src/services/Error/AppErrors.js
@@ -108,4 +108,8 @@ export default {
   team: {
     failure: messages.teamFailure,
   },
+
+  search: {
+    notSupported: messages.searchNotSupported,
+  },
 }

--- a/src/services/Error/Messages.js
+++ b/src/services/Error/Messages.js
@@ -238,4 +238,8 @@ export default defineMessages({
     id: "Errors.team.genericFailure",
     defaultMessage: "Failure{details}"
   },
+  searchNotSupported: {
+    id: "Errors.search.notSupported",
+    defaultMessage: "Short code search not supported{details}"
+  }
 })


### PR DESCRIPTION
* When searching for challenges to add to a virtual project, support searching by id. Short code in search box: i/

* support i/ also on find challenges page for visible challenges

* When attempting to use a short code in a search box that doesn't support that short code show an error