### PR TITLE
Fix weird behavior when searching by challenge id in search box

### DIFF
--- a/src/components/AdminPane/Manage/VirtualProjects/ManageChallengeList.js
+++ b/src/components/AdminPane/Manage/VirtualProjects/ManageChallengeList.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import _get from 'lodash/get'
 import _isObject from 'lodash/isObject'
 import _omit from 'lodash/omit'
+import _isEmpty from 'lodash/isEmpty'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import { Link } from 'react-router-dom'
 import WithManageableProjects
@@ -28,7 +29,7 @@ const ChallengeSearch = WithSearch(
   WithCommandInterpreter(SearchBox, ['p', 'i']),
   'adminChallengeList',
   searchCriteria => {
-    if (_get(searchCriteria, 'filters')) {
+    if (!_isEmpty(_get(searchCriteria, 'filters'))) {
       return extendedFind({filters: _get(searchCriteria, 'filters', {}),
                            onlyEnabled: false}, 1000)
     }

--- a/src/components/HOCs/WithCommandInterpreter/WithCommandInterpreter.js
+++ b/src/components/HOCs/WithCommandInterpreter/WithCommandInterpreter.js
@@ -49,10 +49,7 @@ const WithCommandInterpreter = function(WrappedComponent, acceptedCommands = nul
     clearSearch = () => {
       // Temporary: until we add an Advanced Search dialog where a user can
       // clear a project search filter, we need to do it explicitly here
-      this.props.removeSearchFilters(['query'])
-      this.props.removeSearchFilters(['project'])
-      this.props.removeSearchFilters(['searchType'])
-      this.props.removeSearchFilters(['challengeId'])
+      this.props.removeSearchFilters(['query', 'project', 'searchType', 'challengeId'])
 
       this.props.clearSearch()
       this.setState({commandString: null, searchType: null, searchActive: true})
@@ -128,15 +125,9 @@ export const executeCommand = (props, commandString, searchType, setLoading,
   const command = commandString && commandString.length >= 2 ? commandString.substring(0, 2) : null
   let query = commandString ? commandString.substring(2) : commandString
 
-  // Temporary: until we add an Advanced Search dialog where a user can clear a
-  // project search filter, we need to do it explicitly here if needed
-  if (command !== '/p') {
-    props.removeSearchFilters(['project'])
-  }
-
   switch(command) {
     case 'm/':
-    props.setSearch("") // We need to clear the initial 'm' from the query
+      props.setSearch("") // We need to clear the initial 'm' from the query
       if (isCommandSupported('m', acceptedCommands, props)) {
         if (isComplete && query.length > 0) {
           debouncedMapSearch(props, query, setLoading)
@@ -184,6 +175,8 @@ export const executeCommand = (props, commandString, searchType, setLoading,
       if (command !== 's/') {
         query = commandString
       }
+      // Remove any lingering search filters.
+      props.removeSearchFilters(['project', 'challengeId'])
 
       // Standard search query
       props.setSearch(query)

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -18,6 +18,8 @@ import './SearchBox.scss'
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default class SearchBox extends Component {
+  inputRef = React.createRef()
+
   /**
    * Esc clears search, Enter signals completion
    *
@@ -49,10 +51,18 @@ export default class SearchBox extends Component {
         _get(props, 'searchQuery.query')) || ''
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.inputRef.current) {
+      if (this.getQuery(this.props) !== this.inputRef.current.value) {
+        // We have an uncotrolled input so our cursor can be managed as expected,
+        // so if the input isn't what we expect then we need to change it.
+        this.inputRef.current.value = this.getQuery(this.props)
+      }
+    }
+  }
+
   render() {
-    const query = (this.props.searchGroup ?
-      _get(this.props, `searchQueries.${this.props.searchGroup}.searchQuery.query`) :
-      _get(this.props, 'searchQuery.query')) || ''
+    const query = this.getQuery(this.props)
     const isLoading = _get(this.props, 'searchQuery.meta.fetchingResults')
 
     const clearButton =
@@ -71,7 +81,6 @@ export default class SearchBox extends Component {
           sym="outline-arrow-right-icon"
         />
       </button>
-
 
     return (
       <div
@@ -107,7 +116,7 @@ export default class SearchBox extends Component {
           maxLength="63"
           onChange={this.queryChanged}
           onKeyDown={this.checkForSpecialKeys}
-          value={query}
+          ref={this.inputRef}
         />
 
         {doneButton}


### PR DESCRIPTION
* In search box when searching by challenge id and then reverting
  to normal query search, clear the prior challengeId filter

* To prevent search box cursor from jumping to end when changing
  middle of string let the search box control the input

* When executing virtual challenge search query, search by query when
   filters are empty (and not just undefined/null)