### PR TITLE
Add total count to tasks review table pagination footer

### DIFF
--- a/src/components/IntlTable/IntlTable.js
+++ b/src/components/IntlTable/IntlTable.js
@@ -14,4 +14,5 @@ export const intlTableProps = intl => ({
   rowsText: intl.formatMessage(messages.rows),
   pageJumpText: intl.formatMessage(messages.jumpToPageLabel),
   rowsSelectorText: intl.formatMessage(messages.rowsPerPageLabel),
+  totalText: intl.formatMessage(messages.totalLabel),
 })

--- a/src/components/IntlTable/IntlTablePagination.js
+++ b/src/components/IntlTable/IntlTablePagination.js
@@ -1,0 +1,173 @@
+import React, { Component } from 'react'
+import classnames from 'classnames'
+
+const defaultButton = props => (
+  <button type="button" {...props} className="-btn">
+    {props.children}
+  </button>
+)
+
+/**
+ * Table Pagination for React Table to allow for showing a "total" count of
+ * the items in the pagination component from props.totalCount.
+ *
+ * Code courtesy of: @Morasta from Github issue:
+ * https://github.com/tannerlinsley/react-table/issues/500
+ */
+export default class IntlTablePagination extends Component {
+  constructor (props) {
+    super()
+
+    this.getSafePage = this.getSafePage.bind(this)
+    this.changePage = this.changePage.bind(this)
+    this.applyPage = this.applyPage.bind(this)
+
+    this.updateCurrentRows(props)
+
+    this.state = {
+      page: props.page
+    }
+  }
+
+  componentWillReceiveProps (nextProps) {
+    this.setState({ page: nextProps.page })
+
+    this.updateCurrentRows(nextProps)
+  }
+
+  updateCurrentRows(props) {
+    if (   typeof props.sortedData  !== 'undefined'  //use props.data for unfiltered (all) rows
+        && typeof props.page !== 'undefined'
+        && typeof props.pageSize !== 'undefined'
+    ){
+      this.rowCount = props.sortedData.length  //use props.data.length for unfiltered (all) rows
+      this.rowMin = props.page * props.pageSize + 1
+      this.rowMax = Math.min((props.page + 1) * props.pageSize, this.rowCount)
+    }
+  }
+
+  getSafePage (page) {
+    if (isNaN(page)) {
+      page = this.props.page
+    }
+    return Math.min(Math.max(page, 0), this.props.pages - 1)
+  }
+
+  changePage (page) {
+    page = this.getSafePage(page)
+    this.setState({ page })
+    if (this.props.page !== page) {
+      this.props.onPageChange(page)
+    }
+
+    this.updateCurrentRows(page)
+  }
+
+  applyPage (e) {
+    if (e) { e.preventDefault() }
+    const page = this.state.page
+    this.changePage(page === '' ? this.props.page : page)
+  }
+
+
+  render () {
+    const {
+      // Computed
+      pages,
+      // Props
+      page,
+      showPageSizeOptions,
+      pageSizeOptions,
+      pageSize,
+      showPageJump,
+      canPrevious,
+      canNext,
+      onPageSizeChange,
+      className,
+      PreviousComponent = defaultButton,
+      NextComponent = defaultButton,
+    } = this.props
+
+    return (
+      <div
+        className={classnames(className, '-pagination')}
+        style={this.props.style}
+      >
+        <div className="-previous">
+          <PreviousComponent
+            onClick={() => {
+              if (!canPrevious) return
+              this.changePage(page - 1)
+            }}
+            disabled={!canPrevious}
+          >
+            {this.props.previousText}
+          </PreviousComponent>
+        </div>
+        <div className="-center">
+          <span className="-pageInfo">
+            {this.props.pageText}{' '}
+            {showPageJump
+              ? <div className="-pageJump">
+                <input
+                  type={this.state.page === '' ? 'text' : 'number'}
+                  onChange={e => {
+                    const val = e.target.value
+                    const page = val - 1
+                    if (val === '') {
+                      return this.setState({ page: val })
+                    }
+                    this.setState({ page: this.getSafePage(page) })
+                  }}
+                  value={this.state.page === '' ? '' : this.state.page + 1}
+                  onBlur={this.applyPage}
+                  onKeyPress={e => {
+                    if (e.which === 13 || e.keyCode === 13) {
+                      this.applyPage()
+                    }
+                  }}
+                />
+              </div>
+              : <span className="-currentPage">
+                {page + 1}
+              </span>}{' '}
+            {this.props.ofText}{' '}
+            <span className="-totalPages">{pages || 1}</span>
+          </span>
+
+          {(typeof this.props.totalCount !== 'undefined') ?
+              <span className="-totalInfo">{this.props.totalText}
+                <span className="-totalCount">{this.props.totalCount}</span>
+              </span>
+            : ''}
+
+          {showPageSizeOptions &&
+            <span className="select-wrap -pageSizeOptions">
+              <select
+                onChange={e => onPageSizeChange(Number(e.target.value))}
+                value={pageSize}
+              >
+                {pageSizeOptions.map((option, i) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <option key={i} value={option}>
+                    {option} {this.props.rowsText}
+                  </option>
+                ))}
+              </select>
+            </span>}
+        </div>
+        <div className="-next">
+          <NextComponent
+            onClick={() => {
+              if (!canNext) return
+              this.changePage(page + 1)
+            }}
+            disabled={!canNext}
+          >
+            {this.props.nextText}
+          </NextComponent>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/components/IntlTable/Messages.js
+++ b/src/components/IntlTable/Messages.js
@@ -19,6 +19,11 @@ export default defineMessages({
     defaultMessage: 'Loading...',
   },
 
+  totalLabel: {
+    id: "IntlTable.total.label",
+    defaultMessage: 'Total: ',
+  },
+
   noData: {
     id: "IntlTable.noData",
     defaultMessage: 'No rows found',

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -911,6 +911,7 @@
   "IntlTable.previous.label": "Previous",
   "IntlTable.rows": "rows",
   "IntlTable.rowsPerPage.label": "rows per page",
+  "IntlTable.total.label": "Total: ",
   "KeyMapping.layers.layerMapillary": "Toggle Mapillary Layer",
   "KeyMapping.layers.layerOSMData": "Toggle OSM Data Layer",
   "KeyMapping.layers.layerTaskFeatures": "Toggle Features Layer",

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -25,6 +25,7 @@ import { TaskReviewStatus, keysByReviewStatus, messagesByReviewStatus,
        from '../../../services/Task/TaskReview/TaskReviewStatus'
 import { ReviewTasksType, buildLinkToMapperExportCSV } from '../../../services/Task/TaskReview/TaskReview'
 import { intlTableProps } from '../../../components/IntlTable/IntlTable'
+import IntlTablePagination from '../../../components/IntlTable/IntlTablePagination'
 import TaskCommentsModal
        from '../../../components/TaskCommentsModal/TaskCommentsModal'
 import InTableTagFilter
@@ -305,7 +306,8 @@ export class TaskReviewTable extends Component {
                            taskId => this.setState({openComments: taskId}),
                            data, this.props.reviewCriteria, pageSize)
 
-    const totalPages = Math.ceil(_get(this.props, 'reviewData.totalCount', 0) / pageSize)
+    const totalRows = _get(this.props, 'reviewData.totalCount', 0)
+    const totalPages = Math.ceil(totalRows / pageSize)
 
     let subheader = null
     const columns = _map(_keys(this.props.addedColumns), (column) => columnTypes[column])
@@ -421,9 +423,10 @@ export class TaskReviewTable extends Component {
               />
             </div>
           </header>
-          <div className="mr-mt-6">
+          <div className="mr-mt-6 review">
             <ReactTable data={data} columns={columns} key={this.props.reviewTasksType}
                         pageSize={pageSize}
+                        totalCount={totalRows}
                         defaultSorted={defaultSorted}
                         defaultFiltered={defaultFiltered}
                         minRows={1}
@@ -444,6 +447,7 @@ export class TaskReviewTable extends Component {
                         }}
                         loading={this.props.loading}
                         {...intlTableProps(this.props.intl)}
+                        PaginationComponent={IntlTablePagination}
             />
           </div>
         </div>

--- a/src/styles/vendor/react-table.css
+++ b/src/styles/vendor/react-table.css
@@ -106,3 +106,11 @@
     }
   }
 }
+
+.review {
+  .ReactTable {
+    .rt-noData {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
* In tasks review table pagination footer add "Total: "

* Hide "No rows found" component that is shown when there are 0 results,
  as Safari (v14.0) will cut off dropdowns from the filters
  (ie. challenges/projects)