### PR TITLE
Set min height on task bundle widget map

### DIFF
--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -320,7 +320,7 @@ const BuildBundle = props => {
 
   return (
     <div className="mr-pb-2 mr-h-full mr-rounded">
-      <div className="mr-h-2/5 mr-max-h-100">
+      <div className="mr-h-2/5 mr-min-h-72 mr-max-h-100">
         {props.loading ?
           <BusySpinner className="mr-h-full mr-flex mr-items-center" /> :
           <MapPane showLasso>{map}</MapPane>

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -310,6 +310,7 @@ module.exports = {
       '0': '0',
       '5': '1.25rem',
       '8': '2rem',
+      '72': '18rem',
       xs: '20rem',
       full: '100%',
       screen: '100vh',


### PR DESCRIPTION
- Set minimum height on task bundle widget map to ensure controls aren't
obscured by a map that is too short