### PR TITLE
Fix timezone picker flipping after choosing UTC

### DIFF
--- a/src/components/HOCs/WithSavedFilters/WithSavedFilters.js
+++ b/src/components/HOCs/WithSavedFilters/WithSavedFilters.js
@@ -97,7 +97,6 @@ const WithSavedFilters = function(WrappedComponent, appSettingName) {
           }
         }
         if (key === "status" && (_isFinite(value) || value.indexOf(",") > -1)) {
-          console.log(value)
           const splitValues = _split(value, ",")
           if (splitValues.length === _keys(TaskStatus).length) {
             textValue = null

--- a/src/components/TimezonePicker/TimezonePicker.js
+++ b/src/components/TimezonePicker/TimezonePicker.js
@@ -18,7 +18,7 @@ const TimezonePicker = props => {
   return (
     <select
       onChange={e => props.changeTimezone(e.target.value)}
-      defaultValue={props.currentTimezone || DEFAULT_TIMEZONE_OFFSET}
+      defaultValue={props.currentTimezone || ""}
       className="mr-w-24 mr-select mr-text-xs mr-pr-5"
     >
       {timezones}


### PR DESCRIPTION
* After choosing (UTC) and downloading csv the timezone picker
  will flip to (UTC-12). Change so that the timezone picker
  will still show (UTC) as the chosen timezone. Other timezones
  do not exhibit this problem.