### PR TITLE
Hide admin start challenge control on completed challenges

### DIFF
--- a/src/components/AdminPane/Manage/ChallengeCard/ChallengeControls.js
+++ b/src/components/AdminPane/Manage/ChallengeCard/ChallengeControls.js
@@ -60,6 +60,7 @@ export default class ChallengeControls extends Component {
     return (
       <div className={this.props.className}>
         {hasTasks && isUsableChallengeStatus(status, true) &&
+         status !== ChallengeStatus.finished &&
           <Link
             to={`/challenge/${this.props.challenge.id}`}
             className={this.props.controlClassName}


### PR DESCRIPTION
* In admin challenge dashboard, don't show 'start challenge'
  control if the challenge has been completed as there is nothing
  to 'start'