### PR TITLE
Fix task-map bounds and history for task bundles

### DIFF
--- a/src/components/EnhancedMap/TaskFeatureLayer/TaskFeatureLayer.js
+++ b/src/components/EnhancedMap/TaskFeatureLayer/TaskFeatureLayer.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import { GeoJSON, withLeaflet } from 'react-leaflet'
 import L from 'leaflet'
 import { injectIntl } from 'react-intl'
+import { featureCollection } from '@turf/helpers'
 import _isFunction from 'lodash/isFunction'
 import _get from 'lodash/get'
 import _uniqueId from 'lodash/uniqueId'
@@ -48,7 +49,7 @@ const TaskFeatureLayer = props => {
         key={_uniqueId()}
         mrLayerId={mrLayerId}
         mrLayerLabel={layerLabel}
-        data={features}
+        data={featureCollection(features)}
         pointToLayer={(point, latLng) => {
           return L.marker(latLng, {pane, mrLayerLabel: layerLabel, mrLayerId: mrLayerId})
         }}

--- a/src/components/Widgets/TaskHistoryWidget/TaskHistoryWidget.js
+++ b/src/components/Widgets/TaskHistoryWidget/TaskHistoryWidget.js
@@ -7,6 +7,7 @@ import TaskCommentInput from '../../TaskCommentInput/TaskCommentInput'
 import WithTaskHistory from '../../HOCs/WithTaskHistory/WithTaskHistory'
 import WithSearch from '../../HOCs/WithSearch/WithSearch'
 import AsMappableTask from '../../../interactions/Task/AsMappableTask'
+import AsMappableBundle from '../../../interactions/TaskBundle/AsMappableBundle'
 import QuickWidget from '../../QuickWidget/QuickWidget'
 import { viewDiffOverpass, viewOSMCha } from '../../../services/Overpass/Overpass'
 import messages from './Messages'
@@ -33,6 +34,12 @@ export default class TaskHistoryWidget extends Component {
 
   commentInputRef = React.createRef()
 
+  bbox = () => {
+    return this.props.taskBundle ?
+      AsMappableBundle(this.props.taskBundle).calculateBBox() :
+      AsMappableTask(this.props.task).calculateBBox()
+  }
+
   toggleSelection = (timestamp) => {
     const diffTimestamps = this.state.selectedTimestamps
     if (_indexOf(diffTimestamps, timestamp.toString()) !== -1) {
@@ -43,8 +50,7 @@ export default class TaskHistoryWidget extends Component {
     }
 
     if (diffTimestamps.length >= 2 ) {
-      viewDiffOverpass(AsMappableTask(this.props.task).calculateBBox(),
-                       ...diffTimestamps.slice(-2))
+      viewDiffOverpass(this.bbox(), ...diffTimestamps.slice(-2))
       this.setState({selectedTimestamps: [], diffSelectionActive: false})
     }
     else {
@@ -53,8 +59,7 @@ export default class TaskHistoryWidget extends Component {
   }
 
   viewDiff = () => {
-    viewDiffOverpass(AsMappableTask(this.props.task).calculateBBox(),
-                     ...this.state.selectedTimestamps)
+    viewDiffOverpass(this.bbox(), ...this.state.selectedTimestamps)
   }
 
   viewOSMCha = () => {
@@ -72,8 +77,7 @@ export default class TaskHistoryWidget extends Component {
       }
     })
 
-    viewOSMCha(AsMappableTask(this.props.task).calculateBBox(),
-               earliestDate, usernames)
+    viewOSMCha(this.bbox(), earliestDate, usernames)
   }
 
   getEditor = () => {
@@ -145,9 +149,6 @@ export default class TaskHistoryWidget extends Component {
       </QuickWidget>
     )
   }
-}
-
-TaskHistoryWidget.propTypes = {
 }
 
 registerWidgetType(


### PR DESCRIPTION
- Fix task map to properly fit to bounds of multiple features when
starting with a bundle of tasks (e.g. in task review)

- Fix TaskHistoryWidget to open OSMCha and diffs with bounding box that
encompasses entire task bundle instead of just primary task