### PR TITLE
Ensure FitBoundsControl updated with new center

### DIFF
--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -104,6 +104,11 @@ export class TaskClusterMap extends Component {
       return true
     }
 
+    // The primary task location has changed
+    if (!_isEqual(nextProps.taskCenter, this.props.taskCenter)) {
+      return true
+    }
+
     // the task markers have changed
     if (!_isEqual(nextProps.taskMarkers, this.props.taskMarkers)) {
       return true
@@ -516,7 +521,7 @@ export class TaskClusterMap extends Component {
         <ZoomControl className="mr-z-10" position='topright' />
         {this.props.showFitWorld && <FitWorldControl />}
         {this.props.taskCenter &&
-          <FitBoundsControl centerPoint={this.props.taskCenter} />
+          <FitBoundsControl key={this.props.taskCenter.toString()} centerPoint={this.props.taskCenter} />
         }
         {this.props.showClusterLasso && this.props.onBulkClusterSelection && !this.props.mapZoomedOut &&
           <LassoSelectionControl


### PR DESCRIPTION
- Ensure the FitBoundsControl is re-rendered with updated centerpoint
when the primary task on a cluster map changes

- Fixes #1481