### PR TITLE
Fix multiple datasources being sent on create challenge

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
@@ -338,8 +338,32 @@ export class EditChallenge extends Component {
         delete challengeData.dataOriginDate
       }
 
+      if (_isEmpty(this.state.formData.overpassQL)) {
+        delete challengeData.overpassQL
+      }
+
+      if (_isEmpty(this.state.formData.remoteGeoJson)) {
+        delete challengeData.remoteGeoJson
+      }
+
       challengeData.checkinComment =
         AsEditableChallenge(challengeData).checkinCommentWithoutMaprouletteHashtag()
+    }
+
+    if (this.state.formData.source === "Overpass Query") {
+      // Overpass Query so delete other options
+      delete challengeData.remoteGeoJson
+      delete challengeData.localGeoJSON
+    }
+    else if (this.state.formData.source === "Local File") {
+      // Local file so delete other options
+      delete challengeData.remoteGeoJson
+      delete challengeData.overpassQL
+    }
+    else if (this.state.formData.source === "Remote URL") {
+      // Remote Url so delete other options
+      delete challengeData.overpassQL
+      delete challengeData.localGeoJSON
     }
 
     // The server uses two fields to represent the default basemap: a legacy


### PR DESCRIPTION
* When creating a challenge a user can enter multiple datasources
  by toggling between the options, prevent this so only one datasource
  gets sent to the server.

* When cloning a challenge do not copy original datasource

Closes #1381