### PR TITLE
Link to mustache-tag doc in Custom URL widget

### DIFF
--- a/src/components/CustomUrlList/Messages.js
+++ b/src/components/CustomUrlList/Messages.js
@@ -36,7 +36,7 @@ export default defineMessages({
 
   urlDescription: {
     id: "CustomUrlList.url.description",
-    defaultMessage: "The full URL, using mustache tags for property replacement",
+    defaultMessage: "The full URL, using [mustache tags](https://learn.maproulette.org/documentation/mustache-tag-replacement/) for property replacement. Note that URLs referencing missing or unavailable mustache tags will be automatically disabled to prevent accidental creation of malformed or erroneous URLs",
   },
 
   addLabel: {

--- a/src/components/CustomUrlList/UrlSchema.js
+++ b/src/components/CustomUrlList/UrlSchema.js
@@ -1,3 +1,5 @@
+import React from 'react'
+import MarkdownContent from '../MarkdownContent/MarkdownContent'
 import messages from './Messages'
 
 /**
@@ -44,6 +46,6 @@ export const uiSchema = intl => ({
     "ui:help": intl.formatMessage(messages.descriptionDescription),
   },
   url: {
-    "ui:help": intl.formatMessage(messages.urlDescription),
+    "ui:help": <MarkdownContent markdown={intl.formatMessage(messages.urlDescription)} />,
   },
 })

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -712,7 +712,7 @@
   "CustomUrlList.name.description": "A unique name/label for this custom URL",
   "CustomUrlList.name.label": "Name",
   "CustomUrlList.noCustomUrls": "No custom URLs",
-  "CustomUrlList.url.description": "The full URL, using mustache tags for property replacement",
+  "CustomUrlList.url.description": "The full URL, using [mustache tags](https://learn.maproulette.org/documentation/mustache-tag-replacement/) for property replacement. Note that URLs referencing missing or unavailable mustache tags will be automatically disabled to prevent accidental creation of malformed or erroneous URLs",
   "CustomUrlList.url.label": "URL",
   "Dashboard.ChallengeFilter.pinned.label": "Pinned",
   "Dashboard.ChallengeFilter.visible.label": "Discoverable",


### PR DESCRIPTION
- Provide link to mustache-tag doc in help info for URL field on Custom
URL widget when adding or editing URLs