### PR TITLE
Fix task location widget to show full resized map with widget resizing

### DIFF
--- a/src/components/InsetMap/InsetMap.js
+++ b/src/components/InsetMap/InsetMap.js
@@ -8,6 +8,20 @@ import { layerSourceWithId,
 import './InsetMap.scss'
 
 export default class InsetMap extends Component {
+  constructor(props) {
+    super(props)
+    this.mapRef = React.createRef()
+  }
+
+  componentDidUpdate(prevProps) {
+    // If we are in a widget and the height and widget of our widget layout
+    // changes, then we need to invalidate our map size so that it will
+    // re-render all the tiles.
+    if (prevProps.h !== this.props.h || prevProps.w !== this.props.w) {
+      this.mapRef.current.leafletElement.invalidateSize()
+    }
+  }
+
   render() {
     // Use requested layer source, otherwise the default source
     const layerSource =
@@ -20,7 +34,8 @@ export default class InsetMap extends Component {
              minZoom={this.props.fixedZoom}
              maxZoom={this.props.fixedZoom}
              zoomControl={false} worldCopyJump={true}
-             attributionControl={false}>
+             attributionControl={false}
+             ref={this.mapRef} >
           <SourcedTileLayer source={layerSource} skipAttribution={true} />
           <Marker position={this.props.centerPoint}
                   {...(this.props.markerIcon ? {icon: this.props.markerIcon} : {})} />

--- a/src/components/InsetMap/InsetMap.scss
+++ b/src/components/InsetMap/InsetMap.scss
@@ -1,14 +1,14 @@
 @import '../../variables.scss';
 
 .inset-map {
+  height: 100%;
   .leaflet-container {
-    height: 200px;
+    height: 100%;
     border-radius: $radius-medium;
     border: none;
     -webkit-transform: translate3d(0, 0, 0);
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .2);
     -webkit-backface-visibility: hidden;
-    
     .leaflet-pane {
       z-index: $intralayer-bump;
     }

--- a/src/components/QuickWidget/QuickWidget.js
+++ b/src/components/QuickWidget/QuickWidget.js
@@ -67,7 +67,7 @@ export default class QuickWidget extends Component {
         </header>
         {this.props.noMain ?
           <div className="mr-card-widget__content">{this.props.children}</div> :
-          <div className="mr-card-widget__main">
+          <div className="mr-card-widget__main mr-h-full">
             {this.props.intro &&
             <div className="mr-card-widget__intro">{this.props.intro}</div>
             }
@@ -88,5 +88,5 @@ QuickWidget.propTypes = {
   /** Optional controls to display in widget drop-down menu */
   menuControls: PropTypes.element,
   /** Classnames to pass into Widget */
-  className: PropTypes.string,  
+  className: PropTypes.string,
 }

--- a/src/components/TaskPane/TaskLocationMap/TaskLocationMap.js
+++ b/src/components/TaskPane/TaskLocationMap/TaskLocationMap.js
@@ -16,14 +16,14 @@ const starIconSvg = L.vectorIcon({
     d: "M10 15l-5.878 3.09 1.123-6.545L.489 6.91l6.572-.955L10 0l2.939 5.955 6.572.955-4.756 4.635 1.123 6.545z"
   },
   style: {
-    fill: '#2281C2', // cornflower blue 
+    fill: '#2281C2', // cornflower blue
   },
 })
 
 export class TaskLocationMap extends Component {
   render() {
     return (
-      <div className="task-location-map">
+      <div className="task-location-map mr-h-full">
         <InsetMap
           {...this.props}
           className="task-location-map__primary-map"

--- a/src/components/Widgets/TaskLocationWidget/TaskLocationWidget.js
+++ b/src/components/Widgets/TaskLocationWidget/TaskLocationWidget.js
@@ -25,8 +25,12 @@ export default class TaskLocationWidget extends Component {
       <QuickWidget {...this.props}
                   className="task-location-widget"
                   widgetTitle={<FormattedMessage {...messages.title} />}>
-        <div className="task-location-widget__inset-map">
-          <TaskLocationMap {...this.props} key={this.props.task.id} />
+        <div className="task-location-widget__inset-map mr-h-3/4">
+          <TaskLocationMap {...this.props}
+            key={this.props.task.id} 
+            h={this.props.widgetLayout.h}
+            w={this.props.widgetLayout.w}
+          />
         </div>
 
         <PlaceDescription place={this.props.task.place}


### PR DESCRIPTION
When expanding the task location widget in the widget layout, allow the location map to expand to fill the space.