### PR TITLE
Remove auto suggest text area ignoring of 'enter' key

### DIFF
--- a/src/components/AutosuggestTextBox/AutosuggestMentionTextArea.js
+++ b/src/components/AutosuggestTextBox/AutosuggestMentionTextArea.js
@@ -60,13 +60,6 @@ export default class AutosuggestMentionTextArea extends Component {
     }
   }
 
-  handleKeyDown = e => {
-    if (e.key === "Enter") {
-      // Don't let enter key potentially submit a form
-      e.preventDefault()
-    }
-  }
-
   regex = searchString => {
     return searchString.match(/^()@([\w]*)$/)  || // match "@..."
            searchString.match(/([^[])@([\w]*)$/) ||  // match "hi @..."
@@ -184,7 +177,6 @@ export default class AutosuggestMentionTextArea extends Component {
                     this.props.inputClassName,
                     "mr-flex-grow mr-w-full mr-h-full mr-outline-none"
                   )}
-                  onKeyDown={this.handleKeyDown}
                   onFocus={(e) => this.setState({textBoxActive: true})}
                   onBlur={(e) => this.setState({textBoxActive: false})}
                   placeholder={this.props.placeholder}


### PR DESCRIPTION
AutosuggestMentionTextArea was explicitly catching the 'enter'
key to do a 'preventDefault' on the event. This is not needed
for text areas because enter keys in this case will not submit
the form.