### PR TITLE
Support @type when determining osm type

### DIFF
--- a/src/interactions/TaskFeature/AsIdentifiableFeature.js
+++ b/src/interactions/TaskFeature/AsIdentifiableFeature.js
@@ -66,7 +66,7 @@ export class AsIdentifiableFeature {
 
     let featureType = this.rawFeatureId()
     if (!typeRe.test(featureType)) {
-      featureType = this.properties.type
+      featureType = this.properties.type ? this.properties.type : this.properties["@type"]
       if (!typeRe.test(featureType)) {
         // No luck finding an explicit type. Try to infer from the geometry
         const geometryType = _get(this, 'geometry.type')


### PR DESCRIPTION
When determining osmType, also look at properties.@type