### PR TITLE
Fix obscured Nominatim search overlays

### DIFF
--- a/src/components/EnhancedMap/SearchControl/SearchContent.js
+++ b/src/components/EnhancedMap/SearchControl/SearchContent.js
@@ -1,0 +1,96 @@
+import React from 'react'
+import { FormattedMessage, injectIntl } from 'react-intl'
+import classNames from 'classnames'
+import _map from 'lodash/map'
+import WithNominatimSearch from '../../HOCs/WithNominatimSearch/WithNominatimSearch'
+import BusySpinner from '../../BusySpinner/BusySpinner'
+import SvgSymbol from '../../SvgSymbol/SvgSymbol'
+import messages from './Messages'
+
+const SearchContent = props => {
+  const checkForSpecialKeys = e => {
+    // Esc clears search, Enter signals completion
+    if (e.key === "Escape") {
+      props.clearNominatimSearch()
+    }
+    else if (e.key === "Enter") {
+      props.searchNominatim()
+    }
+  }
+
+  const resultItems = _map(props.nominatimResults, result => (
+    <li key={result.osmId || result.placeId}>
+      <button
+        className='mr-text-current hover:mr-text-yellow'
+        onClick={() => props.chooseNominatimResult(result)}
+      >
+        {result.name}
+      </button>
+    </li>
+  ))
+
+  return (
+    <div className="mr-absolute mr-top-0 mr-mt-3 mr-w-full mr-flex mr-justify-center">
+      <div className={classNames(
+        "mr-min-w-102 mr-z-5 mr-p-4 mr-rounded mr-w-4/5",
+        props.nominatimResults ? "mr-bg-blue-dark" : "mr-bg-blue-dark-50"
+      )}>
+        <div className="mr-flex mr-justify-between mr-items-center">
+          <div className="mr-flex mr-items-center">
+            <input
+              className={classNames(
+                "mr-input mr-input--green-lighter-outline",
+                props.nominatimResults ? "mr-bg-black-15" : "mr-bg-black-50"
+              )}
+              type="text"
+              placeholder={props.intl.formatMessage(messages.nominatimQuery)}
+              value={props.nominatimQuery}
+              onChange={(e) => props.updateNominatimQuery(e.target.value)}
+              onKeyDown={checkForSpecialKeys}
+            />
+            {props.nominatumSearching ?
+              <BusySpinner inline className="mr-static" /> :
+              <button
+                className="mr-button mr-h-10 mr-py-0 mr-ml-4"
+                onClick={props.searchNominatim}
+              >
+                <FormattedMessage {...messages.searchLabel } />
+              </button>
+            }
+          </div>
+          <button
+            className="mr-ml-4"
+            onClick={() => {
+              props.clearNominatimSearch()
+              props.closeSearch()
+            }}
+          >
+            <SvgSymbol
+              sym="icon-close"
+              viewBox="0 0 20 20"
+              className="mr-fill-white mr-w-4 mr-h-4"
+              aria-hidden
+            />
+          </button>
+        </div>
+
+        {props.nominatimResults &&
+          <React.Fragment>
+            <hr className="mr-h-px mr-my-4 mr-bg-blue-light" />
+            {resultItems.length === 0 ?
+              <FormattedMessage {...messages.noResults } /> :
+              <ol
+                className="mr-o-2 mr-max-w-screen50 mr-whitespace-no-wrap mr-overflow-x-scroll"
+                onClick={() => props.closeSearch()}
+              >
+                {resultItems}
+              </ol>
+            }
+          </React.Fragment>
+        }
+      </div>
+    </div>
+  )
+}
+
+export default WithNominatimSearch(injectIntl(SearchContent))

--- a/src/components/EnhancedMap/SearchControl/SearchControl.js
+++ b/src/components/EnhancedMap/SearchControl/SearchControl.js
@@ -2,13 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import L from 'leaflet'
 import { MapControl, withLeaflet } from 'react-leaflet'
-import _map from 'lodash/map'
-import { FormattedMessage, injectIntl } from 'react-intl'
-import WithNominatimSearch from '../../HOCs/WithNominatimSearch/WithNominatimSearch'
 import SvgSymbol from '../../SvgSymbol/SvgSymbol'
-import BusySpinner from '../../BusySpinner/BusySpinner'
-import Dropdown from '../../Dropdown/Dropdown'
-import messages from './Messages'
 
 /**
  * SearchControl presents a Leaflet control that can be used to execute
@@ -45,92 +39,17 @@ const SearchLeafletControl = L.Control.extend({
  * Component that renders the actual control content
  */
 const ControlContent = props => {
-  const checkForSpecialKeys = e => {
-    // Esc clears search, Enter signals completion
-    if (e.key === "Escape") {
-      props.clearNominatimSearch()
-    }
-    else if (e.key === "Enter") {
-      props.searchNominatim()
-    }
-  }
-
-  const resultItems = _map(props.nominatimResults, result => (
-    <li key={result.osmId}>
-      <button
-        className='mr-text-current hover:mr-text-yellow'
-        onClick={() => props.chooseNominatimResult(result)}
-      >
-        {result.name}
-      </button>
-    </li>
-  ))
-
   return (
-    <Dropdown
-      className="mr-dropdown--right"
-      dropdownButton={dropdown =>
-        <button
-          onClick={dropdown.toggleDropdownVisible}
-          className="mr-leading-none mr-p-2 mr-bg-black-50 mr-text-white mr-w-8 mr-h-8 mr-flex mr-items-center mr-shadow mr-rounded-sm mr-transition-normal-in-out-quad hover:mr-text-green-lighter"
-          aria-haspopup="true"
-          aria-controls="dropdown-menu"
-        >
-          <SvgSymbol sym="search-icon" className="mr-w-4 mr-h-4 mr-fill-current" viewBox="0 0 20 20" />
-        </button>
-      }
-      dropdownContent={dropdown =>
-        <div className="mr-min-w-102">
-          <div className="mr-flex mr-justify-between mr-items-center">
-            <div className="mr-flex mr-items-center">
-              <input
-                className="mr-input mr-input--green-lighter-outline mr-bg-black-25"
-                type="text"
-                placeholder={props.intl.formatMessage(messages.nominatimQuery)}
-                value={props.nominatimQuery}
-                onChange={(e) => props.updateNominatimQuery(e.target.value)}
-                onKeyDown={checkForSpecialKeys}
-              />
-              {props.nominatumSearching ?
-                <BusySpinner inline className="mr-static" /> :
-                <button
-                  className="mr-button mr-h-10 mr-py-0 mr-ml-4"
-                  onClick={props.searchNominatim}
-                >
-                  <FormattedMessage {...messages.searchLabel } />
-                </button>
-              }
-            </div>
-            <button
-              className="mr-ml-4"
-              onClick={() => {
-                dropdown.closeDropdown()
-                props.clearNominatimSearch()
-              }}
-            >
-              <SvgSymbol
-                sym="icon-close"
-                viewBox="0 0 20 20"
-                className="mr-fill-white mr-w-4 mr-h-4"
-                aria-hidden
-              />
-            </button>
-          </div>
-
-          {props.nominatimResults &&
-            <React.Fragment>
-              <hr className="mr-h-px mr-my-4 mr-bg-blue" />
-              {resultItems.length === 0 ? <FormattedMessage {...messages.noResults } /> :
-              <ol className="mr-o-2" onClick={() => dropdown.closeDropdown()}>
-                {resultItems}
-              </ol>
-              }
-            </React.Fragment>
-          }
-        </div>
-      }
-    />
+    <button
+      onClick={e => {
+        console.log(e)
+        props.openSearch(e.target)
+      }}
+      className="mr-leading-none mr-p-2 mr-bg-black-50 mr-text-white mr-w-8 mr-h-8 mr-flex mr-items-center mr-shadow mr-rounded-sm mr-transition-normal-in-out-quad hover:mr-text-green-lighter"
+    >
+      <SvgSymbol sym="search-icon" className="mr-w-4 mr-h-4 mr-fill-current" viewBox="0 0 20 20" />
+    </button>
   )
 }
 
-export default WithNominatimSearch(withLeaflet(injectIntl(SearchControl)))
+export default withLeaflet(SearchControl)

--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -32,6 +32,7 @@ import FitBoundsControl from '../EnhancedMap/FitBoundsControl/FitBoundsControl'
 import SourcedTileLayer from '../EnhancedMap/SourcedTileLayer/SourcedTileLayer'
 import LayerToggle from '../EnhancedMap/LayerToggle/LayerToggle'
 import SearchControl from '../EnhancedMap/SearchControl/SearchControl'
+import SearchContent from '../EnhancedMap/SearchControl/SearchContent'
 import LassoSelectionControl
        from '../EnhancedMap/LassoSelectionControl/LassoSelectionControl'
 import WithVisibleLayer from '../HOCs/WithVisibleLayer/WithVisibleLayer'
@@ -81,6 +82,7 @@ export class TaskClusterMap extends Component {
 
   state = {
     mapMarkers: null,
+    searchOpen: false,
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -211,6 +213,10 @@ export class TaskClusterMap extends Component {
       }
     }
   }
+
+  openSearch = () => this.setState({searchOpen: true})
+
+  closeSearch = () => this.setState({searchOpen: false})
 
   debouncedUpdateBounds = _debounce(this.props.updateBounds, 400)
 
@@ -468,10 +474,7 @@ export class TaskClusterMap extends Component {
         {!this.props.hideSearchControl &&
           <SearchControl
             {...this.props}
-            onResultSelected={bounds => {
-              this.currentBounds = toLatLngBounds(bounds)
-              this.props.updateBounds(bounds)
-            }}
+            openSearch={this.openSearch}
           />
         }
         <VisibleTileLayer {...this.props} zIndex={1} />
@@ -499,7 +502,7 @@ export class TaskClusterMap extends Component {
 
     return (
       <div className={classNames('taskcluster-map', {"full-screen-map": this.props.isMobile}, this.props.className)}>
-        {canClusterToggle && !this.props.loading &&
+        {canClusterToggle && !this.state.searchOpen && !this.props.loading &&
          <label className="mr-absolute mr-z-10 mr-top-0 mr-left-0 mr-mt-2 mr-ml-2 mr-shadow mr-rounded-sm mr-bg-black-50 mr-px-2 mr-py-1 mr-text-white mr-text-xs mr-flex mr-items-center">
             <input type="checkbox" className="mr-mr-2"
               checked={this.props.showAsClusters}
@@ -508,10 +511,20 @@ export class TaskClusterMap extends Component {
           </label>
         }
         <LayerToggle {...this.props} overlayOrder={overlayOrder} />
-        {!!this.props.mapZoomedOut && !this.state.locatingToUser &&
+        {!this.state.searchOpen && !!this.props.mapZoomedOut && !this.state.locatingToUser &&
           <ZoomInMessage {...this.props} zoom={this.currentZoom}/>
         }
-        {this.props.delayMapLoad &&
+        {this.state.searchOpen &&
+         <SearchContent
+           {...this.props}
+           onResultSelected={bounds => {
+              this.currentBounds = toLatLngBounds(bounds)
+              this.props.updateBounds(bounds)
+           }}
+           closeSearch={this.closeSearch}
+         />
+        }
+        {this.props.delayMapLoad && !this.state.searchOpen &&
           <div className="mr-absolute mr-top-0 mr-mt-3 mr-w-full mr-flex mr-justify-center"
             onClick={() => this.props.forceMapLoad()}>
             <div className="mr-z-5 mr-flex-col mr-items-center mr-bg-blue-dark-50 mr-text-white mr-rounded">

--- a/src/services/Server/Server.js
+++ b/src/services/Server/Server.js
@@ -75,17 +75,22 @@ export const fetchContent = function(url, normalizationSchema, options={}) {
 
         resolve(result)
       }).catch(error => {
-        // 404 is used by the scala server to indicate no results. Treat as
-        // successful response with empty data.
-        if (error.response && error.response.status === 404) {
-          resolve(normalize(_isArray(normalizationSchema) ? [] : {}, normalizationSchema))
+        if (error.response) {
+          // 404 is used by the scala server to indicate no results. Treat as
+          // successful response with empty data
+          if (error.response.status === 404) {
+            resolve(normalize(_isArray(normalizationSchema) ? [] : {}, normalizationSchema))
+          }
+          else {
+            // Attach any details in the response body to the error
+            parseJSON(error.response).then(jsonData => {
+              error.details = jsonData
+              reject(error)
+            }).catch(() => reject(error))
+          }
         }
         else {
-          // Attach any details in the response body to the error
-          parseJSON(error.response).then(jsonData => {
-            error.details = jsonData
-            reject(error)
-          }).catch(() => reject(error))
+          reject(error)
         }
       })
     })


### PR DESCRIPTION
- Extract SearchContent dialog from SearchControl so that it can be
rendered separately and not be constrained by the control's z-index
stack context

- Do not attempt to parse response body on error if the error does not
contain a body