### PR TITLE
Fix another case where cursor jumps in manage virtual project challenges

### DIFF
--- a/src/components/HOCs/WithCommandInterpreter/WithCommandInterpreter.js
+++ b/src/components/HOCs/WithCommandInterpreter/WithCommandInterpreter.js
@@ -8,6 +8,8 @@ import _find from 'lodash/find'
 import _get from 'lodash/get'
 import _debounce from 'lodash/debounce'
 import _trim from 'lodash/trim'
+import _toNumber from 'lodash/toNumber'
+import _isNaN from 'lodash/isNaN'
 import { fetchPlaceLocation } from '../../../services/Place/Place'
 import WithErrors from '../WithErrors/WithErrors'
 import AppErrors from '../../../services/Error/AppErrors'
@@ -40,7 +42,7 @@ const WithCommandInterpreter = function(WrappedComponent, acceptedCommands = nul
       const wasStandardSearch = executeCommand(this.props, commandString, searchType,
                                                false, false, acceptedCommands)
       this.setState({
-        commandString: wasStandardSearch ? null : commandString,
+        commandString: commandString,
         searchType: searchType,
         searchActive: wasStandardSearch,
       })
@@ -162,7 +164,7 @@ export const executeCommand = (props, commandString, searchType, setLoading,
     case 'i/':
       props.setSearch("") // We need to clear the initial 'i' from the query
       if (isCommandSupported('i', acceptedCommands, props)) {
-        if (query.length > 0) {
+        if (query.length > 0 && !_isNaN(_toNumber(_trim(query)))) {
           props.setSearchFilters({challengeId: _trim(query)})
         }
       }

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -18,7 +18,6 @@ import './SearchBox.scss'
  * @author [Neil Rotstan](https://github.com/nrotstan)
  */
 export default class SearchBox extends Component {
-  inputRef = React.createRef()
 
   /**
    * Esc clears search, Enter signals completion
@@ -49,16 +48,6 @@ export default class SearchBox extends Component {
     return (props.searchGroup ?
         _get(props, `searchQueries.${props.searchGroup}.searchQuery.query`) :
         _get(props, 'searchQuery.query')) || ''
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.inputRef.current) {
-      if (this.getQuery(this.props) !== this.inputRef.current.value) {
-        // We have an uncotrolled input so our cursor can be managed as expected,
-        // so if the input isn't what we expect then we need to change it.
-        this.inputRef.current.value = this.getQuery(this.props)
-      }
-    }
   }
 
   render() {
@@ -116,7 +105,7 @@ export default class SearchBox extends Component {
           maxLength="63"
           onChange={this.queryChanged}
           onKeyDown={this.checkForSpecialKeys}
-          ref={this.inputRef}
+          value={query}
         />
 
         {doneButton}


### PR DESCRIPTION
* Command String was being reset to "" when transitioning from an executed command to a straight up query which would cause the input to lose it's cursor position

* If a non-numeric value was in your challenge id search (i/) an error would be shown that it was not a valid id. Suppressed the call to the server to search on challenge id so the error will no longer be shown since if it's a non-numeric value it's likely you could be in the middle of typing/changing your query string.