### PR TITLE
Allow map overlays to be reordered

### DIFF
--- a/src/components/ChallengePane/ChallengePane.js
+++ b/src/components/ChallengePane/ChallengePane.js
@@ -29,9 +29,15 @@ import TaskChallengeMarkerContent from './TaskChallengeMarkerContent'
 
 // Setup child components with necessary HOCs
 const ChallengeResults = WithStatus(ChallengeResultList)
-const ClusterMap = WithChallengeTaskClusters(
-                      WithTaskClusterMarkers(TaskClusterMap('challenges')),
-                      true)
+const ClusterMap =
+  WithChallengeTaskClusters(
+    WithTaskClusterMarkers(
+      WithCurrentUser(
+        TaskClusterMap('challenges')
+      )
+    ),
+    true
+  )
 const LocationFilter = WithCurrentUser(FilterByLocation)
 
 /**

--- a/src/components/EnhancedMap/ImageMarkerLayer/ImageMarkerLayer.js
+++ b/src/components/EnhancedMap/ImageMarkerLayer/ImageMarkerLayer.js
@@ -1,0 +1,93 @@
+import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { LayerGroup, Marker, Popup } from 'react-leaflet'
+import L from 'leaflet'
+import _map from 'lodash/map'
+import resolveConfig from 'tailwindcss/resolveConfig'
+import tailwindConfig from '../../../tailwind.config.js'
+
+const colors = resolveConfig(tailwindConfig).theme.colors
+
+/**
+ * ImageMarkerLayer renders a layer of positioned image markers that, on hover,
+ * display the image in a popup. If the marker or popup is clicked then the
+ * `imageClicked` function is invoked with the image key.
+ *
+ * Each image must be an object containing `key`, `url,` and `position` (with `lat` and
+ * `lon`) fields
+ *
+ * Pass a `markerColor` prop with the desired marker color, or an `icon` if you
+ * wish to supply your own icon
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
+const ImageMarkerLayer = props => {
+  const [imageMarkers, setImageMarkers] = useState([])
+
+  useEffect(() => {
+    setImageMarkers(
+      buildImageMarkers(
+        props.images,
+        props.icon ? props.icon : circleIcon(props.markerColor),
+        props.imageClicked,
+        props.imageAlt,
+      )
+    )
+  }, [props.images, props.markerColor, props.imageAlt, props.imageClicked, props.icon])
+
+  return (
+    <LayerGroup style={props.style}>
+      {imageMarkers}
+    </LayerGroup>
+  )
+}
+
+ImageMarkerLayer.propTypes = {
+  layerKey: PropTypes.string,
+  images: PropTypes.arrayOf(PropTypes.shape({
+    key: PropTypes.string,
+    url: PropTypes.string,
+    position: PropTypes.object,
+  })),
+  imageClicked: PropTypes.func,
+  imageAlt: PropTypes.string,
+  buildIcon: PropTypes.func,
+  markerColor: PropTypes.string,
+}
+
+const buildImageMarkers = (images, icon, imageClicked, imageAlt) => {
+  if (!images || images.length === 0) {
+    return []
+  }
+
+  return _map(images, imageInfo =>
+    <Marker
+      key={imageInfo.key}
+      position={[imageInfo.lat, imageInfo.lon]}
+      icon={icon}
+      onMouseover={({target}) => target.openPopup()}
+      onClick={() => imageClicked ? imageClicked(imageInfo.key) : null}
+    >
+      <Popup>
+        <img
+          src={imageInfo.url}
+          alt={imageAlt}
+          onClick={() => imageClicked ? imageClicked(imageInfo.key) : null}
+        />
+      </Popup>
+    </Marker>
+  )
+}
+
+const circleIcon = (color = colors["blue-leaflet"]) => {
+  return L.vectorIcon({
+    svgHeight: 12,
+    svgWidth: 12,
+    viewBox: '0 0 12 12',
+    type: 'circle',
+    shape: { r: 6, cx: 6, cy: 6 },
+    style: { fill: color },
+  })
+}
+
+export default ImageMarkerLayer

--- a/src/components/EnhancedMap/MapAnimator/MapAnimator.js
+++ b/src/components/EnhancedMap/MapAnimator/MapAnimator.js
@@ -1,0 +1,58 @@
+/**
+ * Manages animation scheduling for a map
+ *
+ * @author [Neil Rotstan](https://github.com/nrotstan)
+ */
+class MapAnimator {
+  constructor(animationDelay = 250) {
+    this.animationDelay = animationDelay
+    this.animationFunction = null
+    this.animationHandle = null
+  }
+
+  /**
+   * Set the function to be invoked when animation executes
+   */
+  setAnimationFunction(func) {
+    this.animationFunction = func
+  }
+
+  /**
+   * Reset everything, clearing the animation function and cancelling any
+   * pending animations
+   */
+  reset() {
+    this.animationFunction = null
+    this.cancelPendingAnimation()
+  }
+
+  /**
+   * Schedules animation. If animation is already pending, it is first
+   * cancelled prior to scheduling a new one
+   */
+  scheduleAnimation() {
+    this.cancelPendingAnimation()
+    this.animationHandle = setTimeout(() => this.executeAnimation(), this.animationDelay)
+  }
+
+  /**
+   * Cancel any pending animation, clearing the timeout if it exists
+   */
+  cancelPendingAnimation() {
+    if (this.animationHandle) {
+      clearTimeout(this.animationHandle)
+      this.animationHandle = null
+    }
+  }
+
+  /**
+   * Execute the animation, invoking the animation function if set
+   */
+  executeAnimation() {
+    if (this.animationFunction) {
+      this.animationFunction()
+    }
+  }
+}
+
+export default MapAnimator

--- a/src/components/EnhancedMap/MapPane/MapPane.scss
+++ b/src/components/EnhancedMap/MapPane/MapPane.scss
@@ -29,6 +29,14 @@
 
         animation: marker-bounce 2s cubic-bezier(0.175, 0.885, 0.32, 1.275); // easeOutBack
       }
+
+      &.leaflet-popup-pane {
+        z-index: 100;
+      }
+
+      &.custom-pane img {
+        max-width: none !important;
+      }
     }
 
     .leaflet-control-container {

--- a/src/components/EnhancedMap/OSMDataLayer/OSMDataLayer.js
+++ b/src/components/EnhancedMap/OSMDataLayer/OSMDataLayer.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import { Path, withLeaflet } from 'react-leaflet'
 import L from 'leaflet'
 import _isEqual from 'lodash/isEqual'
+import _get from 'lodash/get'
 import PropertyList from '../PropertyList/PropertyList'
 import resolveConfig from 'tailwindcss/resolveConfig'
 import tailwindConfig from '../../../tailwind.config.js'
@@ -40,9 +41,7 @@ export class OSMDataLayer extends Path {
 
   createLeafletElement(props) {
     this.lastZoom = props.zoom
-    const osmLayerGroup = this.generateLayer(props)
-    osmLayerGroup.on('add', () => osmLayerGroup.bringToBack())
-    return osmLayerGroup
+    return this.generateLayer(props)
   }
 
   updateLeafletElement(fromProps, toProps) {
@@ -53,7 +52,6 @@ export class OSMDataLayer extends Path {
       newLayers.eachLayer(layer => this.leafletElement.addLayer(layer))
       this.lastZoom = toProps.zoom
     }
-    this.leafletElement.bringToBack()
   }
 
   generateElementStyles(props) {
@@ -80,9 +78,13 @@ export class OSMDataLayer extends Path {
       showNodes: props.showOSMElements.nodes,
       showWays: props.showOSMElements.ways,
       showAreas: props.showOSMElements.areas,
+      pane: _get(props, 'leaflet.pane'),
     })
 
-    layerGroup.eachLayer(layer => layer.options.fill = false)
+    layerGroup.eachLayer(layer => {
+      layer.options.fill = false
+      layer.options.pane = layerGroup.options.pane
+    })
     layerGroup.bindPopup(this.popupContent)
     return layerGroup
   }

--- a/src/components/EnhancedMap/TaskFeatureLayer/TaskFeatureLayer.js
+++ b/src/components/EnhancedMap/TaskFeatureLayer/TaskFeatureLayer.js
@@ -1,0 +1,68 @@
+import React, { useState, useEffect } from 'react'
+import ReactDOM from 'react-dom'
+import { GeoJSON, withLeaflet } from 'react-leaflet'
+import L from 'leaflet'
+import _isFunction from 'lodash/isFunction'
+import _get from 'lodash/get'
+import _uniqueId from 'lodash/uniqueId'
+import AsSimpleStyleableFeature
+       from '../../../interactions/TaskFeature/AsSimpleStyleableFeature'
+import PropertyList from '../PropertyList/PropertyList'
+
+/**
+ * TaskFeatureLayer renders a react-leaflet map layer representing the given
+ * (GeoJSON) features, properly styled and with a popup for the feature
+ * properties
+ */
+const TaskFeatureLayer = props => {
+  const [layer, setLayer] = useState(null)
+
+  const propertyList = featureProperties => {
+    const contentElement = document.createElement('div')
+    ReactDOM.render(
+      <PropertyList featureProperties={featureProperties} />,
+      contentElement
+    )
+    return contentElement
+  }
+
+  const { features, mrLayerId, animator } = props
+  const pane = _get(props, 'leaflet.pane')
+
+  useEffect(() => {
+    setLayer(
+      <GeoJSON
+        key={_uniqueId()}
+        mrLayerId={mrLayerId}
+        data={features}
+        pointToLayer={(point, latLng) => {
+          return L.marker(latLng, { pane })
+        }}
+        onEachFeature={(feature, layer) => {
+          layer.bindPopup(() => propertyList(feature.properties))
+
+          // Animate features when added to map (if requested)
+          if (animator) {
+            const oldOnAdd = layer.onAdd
+            layer.onAdd = map => {
+              oldOnAdd.call(layer, map)
+              animator.scheduleAnimation()
+            }
+          }
+
+          // Support custom layer styling
+          if (_isFunction(feature.styleLeafletLayer)) {
+            feature.styleLeafletLayer(layer)
+          }
+          else {
+            AsSimpleStyleableFeature(feature).styleLeafletLayer(layer)
+          }
+        }}
+      />
+    )
+  }, [features, mrLayerId, pane, animator])
+
+  return layer
+}
+
+export default withLeaflet(TaskFeatureLayer)

--- a/src/components/Sprites/Sprites.js
+++ b/src/components/Sprites/Sprites.js
@@ -5,6 +5,7 @@ import './Sprites.scss'
  * Most of these are from [Zondicons](http://www.zondicons.com/icons.html)
  * Puzzle-piece icon from earlier version of [Octicons](https://octicons.github.com/)
  * Lasso and outline-circle icons made by Freepik from www.flaticon.com
+ * reorder-icon made by Theo K. from the Noun Project
  */
 export default function() {
   return (
@@ -38,6 +39,9 @@ export default function() {
         </symbol>
         <symbol id="drag-handle-icon" viewBox="0 0 96 96">
           <path d="M94.2422,43.7578l-12-12a5.9994,5.9994,0,0,0-8.4844,8.4844L75.5156,42H54V20.4844l1.7578,1.7578a5.9994,5.9994,0,0,0,8.4844-8.4844l-12-12a5.9979,5.9979,0,0,0-8.4844,0l-12,12a5.9994,5.9994,0,0,0,8.4844,8.4844L42,20.4844V42H20.4844l1.7578-1.7578a5.9994,5.9994,0,0,0-8.4844-8.4844l-12,12a5.9979,5.9979,0,0,0,0,8.4844l12,12a5.9994,5.9994,0,1,0,8.4844-8.4844L20.4844,54H42V75.5156l-1.7578-1.7578a5.9994,5.9994,0,0,0-8.4844,8.4844l12,12a5.9979,5.9979,0,0,0,8.4844,0l12-12a5.9994,5.9994,0,0,0-8.4844-8.4844L54,75.5156V54H75.5156l-1.7578,1.7578a5.9994,5.9994,0,1,0,8.4844,8.4844l12-12A5.9979,5.9979,0,0,0,94.2422,43.7578Z" />
+        </symbol>
+        <symbol id="reorder-icon" viewBox="0 0 100 125">
+          <path d="M14 40h72v4H14zM50 14L34.459 31h31zM50 86l15.459-17h-31zM14 48h72v4H14zM14 56h72v4H14z" />
         </symbol>
         <symbol id="spinner-icon" viewBox="0 0 50 50">
           <path d="M25.251,6.461c-10.318,0-18.683,8.365-18.683,18.683h4.068c0-8.071,6.543-14.615,14.615-14.615V6.461z">

--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -2,7 +2,8 @@ import React, { Component } from 'react'
 import { FormattedMessage } from 'react-intl'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { ZoomControl, Marker, Rectangle} from 'react-leaflet'
+import { ZoomControl, Marker, LayerGroup, Rectangle, Pane }
+       from 'react-leaflet'
 import { latLng } from 'leaflet'
 import bbox from '@turf/bbox'
 import bboxPolygon from '@turf/bbox-polygon'
@@ -18,6 +19,7 @@ import _uniqueId from 'lodash/uniqueId'
 import _compact from 'lodash/compact'
 import _cloneDeep from 'lodash/cloneDeep'
 import _isObject from 'lodash/isObject'
+import _sortBy from 'lodash/sortBy'
 import _omit from 'lodash/omit'
 import { buildLayerSources } from '../../services/VisibleLayer/LayerSources'
 import { TaskPriorityColors } from '../../services/Task/TaskPriority/TaskPriority'
@@ -118,6 +120,12 @@ export class TaskClusterMap extends Component {
 
     // the visible overlays have changed
     if (nextProps.visibleOverlays.length !== this.props.visibleOverlays.length) {
+       return true
+    }
+
+    // the ordering of overlays has changed
+    if (!_isEqual(nextProps.getUserAppSetting(nextProps.user, 'mapOverlayOrder'),
+                  this.props.getUserAppSetting(this.props.user, 'mapOverlayOrder'))) {
        return true
     }
 
@@ -366,11 +374,40 @@ export class TaskClusterMap extends Component {
   }
 
   render() {
-    const overlayLayers = buildLayerSources(
+    const renderId = _uniqueId()
+    const overlayOrder = this.props.getUserAppSetting(this.props.user, 'mapOverlayOrder')
+    let overlayLayers = buildLayerSources(
       this.props.visibleOverlays, _get(this.props, 'user.settings.customBasemaps'),
-      (layerId, index, layerSource) =>
-        <SourcedTileLayer key={layerId} source={layerSource} zIndex={index + 2} />
+      (layerId, index, layerSource) => ({
+        id: layerId,
+        component: <SourcedTileLayer key={layerId} source={layerSource} />,
+      })
     )
+
+    if (this.props.showPriorityBounds) {
+      overlayLayers.push({
+        id: "priority-bounds",
+        component: (
+          <LayerGroup key="priority-bounds">
+            {this.props.priorityBounds.map((bounds, index) =>
+              <Rectangle
+                key={index}
+                bounds={toLatLngBounds(bounds.boundingBox)}
+                color={TaskPriorityColors[bounds.priorityLevel]}
+              />
+            )}
+          </LayerGroup>
+        )
+      })
+    }
+
+    // Sort the overlays according to the user's preferences
+    if (overlayOrder && overlayOrder.length > 0) {
+      overlayLayers = _sortBy(overlayLayers, layer => {
+        const position = overlayOrder.indexOf(layer.id)
+        return position === -1 ? Number.MAX_SAFE_INTEGER : position
+      }).reverse()
+    }
 
     const canClusterToggle = !!this.props.allowClusterToggle &&
       this.props.totalTaskCount <= UNCLUSTER_THRESHOLD &&
@@ -394,23 +431,17 @@ export class TaskClusterMap extends Component {
       this.currentBounds = this.props.initialBounds
     }
 
-    const priorityBounds = !this.props.showPriorityBounds ? null :
-      this.props.priorityBounds.map((bounds, index) =>
-        <Rectangle key={index}
-          bounds={toLatLngBounds(bounds.boundingBox)}
-          color={TaskPriorityColors[bounds.priorityLevel]}/>
-      )
-
-
     const map =
-      <EnhancedMap className="mr-z-0"
-                   center={latLng(0, 0)}
-                   zoom={this.currentZoom} minZoom={MIN_ZOOM} maxZoom={MAX_ZOOM}
-                   setInitialBounds={false}
-                   initialBounds = {this.currentBounds}
-                   zoomControl={false} animate={false} worldCopyJump={true}
-                   onBoundsChange={this.updateBounds}
-                   justFitFeatures>
+      <EnhancedMap
+        className="mr-z-0"
+        center={latLng(0, 0)}
+        zoom={this.currentZoom} minZoom={MIN_ZOOM} maxZoom={MAX_ZOOM}
+        setInitialBounds={false}
+        initialBounds = {this.currentBounds}
+        zoomControl={false} animate={false} worldCopyJump={true}
+        onBoundsChange={this.updateBounds}
+        justFitFeatures
+      >
         <ZoomControl className="mr-z-10" position='topright' />
         {this.props.showLasso && this.props.onBulkTaskSelection &&
           (!this.props.showAsClusters || this.props.totalTaskCount <= CLUSTER_POINTS) &&
@@ -430,11 +461,26 @@ export class TaskClusterMap extends Component {
           />
         }
         <VisibleTileLayer {...this.props} zIndex={1} />
-        {overlayLayers}
+        {_map(overlayLayers, (layer, index) => (
+          <Pane
+            key={`pane-${renderId}-${index}`}
+            name={`pane-${index}`}
+            style={{zIndex: 10 + index}}
+            className="custom-pane"
+          >
+            {layer.component}
+          </Pane>
+        ))}
         {!this.props.mapZoomedOut &&
-          <span key={_uniqueId()}>{this.state.mapMarkers}</span>
+         <Pane
+           key={`pane-${renderId}-task-markers`}
+           name={`pane-${renderId}-task-markers`}
+           style={{zIndex: 10 + overlayLayers.length}}
+           className="custom-pane"
+         >
+           {this.state.mapMarkers}
+         </Pane>
         }
-        {priorityBounds}
       </EnhancedMap>
 
     return (
@@ -447,7 +493,7 @@ export class TaskClusterMap extends Component {
             <FormattedMessage {...messages.clusterTasksLabel} />
           </label>
         }
-        <LayerToggle {...this.props} />
+        <LayerToggle {...this.props} overlayOrder={overlayOrder} />
         {!!this.props.mapZoomedOut && !this.state.locatingToUser &&
           <ZoomInMessage {...this.props} zoom={this.currentZoom}/>
         }

--- a/src/components/TaskPane/TaskMap/TaskMap.js
+++ b/src/components/TaskPane/TaskMap/TaskMap.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { ZoomControl, LayerGroup, Marker, Popup } from 'react-leaflet'
-import L from 'leaflet'
+import { ZoomControl, LayerGroup, Pane } from 'react-leaflet'
 import { featureCollection } from '@turf/helpers'
 import { coordAll } from '@turf/meta'
 import { point } from '@turf/helpers'
@@ -13,10 +12,12 @@ import _isFinite from 'lodash/isFinite'
 import _map from 'lodash/map'
 import _pick from 'lodash/pick'
 import _each from 'lodash/each'
+import _sortBy from 'lodash/sortBy'
 import _compact from 'lodash/compact'
 import _flatten from 'lodash/flatten'
 import _isEmpty from 'lodash/isEmpty'
 import _clone from 'lodash/clone'
+import _uniqueId from 'lodash/uniqueId'
 import { buildLayerSources } from '../../../services/VisibleLayer/LayerSources'
 import EnhancedMap from '../../EnhancedMap/EnhancedMap'
 import DirectionalIndicationMarker
@@ -26,9 +27,12 @@ import OpenStreetCamViewer from '../../OpenStreetCamViewer/OpenStreetCamViewer'
 import SourcedTileLayer
        from '../../EnhancedMap/SourcedTileLayer/SourcedTileLayer'
 import OSMDataLayer from '../../EnhancedMap/OSMDataLayer/OSMDataLayer'
+import ImageMarkerLayer from '../../EnhancedMap/ImageMarkerLayer/ImageMarkerLayer'
+import TaskFeatureLayer from '../../EnhancedMap/TaskFeatureLayer/TaskFeatureLayer'
 import LayerToggle from '../../EnhancedMap/LayerToggle/LayerToggle'
 import FitBoundsControl
        from '../../EnhancedMap/FitBoundsControl/FitBoundsControl'
+import MapAnimator from '../../EnhancedMap/MapAnimator/MapAnimator'
 import WithTaskCenterPoint
        from '../../HOCs/WithTaskCenterPoint/WithTaskCenterPoint'
 import WithSearch from '../../HOCs/WithSearch/WithSearch'
@@ -61,6 +65,7 @@ const shortcutGroup = 'layers'
  */
 export class TaskMap extends Component {
   latestBounds = null // track latest map bounds without causing rerender
+  animator = new MapAnimator()
 
   state = {
     showTaskFeatures: true,
@@ -76,7 +81,7 @@ export class TaskMap extends Component {
     openStreetCamViewerImage: null,
     skipFit: false,
     latestZoom: null,
-    directionalityIndicators: [],
+    directionalityIndicators: {},
   }
 
   /** Process keyboard shortcuts for the layers */
@@ -283,6 +288,11 @@ export class TaskMap extends Component {
       return true
     }
 
+    if (!_isEqual(this.props.getUserAppSetting(nextProps.user, 'mapOverlayOrder'),
+                  this.props.getUserAppSetting(this.props.user, 'mapOverlayOrder'))) {
+      return true
+    }
+
     if (!_isEqual(_get(nextProps, 'taskBundle.taskIds'),
                   _get(this.props, 'taskBundle.taskIds'))) {
       return true
@@ -356,58 +366,31 @@ export class TaskMap extends Component {
     }
   }
 
-  mapillaryImageMarkers = () => {
-    return this.streetLevelImageMarkers(
-      "Mapillary",
-      this.props.mapillaryImages,
-      'mapillaryViewerImage',
-      "#39AF64" // Mapillary green
-    )
-  }
+  mapillaryImageMarkers = () => ({
+    id: "mapillary",
+    component: (
+      <ImageMarkerLayer
+        key="mapillary"
+        images={this.props.mapillaryImages}
+        markerColor="#39AF64"
+        imageClicked={imageKey => this.setState({"mapillaryViewerImage": imageKey})}
+        imageAlt="Mapillary"
+      />
+    ),
+  })
 
-  openStreetCamImageMarkers = () => {
-    return this.streetLevelImageMarkers(
-      "OpenStreetCam",
-      this.props.openStreetCamImages,
-      'openStreetCamViewerImage',
-      "#C851E0" // OpenStreetCam magenta
-    )
-  }
-
-  streetLevelImageMarkers = (serviceName, images, viewerName, markerColor, imageAlt) => {
-    if (!images || images.length === 0) {
-      return []
-    }
-
-    const icon = L.vectorIcon({
-      svgHeight: 12,
-      svgWidth: 12,
-      viewBox: '0 0 12 12',
-      type: 'circle',
-      shape: { r: 6, cx: 6, cy: 6 },
-      style: { fill: markerColor },
-    })
-
-    const markers = _map(images, imageInfo =>
-      <Marker
-        key={imageInfo.key}
-        position={[imageInfo.lat, imageInfo.lon]}
-        icon={icon}
-        onMouseover={({target}) => target.openPopup()}
-        onClick={() => this.setState({[viewerName]: imageInfo.key})}
-      >
-        <Popup>
-          <img
-            src={imageInfo.url}
-            alt={`From ${serviceName}`}
-            onClick={() => this.setState({[viewerName]: imageInfo.key})}
-          />
-        </Popup>
-      </Marker>
-    )
-
-    return <LayerGroup key={Date.now()}>{markers}</LayerGroup>
-  }
+  openStreetCamImageMarkers = () => ({
+    id: "openstreetcam",
+    component: (
+      <ImageMarkerLayer
+        key="openstreetcam"
+        images={this.props.openStreetCamImages}
+        markerColor="#C851E0"
+        imageClicked={imageKey => this.setState({"openStreetCamViewerImage": imageKey})}
+        imageAlt="OpenStreetCam"
+      />
+    ),
+  })
 
   generateDirectionalityMarkers = () => {
     const markers = []
@@ -446,7 +429,12 @@ export class TaskMap extends Component {
       }
     })
 
-    this.setState({directionalityIndicators: markers})
+    this.setState({
+      directionalityIndicators: {
+        id: "directionality-indicators",
+        component: <LayerGroup key="directionality-indicators">{markers}</LayerGroup>,
+      }
+    })
   }
 
   taskFeatures = () => {
@@ -487,25 +475,73 @@ export class TaskMap extends Component {
   }
 
   render() {
+    const zoom = _get(this.props.task, "parent.defaultZoom", DEFAULT_ZOOM)
+    const minZoom = _get(this.props.task, "parent.minZoom", MIN_ZOOM)
+    const maxZoom = _get(this.props.task, "parent.maxZoom", MAX_ZOOM)
+    const overlayOrder = this.props.getUserAppSetting(this.props.user, 'mapOverlayOrder')
+    const renderId = _uniqueId()
+    this.animator.reset()
+
     if (!this.props.task || !_isObject(this.props.task.parent)) {
       return <BusySpinner />
     }
 
-    const overlayLayers = buildLayerSources(
+    let overlayLayers = buildLayerSources(
       this.props.visibleOverlays, _get(this.props, 'user.settings.customBasemaps'),
-      (layerId, index, layerSource) =>
-        <SourcedTileLayer key={layerId} source={layerSource} zIndex={index + 2} />
+      (layerId, index, layerSource) => ({
+        id: layerId,
+        component: <SourcedTileLayer key={layerId} source={layerSource} />,
+      })
     )
 
-    const mapillaryMarkers = this.props.showMapillaryLayer ?
-                             this.mapillaryImageMarkers() : []
+    if (this.state.showTaskFeatures) {
+      overlayLayers.push({
+        id: "task-features",
+        component: (
+          <TaskFeatureLayer
+            key="task-features"
+            mrLayerId="task-features"
+            features={this.applyStyling(this.taskFeatures())}
+            animator={this.animator}
+          />
+        )
+      })
+    }
 
-    const openStreetCamMarkers = this.props.showOpenStreetCamLayer ?
-                                 this.openStreetCamImageMarkers() : []
+    if (this.props.showMapillaryLayer) {
+      overlayLayers.push(this.mapillaryImageMarkers())
+    }
 
-    const zoom = _get(this.props.task, "parent.defaultZoom", DEFAULT_ZOOM)
-    const minZoom = _get(this.props.task, "parent.minZoom", MIN_ZOOM)
-    const maxZoom = _get(this.props.task, "parent.maxZoom", MAX_ZOOM)
+    if (this.props.showOpenStreetCamLayer) {
+      overlayLayers.push(this.openStreetCamImageMarkers())
+    }
+
+    if (this.state.showOSMData && this.state.osmData) {
+      overlayLayers.push({
+        id: "osm-data",
+        component: (
+          <OSMDataLayer
+            key="osm-data"
+            xmlData={this.state.osmData}
+            zoom={_isFinite(this.state.latestZoom) ? this.state.latestZoom : zoom}
+            showOSMElements={this.state.showOSMElements}
+            animator={this.animator}
+          />
+        ),
+      })
+    }
+
+    if (this.state.showTaskFeatures && !_isEmpty(this.state.directionalityIndicators)) {
+      overlayLayers.push(this.state.directionalityIndicators)
+    }
+
+    // Sort the overlays according to the user's preferences
+    if (overlayOrder && overlayOrder.length > 0) {
+      overlayLayers = _sortBy(overlayLayers, layer => {
+        const position = overlayOrder.indexOf(layer.id)
+        return position === -1 ? Number.MAX_SAFE_INTEGER : position
+      }).reverse()
+    }
 
     // Note: we need to also pass maxZoom to the tile layer (in addition to the
     // map), or else leaflet won't autoscale if the zoom goes beyond the
@@ -528,6 +564,7 @@ export class TaskMap extends Component {
           toggleOpenStreetCam={this.props.isOpenStreetCamEnabled() ? this.toggleOpenStreetCamVisibility : undefined}
           showOpenStreetCam={this.props.showOpenStreetCamLayer}
           openStreetCamCount={_get(this.props, 'openStreetCamImages.length', 0)}
+          overlayOrder={overlayOrder}
         />
         <EnhancedMap
           center={this.props.centerPoint}
@@ -537,27 +574,25 @@ export class TaskMap extends Component {
           maxZoom={maxZoom}
           worldCopyJump={true}
           features={this.applyStyling(this.taskFeatures())}
-          justFitFeatures={!this.state.showTaskFeatures}
-          skipFit={this.state.skipFit}
-          fitFeaturesOnlyAsNecessary
-          animateFeatures
+          fitToLayer={this.state.skipFit ? null : 'task-features'}
+          fitBoundsOnlyAsNecessary
+          animator={this.animator}
           onBoundsChange={this.updateTaskBounds}
           conditionalStyles={_get(this.props, 'challenge.taskStyles')}
         >
           <ZoomControl position='topright' />
           <FitBoundsControl />
-          <SourcedTileLayer maxZoom={maxZoom} {...this.props} zIndex={1} />
-          {overlayLayers}
-          {this.state.showOSMData && this.state.osmData &&
-           <OSMDataLayer
-             xmlData={this.state.osmData}
-             zoom={_isFinite(this.state.latestZoom) ? this.state.latestZoom : zoom}
-             showOSMElements={this.state.showOSMElements}
-           />
-          }
-          {this.props.showMapillaryLayer && mapillaryMarkers}
-          {this.props.showOpenStreetCamLayer && openStreetCamMarkers}
-          {this.state.showTaskFeatures && this.state.directionalityIndicators}
+          <SourcedTileLayer maxZoom={maxZoom} {...this.props} />
+          {_map(overlayLayers, (layer, index) => (
+            <Pane
+              key={`pane-${renderId}-${index}`}
+              name={`pane-${index}`}
+              style={{zIndex: 10 + index}}
+              className="custom-pane"
+            >
+              {layer.component}
+            </Pane>
+          ))}
         </EnhancedMap>
 
         {this.state.mapillaryViewerImage &&

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -395,6 +395,7 @@ module.exports = {
       '2px': '2px',
       '3px': '3px',
       '4px': '4px',
+      '6px': '6px',
       'n2px': '-2px',
       '0': '0',
       '1': '0.25rem',


### PR DESCRIPTION
* Allow overlay layers to be reordered via drag-and-drop in the layer
toggle dropdown, with the upper-most layers in the list being rendered
on the map above those lower down in the list

* Save the layer order to the user's preferences