### PR TITLE
Don't convert missing JSX children in templating

### DIFF
--- a/src/services/Templating/Templating.js
+++ b/src/services/Templating/Templating.js
@@ -40,7 +40,7 @@ export const expandTemplatingInJSX = function(jsxNode, props) {
   return React.cloneElement(
     jsxNode,
     {},
-    _map(jsxNode.props.children, child => {
+    jsxNode.props.children ? _map(jsxNode.props.children, child => {
       if (_isString(child)) {
         // Let short-code handlers have an opportunity to normalize the content
         // prior to tokenization
@@ -62,7 +62,7 @@ export const expandTemplatingInJSX = function(jsxNode, props) {
       else {
         return expandTemplatingInJSX(child, props)
       }
-    })
+    }) : jsxNode.props.children
   )
 }
 


### PR DESCRIPTION
- Don't convert missing child nodes to array of empty nodes when
performing template substitution on a JSX tree, as React does not allow
some tags (like `img`) to have child nodes and will generate an error

- Fixes #1518