### PR TITLE
Expand task instructions to configured height

### DIFF
--- a/src/components/Widgets/TaskInstructionsWidget/TaskInstructionsWidget.js
+++ b/src/components/Widgets/TaskInstructionsWidget/TaskInstructionsWidget.js
@@ -32,6 +32,13 @@ export default class TaskInstructionsWidget extends Component {
   toggleMinimized = () => {
     const challengeId = _get(this.props.task, 'parent.id')
     if (_isFinite(challengeId)) {
+      if (!this.props.collapseInstructions) {
+        // Save our current height before collapsing so that we can restore it
+        // later (as our actual height from the widget workspace will reflect
+        // our collapsed state)
+        this.props.updateWidgetConfiguration({expandedHeight: this.props.widgetLayout.h})
+      }
+
       this.props.setInstructionsCollapsed(challengeId, false, !this.props.collapseInstructions)
     }
   }
@@ -43,7 +50,11 @@ export default class TaskInstructionsWidget extends Component {
     }
     else if (!this.props.collapseInstructions &&
              this.props.widgetLayout.h === descriptor.minHeight) {
-      this.props.updateWidgetHeight(this.props.widgetLayout.i, descriptor.defaultHeight) 
+      this.props.updateWidgetHeight(
+        this.props.widgetLayout.i,
+        _isFinite(this.props.widgetConfiguration.expandedHeight) ?
+          this.props.widgetConfiguration.expandedHeight : descriptor.defaultHeight
+      )
     }
   }
 


### PR DESCRIPTION
- When task instructions are minimized and then re-expanded, expand back
to proper height set by user in their layout instead of the widget's
default height