### PR TITLE
Cooperative sort was sorting by wrong name

### DIFF
--- a/src/services/Search/Messages.js
+++ b/src/services/Search/Messages.js
@@ -20,7 +20,7 @@ export default defineMessages({
     id: "Challenge.sort.popularity",
     defaultMessage: "Popular",
   },
-  has_cooperative_work: {
+  cooperative_type: {
     id: "Challenge.sort.cooperativeWork",
     defaultMessage: "Cooperative",
   },

--- a/src/services/Search/Search.js
+++ b/src/services/Search/Search.js
@@ -45,7 +45,7 @@ export const SORT_NAME = 'name'
 export const SORT_CREATED = 'created'
 export const SORT_OLDEST = 'Created'
 export const SORT_POPULARITY = 'popularity'
-export const SORT_COOPERATIVE_WORK = 'has_cooperative_work'
+export const SORT_COOPERATIVE_WORK = 'cooperative_type'
 export const SORT_DEFAULT = 'default'
 export const ALL_SORT_OPTIONS = [SORT_NAME, SORT_CREATED, SORT_OLDEST, SORT_POPULARITY, SORT_COOPERATIVE_WORK, SORT_DEFAULT]
 


### PR DESCRIPTION
* Change cooperative sort value from 'has_cooperative_work' to
  'cooperative_type'

Fixes #1395 