### PR TITLE
Fix parsing priorities in saved filters

### DIFF
--- a/src/components/HOCs/WithSavedFilters/WithSavedFilters.js
+++ b/src/components/HOCs/WithSavedFilters/WithSavedFilters.js
@@ -6,6 +6,7 @@ import _keys from 'lodash/keys'
 import _isFinite from 'lodash/isFinite'
 import _compact from 'lodash/compact'
 import _split from 'lodash/split'
+import _indexOf from 'lodash/indexOf'
 import { buildSearchURL,
          buildSearchCriteriafromURL }
        from '../../../services/SearchCriteria/SearchCriteria'
@@ -86,7 +87,7 @@ const WithSavedFilters = function(WrappedComponent, appSettingName) {
         if (key === "priority" && _isFinite(value)) {
           textValue = this.props.intl.formatMessage(messagesByPriority[value])
         }
-        else if (key === "priorities" && value.indexOf(",") > -1) {
+        else if (key === "priorities" && _indexOf(value, ",") > -1) {
           const splitValues = _split(value, ",")
           if (splitValues.length === _keys(TaskPriority).length) {
             textValue = null


### PR DESCRIPTION
Parsing savedfilters was attempting to call an indexOf on the
number 0 and resulting in an error. Change to using lodash function

Fixes issue #1513 