### PR TITLE
On project details page fetch project summary without priority

### DIFF
--- a/src/components/HOCs/WithProject/WithProject.js
+++ b/src/components/HOCs/WithProject/WithProject.js
@@ -109,7 +109,7 @@ const mapDispatchToProps = dispatch => ({
   fetchProjectChallenges: projectId =>
     dispatch(fetchProjectChallenges(projectId, -1)),
   fetchProjectChallengeActions: projectId =>
-    dispatch(fetchProjectChallengeActions(projectId)),
+    dispatch(fetchProjectChallengeActions(projectId, false, false)),
 })
 
 export default (WrappedComponent, options) =>

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -437,12 +437,13 @@ export const fetchChallengeActions = function(challengeId = null, suppressReceiv
 /**
  * Fetch action metrics for all challenges in the given project.
  */
-export const fetchProjectChallengeActions = function(projectId, onlyEnabled=false) {
+export const fetchProjectChallengeActions = function(projectId, onlyEnabled=false,
+  includeByPriority=true) {
   return function(dispatch) {
     return new Endpoint(
       api.challenges.actions,
       {schema: [ challengeSchema() ], params: {projectList: projectId, onlyEnabled,
-                                               includeByPriority: true}}
+                                               includeByPriority}}
     ).execute().then(normalizedResults => {
       dispatch(receiveChallenges(normalizedResults.entities))
     }).catch(error => {


### PR DESCRIPTION
On project details page fetch project summary do not includeByPriority on the api call.