### PR TITLE
Fix "all" status on review tables messing up next task to review

### DIFF
--- a/src/components/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
+++ b/src/components/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
@@ -284,7 +284,7 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
       const criteria =
          this.props.history.location.search ?
          buildSearchCriteriafromURL(this.props.history.location.search) :
-         this.props.history.location.state
+         _cloneDeep(this.props.history.location.state)
 
       // These values will come in as comma-separated strings and need to be turned
       // into number arrays


### PR DESCRIPTION
* status "all" was being converted to [0] on the Review page
  and so fetching the next task to review was failing.