### PR TITLE
Preserve URL query params on signin

### DIFF
--- a/src/components/SignInButton/SignInButton.js
+++ b/src/components/SignInButton/SignInButton.js
@@ -31,9 +31,14 @@ export class SignInButton extends Component {
     }
 
     return (
-      <a className={classNames("mr-button", this.props.className)}
-         onClick={() => this.setState({clicked: true})}
-         href={`${process.env.REACT_APP_SERVER_OAUTH_URL}${this.props.history.location.pathname}`}
+      <a
+        className={classNames("mr-button", this.props.className)}
+        onClick={() => this.setState({clicked: true})}
+        href={
+          `${process.env.REACT_APP_SERVER_OAUTH_URL}${encodeURIComponent(
+            this.props.history.location.pathname + this.props.history.location.search
+          )}`
+        }
       >
         {this.props.children || (
          this.props.longForm ?


### PR DESCRIPTION
- Include query params from the current URL in the oauth redirect URL
provided to the server when signing in a user