### PR TITLE
Prepare for v3.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on
 This project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v3.7.4] - 2021-01-28
+### Fixed
+- Error when trying to review task after using browser back button
+- Unable to review consecutive tasks using Task Status "all" filter
+- Overlay indicating screen is too narrow sometimes obscured
+
+
 ## [v3.7.3] - 2021-01-27
 ### Added
 - Additional performance optimizations

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maproulette3",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.1.1",

--- a/src/components/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
+++ b/src/components/HOCs/WithFilteredClusteredTasks/WithFilteredClusteredTasks.js
@@ -302,10 +302,10 @@ export default function WithFilteredClusteredTasks(WrappedComponent,
 
       if (useURLFilters) {
         const filteredTasks =
-          this.filterTasks(criteria.filters.status,
-                           criteria.filters.reviewStatus,
-                           criteria.filters.metaReviewStatus,
-                           criteria.filters.priorities,
+          this.filterTasks(criteria.filters.status || this.state.includeStatuses,
+                           criteria.filters.reviewStatus || this.state.includeReviewStatuses,
+                           criteria.filters.metaReviewStatus || this.state.includeMetaReviewStatuses,
+                           criteria.filters.priorities || this.state.includePriorities,
                            this.state.includeLocked)
 
         // Statuses to be shown in drop down need to appear in this list,


### PR DESCRIPTION
### Fixed
- Error when trying to review task after using browser back button
- Unable to review consecutive tasks using Task Status "all" filter
- Overlay indicating screen is too narrow sometimes obscured