### PR TITLE
Replace relative timestamps with actual timestamps

### DIFF
--- a/src/components/ActivityListing/ActivityTime.js
+++ b/src/components/ActivityListing/ActivityTime.js
@@ -19,7 +19,13 @@ import parse from 'date-fns/parse'
 export const ActivityTime = props => {
   const timestamp = parse(props.entry.created)
   const created = `${props.intl.formatDate(timestamp)} ${props.intl.formatTime(timestamp)}`
-  const selectedUnit = selectUnit(timestamp)
+  const selectedUnit = selectUnit(timestamp, Date.now(),
+    {
+      second: 30,
+      minute: 60,
+      hour: 24,
+      day: 30
+    })
   if (selectedUnit.unit === "second" ||
       selectedUnit.unit === "minute" ||
       selectedUnit.unit === "hour") {
@@ -34,7 +40,7 @@ export const ActivityTime = props => {
       )}
       title={created}
     >
-      {props.showExactDates ?
+      {(props.showExactDates || selectedUnit.unit === "year")?
        <span>
          <FormattedDate value={props.entry.created} /> <FormattedTime value={props.entry.created} />
        </span> :

--- a/src/components/CardChallenge/CardChallenge.js
+++ b/src/components/CardChallenge/CardChallenge.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { FormattedMessage, FormattedRelativeTime } from 'react-intl'
-import { selectUnit } from '@formatjs/intl-utils'
+import { FormattedMessage, FormattedDate } from 'react-intl'
 import { Link } from 'react-router-dom'
 import classNames from 'classnames'
 import parse from 'date-fns/parse'
@@ -136,8 +135,9 @@ export class CardChallenge extends Component {
               <li>
                 <strong className="mr-text-yellow">
                   <FormattedMessage {...messages.lastTaskRefreshLabel} />:
-                </strong> <FormattedRelativeTime
-                  {...selectUnit(parse(this.props.challenge.dataOriginDate))}
+                </strong> <FormattedDate
+                  value={parse(this.props.challenge.dataOriginDate)}
+                  year='numeric' month='long' day='2-digit'
                 />
               </li>
               <li>

--- a/src/components/ChallengeDetail/ChallengeDetail.js
+++ b/src/components/ChallengeDetail/ChallengeDetail.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
-import { FormattedMessage, FormattedRelativeTime, injectIntl }
+import { FormattedMessage, FormattedDate, injectIntl }
        from 'react-intl'
-import { selectUnit } from '@formatjs/intl-utils'
 import classNames from 'classnames'
 import _isObject from 'lodash/isObject'
 import _get from 'lodash/get'
@@ -196,7 +195,8 @@ export class ChallengeDetail extends Component {
                           />
                           :
                         </strong>{' '}
-                        <FormattedRelativeTime {...selectUnit(parse(challenge.dataOriginDate))} />
+                        <FormattedDate value={parse(challenge.dataOriginDate)}
+                                        year='numeric' month='long' day='2-digit' />
                       </li>
                       <li>
                         <Link

--- a/src/components/ProjectDetail/ProjectDetail.js
+++ b/src/components/ProjectDetail/ProjectDetail.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 import classNames from 'classnames'
-import { FormattedMessage, FormattedRelativeTime, injectIntl }
+import { FormattedMessage, FormattedDate, injectIntl }
        from 'react-intl'
-import { selectUnit } from '@formatjs/intl-utils'
 import _isObject from 'lodash/isObject'
 import _get from 'lodash/get'
 import parse from 'date-fns/parse'
@@ -95,7 +94,8 @@ export class ProjectDetail extends Component {
                         />
                         :
                       </strong>{' '}
-                      <FormattedRelativeTime {...selectUnit(parse(project.created))} />
+                      <FormattedDate value={parse(project.created)}
+                                      year='numeric' month='long' day='2-digit' />
                     </li>
                     <li>
                       <strong className="mr-text-yellow">
@@ -104,7 +104,8 @@ export class ProjectDetail extends Component {
                         />
                         :
                       </strong>{' '}
-                      <FormattedRelativeTime {...selectUnit(parse(project.modified))} />
+                      <FormattedDate value={parse(project.modified)}
+                                      year='numeric' month='long' day='2-digit' />
                     </li>
                     {_get(this.props, 'challenges.length', 0) > 0 &&
                       <li>


### PR DESCRIPTION
Due to a change made by @formatjs/intl-utils selectUnit, the relative
timestamps shown can be off when displaying years -- ie. December
is showing as "1 year ago". Converted relative timestamps to
actual timestamps when displaying challenge and project details.

As for activity, converted only "year" units to actual timestamp to
still give a nice display of "X minutes ago" and "Y days ago" for
more recent activity.

Close #1479 