### PR TITLE
Thicken feature stroke on selection highlight

### DIFF
--- a/src/components/EnhancedMap/OSMDataLayer/OSMDataLayer.js
+++ b/src/components/EnhancedMap/OSMDataLayer/OSMDataLayer.js
@@ -13,7 +13,11 @@ import tailwindConfig from '../../../tailwind.config.js'
 import layerMessages from '../LayerToggle/Messages'
 
 const colors = resolveConfig(tailwindConfig).theme.colors
-const HIGHLIGHT_COLOR = "gold"
+const HIGHLIGHT_STYLE = {
+  color: colors.gold,
+  fillColor: colors.gold,
+  weight: 7,
+}
 
 /**
  * Serves as a react-leaflet adapter for the leaflet-osm package
@@ -114,15 +118,15 @@ export class OSMDataLayer extends Path {
           styleableLayer.popStyle('mr-external-interaction:start-preview')
           const popup = L.popup({}, layer).setLatLng(latlng).setContent(this.popupContent(layer, onBack))
           // Highlight selected feature
-          styleableLayer.pushStyle({color: HIGHLIGHT_COLOR, fillColor: HIGHLIGHT_COLOR})
+          styleableLayer.pushStyle(Object.assign({}, HIGHLIGHT_STYLE))
           popup.on('remove', () => styleableLayer.popStyle())
           popup.openOn(map)
         })
         layer.on('mr-external-interaction:start-preview', () => {
-          styleableLayer.pushStyle({
-            color: HIGHLIGHT_COLOR,
-            fillColor: HIGHLIGHT_COLOR,
-          }, 'mr-external-interaction:start-preview')
+          styleableLayer.pushStyle(
+            Object.assign({}, HIGHLIGHT_STYLE),
+            'mr-external-interaction:start-preview'
+          )
         })
         layer.on('mr-external-interaction:end-preview', () => {
           styleableLayer.popStyle('mr-external-interaction:start-preview')

--- a/src/components/EnhancedMap/TaskFeatureLayer/TaskFeatureLayer.js
+++ b/src/components/EnhancedMap/TaskFeatureLayer/TaskFeatureLayer.js
@@ -9,9 +9,17 @@ import _uniqueId from 'lodash/uniqueId'
 import AsSimpleStyleableFeature
        from '../../../interactions/TaskFeature/AsSimpleStyleableFeature'
 import PropertyList from '../PropertyList/PropertyList'
+import resolveConfig from 'tailwindcss/resolveConfig'
+import tailwindConfig from '../../../tailwind.config.js'
 import layerMessages from '../LayerToggle/Messages'
 
-const HIGHLIGHT_COLOR = "gold"
+const colors = resolveConfig(tailwindConfig).theme.colors
+const HIGHLIGHT_SIMPLESTYLE = {
+  "marker-color": colors.gold,
+  stroke: colors.gold,
+  "stroke-width": 7,
+  fill: colors.gold,
+}
 
 /**
  * TaskFeatureLayer renders a react-leaflet map layer representing the given
@@ -61,11 +69,7 @@ const TaskFeatureLayer = props => {
               // Highlight selected feature, preserving existing marker size (if a marker)
               styleableFeature.pushLeafletLayerSimpleStyles(
                 layer,
-                Object.assign(styleableFeature.markerSimplestyles(layer), {
-                  "marker-color": HIGHLIGHT_COLOR,
-                  stroke: HIGHLIGHT_COLOR,
-                  fill: HIGHLIGHT_COLOR,
-                })
+                Object.assign(styleableFeature.markerSimplestyles(layer), HIGHLIGHT_SIMPLESTYLE)
               )
               popup.on('remove', function() {
                 // Restore original styling when popup closes
@@ -77,11 +81,7 @@ const TaskFeatureLayer = props => {
             layer.on('mr-external-interaction:start-preview', () => {
               styleableFeature.pushLeafletLayerSimpleStyles(
                 layer,
-                Object.assign(styleableFeature.markerSimplestyles(layer), {
-                  "marker-color": HIGHLIGHT_COLOR,
-                  stroke: HIGHLIGHT_COLOR,
-                  fill: HIGHLIGHT_COLOR,
-                }),
+                Object.assign(styleableFeature.markerSimplestyles(layer), HIGHLIGHT_SIMPLESTYLE),
                 'mr-external-interaction:start-preview'
               )
             })


### PR DESCRIPTION
- When a map feature is highlighted during feature selection, increase
the weight of its stroke so that fully-obscured paths will become
visible