### PR TITLE
Let long nominatim results scroll horizontally

### DIFF
--- a/src/components/EnhancedMap/SearchControl/LocationSearchBox.js
+++ b/src/components/EnhancedMap/SearchControl/LocationSearchBox.js
@@ -35,7 +35,7 @@ export class LocationSearchBox extends Component {
 
   render() {
     const resultItems = _map(this.props.nominatimResults, result => (
-      <li key={result.osmId}>
+      <li key={result.osmId || result.placeId}>
         <button
           className='mr-text-current hover:mr-text-yellow'
           onClick={() => this.props.chooseNominatimResult(result)}
@@ -98,7 +98,10 @@ export class LocationSearchBox extends Component {
                    </button>
                  </div>
                  {resultItems.length === 0 ? <FormattedMessage {...messages.noResults } /> :
-                  <ol className="mr-o-2" onClick={() => this.setState({showDropdown: false})}>
+                  <ol
+                    className="mr-o-2 mr-max-w-screen50 mr-overflow-x-scroll"
+                    onClick={() => this.setState({showDropdown: false})}
+                  >
                     {resultItems}
                   </ol>
                  }

--- a/src/services/Place/Place.js
+++ b/src/services/Place/Place.js
@@ -62,6 +62,7 @@ export const fetchPlaceLocation = function(placeSearch, limit=5) {
       const bounds = _map(place.boundingbox, point => parseFloat(point))
       return {
         osmId: place.osm_id,
+        placeId: place.place_id,
         name: place.display_name,
         type: place.type,
         bbox: [bounds[2], bounds[1], bounds[3], bounds[0]], // NSWE => WSEN

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -348,6 +348,7 @@ module.exports = {
       '1/6': '16.66667%',
       '5/6': '83.33333%',
       'screen40': '40vw',
+      'screen50': '50vw',
       'screen60': '60vw',
       'screen80': '80vw',
       'screen90': '90vw',


### PR DESCRIPTION
- Constrain max width of nominatim results box and let long results
scroll horizontally

- Use placeId for list-item key if result has no osmId to avoid react
errors