### PR TITLE
Fix challenge admin showing no tasks after saving

### DIFF
--- a/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
+++ b/src/components/AdminPane/Manage/ManageChallenges/EditChallenge/EditChallenge.js
@@ -17,6 +17,7 @@ import _merge from 'lodash/merge'
 import _map from 'lodash/map'
 import _without from 'lodash/without'
 import _clone from 'lodash/clone'
+import _cloneDeep from 'lodash/cloneDeep'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import { Link } from 'react-router-dom'
 import External from '../../../../External/External'
@@ -291,9 +292,12 @@ export class EditChallenge extends Component {
     this.prepareFormDataForSaving().then(formData => {
       return this.props.saveChallenge(formData).then(challenge => {
         if (_isObject(challenge) && _isNumber(challenge.parent)) {
+          const nextState = _cloneDeep(this.challengeState)
+          nextState.refreshAfterSave = true
+
           this.props.history.push({
             pathname: `/admin/project/${challenge.parent}/challenge/${challenge.id}`,
-            state: this.challengeState
+            state: nextState
           })
         }
         else {

--- a/src/components/AdminPane/Manage/ManageTasks/EditTask/EditTask.js
+++ b/src/components/AdminPane/Manage/ManageTasks/EditTask/EditTask.js
@@ -7,6 +7,7 @@ import _isFinite from 'lodash/isFinite'
 import _filter from 'lodash/filter'
 import _isEmpty from 'lodash/isEmpty'
 import _split from 'lodash/split'
+import _cloneDeep from 'lodash/cloneDeep'
 import classNames from 'classnames'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import { Link } from 'react-router-dom'
@@ -64,10 +65,13 @@ export class EditTask extends Component {
       })
     }
     else {
+      const challengeState = _cloneDeep(this.challengeState)
+      challengeState.refreshAfterSave = true
+
       this.props.history.push({
         pathname:`/admin/project/${this.props.projectId}/` +
           `challenge/${this.props.challengeId}`,
-        state: this.challengeState
+        state: challengeState
       })
     }
   }

--- a/src/components/AdminPane/Manage/Widgets/ChallengeOverviewWidget/ChallengeOverviewWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/ChallengeOverviewWidget/ChallengeOverviewWidget.js
@@ -32,7 +32,8 @@ export default class ChallengeOverviewWidget extends Component {
     const manager = AsManager(this.props.user)
     const status = _get(this.props, 'challenge.status', ChallengeStatus.none)
 
-    const dataOriginDateText = !this.props.challenge.dataOriginDate ? null :
+    const dataOriginDateText =
+      (!this.props.challenge.dataOriginDate || !this.props.challenge.lastTaskRefresh) ? null :
       this.props.intl.formatMessage(messages.dataOriginDate,
         {refreshDate: this.props.intl.formatDate(parse(this.props.challenge.lastTaskRefresh)),
          sourceDate: this.props.intl.formatDate(parse(this.props.challenge.dataOriginDate))})

--- a/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
+++ b/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
@@ -247,6 +247,9 @@ export const WithFilterCriteria = function(WrappedComponent, ignoreURL = true) {
                 this.props.challengeId !== prevProps.challengeId) {
          this.refreshTasks(typedCriteria)
        }
+       else if (_get(this.props.history.location, 'state.refreshAfterSave')) {
+         this.refreshTasks(typedCriteria)
+       }
      }
 
      render() {


### PR DESCRIPTION
After saving a challenge or editing a task and saving, the challenge
admin page would show no rows in tasks table. Fixed by asking that
the tasks be refetched followig a save.