### PR TITLE
Fix empty project shows review status metrics for everything

### DIFF
--- a/src/components/AdminPane/HOCs/WithProjectReviewMetrics/WithProjectReviewMetrics.js
+++ b/src/components/AdminPane/HOCs/WithProjectReviewMetrics/WithProjectReviewMetrics.js
@@ -34,7 +34,8 @@ export const WithProjectReviewMetrics = function(WrappedComponent) {
       this.setState({loading: true})
 
       const challengeIds = this.getChallengeIds(props)
-      props.refreshReviewMetrics(_get(props.user, 'id'), challengeIds).then(() => {
+      props.refreshReviewMetrics(_get(props.user, 'id'), challengeIds,
+        _get(props.project, 'id')).then(() => {
         this.setState({loading: false, currentChallengeIds: challengeIds})
       })
     }
@@ -67,8 +68,9 @@ const mapStateToProps = state => (
 )
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  refreshReviewMetrics: (userId, challengeIds) => {
-    return dispatch(fetchReviewMetrics(userId, ReviewTasksType.allReviewedTasks, {filters:{challengeId: challengeIds}}))
+  refreshReviewMetrics: (userId, challengeIds, projectId) => {
+    return dispatch(fetchReviewMetrics(userId, ReviewTasksType.allReviewedTasks,
+      {filters:{challengeId: challengeIds, projectId: projectId}}))
   },
 })
 


### PR DESCRIPTION
  In an empty project with no challenges, when it fetches the review
  status metrics, the project id was not being included so the stats
  were coming back for everything visible in the system.