### PR TITLE
Fix lasso deselection of VC unclustered tasks

### DIFF
--- a/src/components/ChallengePane/ChallengePane.js
+++ b/src/components/ChallengePane/ChallengePane.js
@@ -62,8 +62,15 @@ export class ChallengePane extends Component {
   }
 
   onBulkClusterDeselection = clusters => {
+    if (!clusters || clusters.length === 0) {
+      return
+    }
+
+    // Handle both clusters and individual tasks in case user declustered
     this.setState({
-      selectedClusters: _differenceBy(this.state.selectedClusters, clusters, 'clusterId'),
+      selectedClusters: _differenceBy(
+        this.state.selectedClusters, clusters, clusters[0].isTask ? 'taskId' : 'clusterId'
+      ),
     })
   }
 

--- a/src/components/HOCs/WithStartChallenge/WithStartChallenge.js
+++ b/src/components/HOCs/WithStartChallenge/WithStartChallenge.js
@@ -155,10 +155,6 @@ export const mapDispatchToProps = (dispatch, ownProps) => ({
 
   createVirtualChallenge: (name, clusters) => {
     const tasks = _compact(_map(clusters, c => c.isTask ? c.taskId : null))
-    if (tasks.length > 0 && tasks.length !== clusters.length) {
-      throw new Error("Cannot create virtual challenge with mix of tasks and clusters")
-    }
-
     return dispatch(
       createVirtualChallenge(name, _isEmpty(tasks) ? null : tasks, null, _isEmpty(tasks) ? clusters : null)
     ).then(virtualChallenge => {

--- a/src/components/SavedChallenges/SavedChallengesWidget.js
+++ b/src/components/SavedChallenges/SavedChallengesWidget.js
@@ -58,7 +58,7 @@ const SavedChallengeList = function(props) {
           key={challenge.id}
           className="mr-py-2 mr-flex mr-justify-between mr-items-center"
         >
-          <div class="mr-flex mr-flex-col">
+          <div className="mr-flex mr-flex-col">
             <Link to={`/browse/challenges/${challenge.id}`}>
               {challenge.name}
             </Link>

--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -516,7 +516,7 @@ export class TaskClusterMap extends Component {
         {this.props.taskCenter &&
           <FitBoundsControl centerPoint={this.props.taskCenter} />
         }
-        {this.props.showClusterLasso && this.props.onBulkClusterSelection &&
+        {this.props.showClusterLasso && this.props.onBulkClusterSelection && !this.props.mapZoomedOut &&
           <LassoSelectionControl
             onLassoSelection={this.selectClustersInLayers}
             onLassoDeselection={this.deselectClustersInLayers}


### PR DESCRIPTION
- Fix deselection of individual (unclustered) tasks via lasso tool for
virtual challenge creation

- Don't offer lasso tool on Find Challenges map if the map is zoomed out
too far to show task clusters

- Remove error check for condition that should never happen

- Fix incorrect `className` prop