### PR TITLE
Color task-marker spidered lines based on task id

### DIFF
--- a/src/components/EnhancedMap/EnhancedMap.js
+++ b/src/components/EnhancedMap/EnhancedMap.js
@@ -209,10 +209,6 @@ export class EnhancedMap extends ReactLeafletMap {
   componentDidMount() {
     super.componentDidMount()
 
-    if (this.props.setLeafletMap) {
-      this.props.setLeafletMap(this.leafletElement)
-    }
-
     if (this.props.animator) {
       this.props.animator.setAnimationFunction(this.animateFeatures)
     }

--- a/src/components/OSMElementHistory/OSMElementHistory.js
+++ b/src/components/OSMElementHistory/OSMElementHistory.js
@@ -15,7 +15,7 @@ import AsMappableTask
        from '../../interactions/Task/AsMappableTask'
 import AsIdentifiableFeature
        from '../../interactions/TaskFeature/AsIdentifiableFeature'
-import { mapColors } from '../../interactions/User/AsEndUser'
+import AsColoredHashable from '../../interactions/Hashable/AsColoredHashable'
 import Dropdown from '../Dropdown/Dropdown'
 import SvgSymbol from '../SvgSymbol/SvgSymbol'
 import BusySpinner from '../BusySpinner/BusySpinner'
@@ -219,7 +219,7 @@ const HistoryEntry = props => {
         }
         <div
           className="mr-mb-2"
-          style={{color: mapColors(props.user)}}
+          style={{color: AsColoredHashable(props.user).hashColor}}
         >
           {props.user}
         </div>

--- a/src/components/TaskAnalysisTable/TaskAnalysisTable.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTable.js
@@ -33,8 +33,8 @@ import { messagesByReviewStatus,
       from '../../services/Task/TaskReview/TaskReviewStatus'
 import { messagesByPriority }
        from '../../services/Task/TaskPriority/TaskPriority'
-import { mapColors } from '../../interactions/User/AsEndUser'
 import AsManager from '../../interactions/User/AsManager'
+import AsColoredHashable from '../../interactions/Hashable/AsColoredHashable'
 import WithLoadedTask from '../HOCs/WithLoadedTask/WithLoadedTask'
 import WithConfigurableColumns from '../HOCs/WithConfigurableColumns/WithConfigurableColumns'
 import { intlTableProps } from '../../components/IntlTable/IntlTable'
@@ -422,7 +422,7 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
     Cell: ({row}) => (
       <div
         className="row-user-column"
-        style={{color: mapColors(_get(row._original.completedBy, 'username') || row._original.completedBy)}}
+        style={{color: AsColoredHashable(_get(row._original.completedBy, 'username') || row._original.completedBy).hashColor}}
       >
         {_get(row._original.completedBy, 'username') || row._original.completedBy}
       </div>
@@ -502,7 +502,7 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
       null :
       <div
         className="row-user-column"
-        style={{color: mapColors(row._original.reviewedBy.username || row._original.reviewedBy)}}
+        style={{color: AsColoredHashable(row._original.reviewedBy.username || row._original.reviewedBy).hashColor}}
       >
         {row._original.reviewedBy.username || row._original.reviewedBy}
       </div>
@@ -524,7 +524,7 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
       null :
       <div
         className="row-user-column"
-        style={{color: mapColors(row._original.metaReviewedBy.username || row._original.metaReviewedBy)}}
+        style={{color: AsColoredHashable(row._original.metaReviewedBy.username || row._original.metaReviewedBy).hashColor}}
       >
         {row._original.metaReviewedBy.username || row._original.metaReviewedBy}
       </div>
@@ -581,12 +581,12 @@ const setupColumnTypes = (props, taskBaseRoute, manager, data, openComments) => 
     Cell: ({row}) => (
       <div
         className="row-user-column"
-        style={{color: mapColors(_get(row._original.completedBy, 'username') || row._original.completedBy)}}
+        style={{color: AsColoredHashable(_get(row._original.completedBy, 'username') || row._original.completedBy).hashColor}}
       >
         {_map(row._original.additionalReviewers, (reviewer, index) => {
           return (
             <React.Fragment key={reviewer.username + "-" + index}>
-              <span style={{color: mapColors(reviewer.username)}}>{reviewer.username}</span>
+              <span style={{color: AsColoredHashable(reviewer.username).hashColor}}>{reviewer.username}</span>
               {(index + 1) !== _get(row._original.additionalReviewers, 'length') ? ", " : ""}
             </React.Fragment>
           )

--- a/src/components/TaskHistoryList/TaskHistoryList.js
+++ b/src/components/TaskHistoryList/TaskHistoryList.js
@@ -15,6 +15,7 @@ import _sortBy from 'lodash/sortBy'
 import _reverse from 'lodash/reverse'
 import _find from 'lodash/find'
 import _noop from 'lodash/noop'
+import AsColoredHashable from '../../interactions/Hashable/AsColoredHashable'
 import MarkdownContent from '../MarkdownContent/MarkdownContent'
 import SvgSymbol from '../SvgSymbol/SvgSymbol'
 import { keysByStatus, messagesByStatus, TASK_STATUS_CREATED }
@@ -24,7 +25,6 @@ import { TaskReviewStatus, keysByReviewStatus, messagesByReviewStatus,
       from '../../services/Task/TaskReview/TaskReviewStatus'
 import { TaskHistoryAction } from '../../services/Task/TaskHistory/TaskHistory'
 import { viewAtticOverpass } from '../../services/Overpass/Overpass'
-import { mapColors } from '../../interactions/User/AsEndUser'
 import messages from './Messages'
 
 
@@ -140,7 +140,7 @@ export class TaskHistoryList extends Component {
                                   <div>
                                     <span
                                       className="mr-mr-2"
-                                      style={{color: mapColors(username)}}
+                                      style={{color: AsColoredHashable(username).hashColor}}
                                     >
                                       {username}
                                     </span> <FormattedMessage {...messages.startedOnLabel} />
@@ -200,7 +200,7 @@ export class TaskHistoryList extends Component {
           return (
             <li key={c.username + c.userType} className="">
               <span className="mr-w-40 mr-inline-block mr-px-2 mr-py-1"
-                    style={{color: mapColors(c.username)}} >
+                    style={{color: AsColoredHashable(c.username).hashColor}} >
                 {c.username}
               </span>
               <span className="mr-inline-block mr-text-pink mr-py-1">
@@ -255,7 +255,7 @@ export class TaskHistoryList extends Component {
             {(log.username || log.status) &&
               <li className="mr-mb-4">
                 <div className="mr-flex mr-justify-between">
-                  <span style={{color: mapColors(log.username)}}>
+                  <span style={{color: AsColoredHashable(log.username).hashColor}}>
                     {log.username}
                   </span>
                   {log.status}

--- a/src/interactions/Hashable/AsColoredHashable.js
+++ b/src/interactions/Hashable/AsColoredHashable.js
@@ -1,0 +1,52 @@
+// A curated subset of contrasting colors from:
+// http://godsnotwheregodsnot.blogspot.com/2013/11/kmeans-color-quantization-seeding.html
+const CONTRASTING_COLORS = [
+  "#FFFF00", "#1CE6FF", "#FF34FF", "#FFDBE5", "#63FFAC", "#B79762", "#8FB0FF",
+  "#809693", "#FEFFE6", "#4FC601", "#FF2F80", "#00C2A0", "#FFAA92", "#FF90C9",
+  "#D16100", "#DDEFFF", "#A1C299", "#0AA6D8", "#FFB500", "#C2FFED", "#A079BF",
+  "#C0B9B2", "#C2FF99", "#0CBD66", "#EEC3FF", "#B77B68", "#FAD09F", "#FF8A9A",
+  "#D157A0", "#BEC459", "#0086ED", "#B4A8BD", "#00A6AA", "#A3C8C9", "#FF913F",
+  "#00FECF", "#8CD0FF", "#04F757", "#C8A1A1", "#D790FF", "#9B9700", "#549E79",
+  "#FFF69F", "#99ADC0", "#FDE8DC", "#CB7E98", "#A4E804", "#83AB58", "#D1F7CE",
+  "#C8D0F6", "#A3A489", "#8ADBB4", "#C895C5", "#FF6832", "#66E1D3", "#CFCDAC",
+  "#D0AC94", "#7ED379", "#D68E01", "#78AFA1", "#FEB2C6", "#B5F4FF", "#D2DCD5",
+  "#0AA3F7", "#E98176", "#DBD5DD", "#5EBCD1", "#9695C5", "#E773CE", "#D86A78",
+  "#CA834E", "#FF5DA7", "#F7C9BF", "#6B94AA", "#51A058", "#E7AB63", "#97979E",
+  "#F4D749", "#DDB6D0", "#9FB2A4", "#00D891", "#BC65E9", "#C6DC99", "#F5E1FF",
+  "#FFA0F2", "#CCAA35", "#8BB400", "#C86240", "#CCB87C", "#B88183", "#B5D6C3",
+  "#A38469", "#9F94F0", "#B894A6", "#71BB8C", "#00B433", "#789EC9", "#6D80BA",
+  "#5EFF03", "#E4FFFC", "#1BE177", "#BCB1E5", "#A76F42", "#A88C85", "#F4ABAA",
+  "#A3F3AB", "#00C6C8", "#EA8B66", "#BDC9D2", "#9FA064", "#DFFB71", "#98D058",
+  "#D7BFC2", "#D25B88", "#00B57F", "#00CCFF", "#92896B"
+]
+
+// Simple fast hashing -- enough to get a unique color
+function hashCode(s) {
+  let h = 0
+  for(let i = 0; i < s.length; i++)
+    h = Math.imul(31, h) + s.charCodeAt(i) | 0
+  return h
+}
+
+ /**
+  * Returns a hex color based off a hash of the hashable value, which must be a
+  * string or have a toString method
+  */
+export function computeHashColor(hashable) {
+  if (!hashable || !hashable.toString) return ""
+
+  const hash = hashCode(hashable.toString())
+  return CONTRASTING_COLORS[Math.abs(hash) % CONTRASTING_COLORS.length]
+}
+
+/**
+ * Provides basic methods for generating different colors based on a string's
+ * hashcode
+ */
+export class AsColoredHashable {
+  constructor(hashable) {
+    this.hashColor = computeHashColor(hashable)
+  }
+}
+
+export default (hashable) => new AsColoredHashable(hashable)

--- a/src/interactions/User/AsEndUser.js
+++ b/src/interactions/User/AsEndUser.js
@@ -5,28 +5,6 @@ import _filter from 'lodash/filter'
 import _isObject from 'lodash/isObject'
 import _isNumber from 'lodash/isNumber'
 
-// A curated subset of contrasting colors from:
-// http://godsnotwheregodsnot.blogspot.com/2013/11/kmeans-color-quantization-seeding.html
-const CONTRASTING_COLORS = [
-  "#FFFF00", "#1CE6FF", "#FF34FF", "#FFDBE5", "#63FFAC", "#B79762", "#8FB0FF",
-  "#809693", "#FEFFE6", "#4FC601", "#FF2F80", "#00C2A0", "#FFAA92", "#FF90C9",
-  "#D16100", "#DDEFFF", "#A1C299", "#0AA6D8", "#FFB500", "#C2FFED", "#A079BF",
-  "#C0B9B2", "#C2FF99", "#0CBD66", "#EEC3FF", "#B77B68", "#FAD09F", "#FF8A9A",
-  "#D157A0", "#BEC459", "#0086ED", "#B4A8BD", "#00A6AA", "#A3C8C9", "#FF913F",
-  "#00FECF", "#8CD0FF", "#04F757", "#C8A1A1", "#D790FF", "#9B9700", "#549E79",
-  "#FFF69F", "#99ADC0", "#FDE8DC", "#CB7E98", "#A4E804", "#83AB58", "#D1F7CE",
-  "#C8D0F6", "#A3A489", "#8ADBB4", "#C895C5", "#FF6832", "#66E1D3", "#CFCDAC",
-  "#D0AC94", "#7ED379", "#D68E01", "#78AFA1", "#FEB2C6", "#B5F4FF", "#D2DCD5",
-  "#0AA3F7", "#E98176", "#DBD5DD", "#5EBCD1", "#9695C5", "#E773CE", "#D86A78",
-  "#CA834E", "#FF5DA7", "#F7C9BF", "#6B94AA", "#51A058", "#E7AB63", "#97979E",
-  "#F4D749", "#DDB6D0", "#9FB2A4", "#00D891", "#BC65E9", "#C6DC99", "#F5E1FF",
-  "#FFA0F2", "#CCAA35", "#8BB400", "#C86240", "#CCB87C", "#B88183", "#B5D6C3",
-  "#A38469", "#9F94F0", "#B894A6", "#71BB8C", "#00B433", "#789EC9", "#6D80BA",
-  "#5EFF03", "#E4FFFC", "#1BE177", "#BCB1E5", "#A76F42", "#A88C85", "#F4ABAA",
-  "#A3F3AB", "#00C6C8", "#EA8B66", "#BDC9D2", "#9FA064", "#DFFB71", "#98D058",
-  "#D7BFC2", "#D25B88", "#00B57F", "#00CCFF", "#92896B"
-]
-
 /**
  * Provides basic methods for interacting with users.
  */
@@ -84,22 +62,6 @@ export class AsEndUser {
 
     return _filter(this.user.notifications, {isRead: false}).length
   }
-}
-
-/**
- * Returns a hex color based off a hash of the username
- */
-export function mapColors(username) {
-  if (!username) return ""
-
-  return CONTRASTING_COLORS[Math.abs(hashCode(username)) % CONTRASTING_COLORS.length]
-}
-
-export function hashCode(s) {
-  let h = 0
-  for(let i = 0; i < s.length; i++)
-    h = Math.imul(31, h) + s.charCodeAt(i) | 0
-  return h
 }
 
 export default user => new AsEndUser(user)

--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -24,6 +24,7 @@ import { TaskReviewStatus, keysByReviewStatus, messagesByReviewStatus,
          messagesByMetaReviewStatus, isNeedsReviewStatus, isMetaReviewStatus }
        from '../../../services/Task/TaskReview/TaskReviewStatus'
 import { ReviewTasksType, buildLinkToMapperExportCSV } from '../../../services/Task/TaskReview/TaskReview'
+import AsColoredHashable from '../../../interactions/Hashable/AsColoredHashable'
 import { intlTableProps } from '../../../components/IntlTable/IntlTable'
 import IntlTablePagination from '../../../components/IntlTable/IntlTablePagination'
 import TaskCommentsModal
@@ -39,7 +40,6 @@ import Dropdown from '../../../components/Dropdown/Dropdown'
 import IntlDatePicker from '../../../components/IntlDatePicker/IntlDatePicker'
 import WithConfigurableColumns from '../../../components/HOCs/WithConfigurableColumns/WithConfigurableColumns'
 import WithCurrentUser from '../../../components/HOCs/WithCurrentUser/WithCurrentUser'
-import { mapColors } from '../../../interactions/User/AsEndUser'
 import messages from './Messages'
 import { ViewCommentsButton, StatusLabel, makeInvertable }
   from '../../../components/TaskAnalysisTable/TaskTableHelpers'
@@ -608,7 +608,7 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
     Cell: ({row}) => (
       <div
         className="row-user-column"
-        style={{color: mapColors(_get(row._original.reviewRequestedBy, 'username'))}}
+        style={{color: AsColoredHashable(_get(row._original.reviewRequestedBy, 'username')).hashColor}}
       >
         {_get(row._original.reviewRequestedBy, 'username')}
       </div>
@@ -625,12 +625,12 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
     Cell: ({row}) => (
       <div
         className="row-user-column"
-        style={{color: mapColors(_get(row._original.completedBy, 'username') || row._original.completedBy)}}
+        style={{color: AsColoredHashable(_get(row._original.completedBy, 'username') || row._original.completedBy).hashColor}}
       >
         {_map(row._original.additionalReviewers, (reviewer, index) => {
           return (
             <React.Fragment key={reviewer + "-" + index}>
-              <span style={{color: mapColors(reviewer.username)}}>{reviewer.username}</span>
+              <span style={{color: AsColoredHashable(reviewer.username).hashColor}}>{reviewer.username}</span>
               {(index + 1) !== _get(row._original.additionalReviewers, 'length') ? ", " : ""}
             </React.Fragment>
           )
@@ -796,7 +796,7 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
     Cell: ({row}) => (
       <div
         className="row-user-column"
-        style={{color: mapColors(_get(row._original.reviewedBy, 'username'))}}
+        style={{color: AsColoredHashable(_get(row._original.reviewedBy, 'username')).hashColor}}
       >
         {row._original.reviewedBy ? row._original.reviewedBy.username : "N/A"}
       </div>
@@ -943,7 +943,7 @@ const setupColumnTypes = (props, openComments, data, criteria, pageSize) => {
     Cell: ({row}) => (
       <div
         className="row-user-column"
-        style={{color: mapColors(_get(row._original.metaReviewedBy, 'username'))}}
+        style={{color: AsColoredHashable(_get(row._original.metaReviewedBy, 'username')).hashColor}}
       >
         {row._original.metaReviewedBy ? row._original.metaReviewedBy.username : ""}
       </div>


### PR DESCRIPTION
- Color spidered lines differently for each task based on the task id

- Make spidered line bold for task when its marker popup is activated

- Extract hash color functionality from AsEndUser into standalone
AsColoredHashable interaction so that it can be easily reused for more
than just usernames (e.g. task ids)

- Switch TaskClusterMap and EnhancedMap from using a callback to gain
access to the Leaflet map to using a React ref instead