### PR TITLE
Fix wrong project name showing in review table column filter

### DIFF
--- a/src/pages/Review/TasksReview/TasksReviewTable.js
+++ b/src/pages/Review/TasksReview/TasksReviewTable.js
@@ -341,7 +341,7 @@ export class TaskReviewTable extends Component {
         if (reviewFilters.projectId || reviewFilters.projectName) {
           reviewFilters.project = reviewFilters.projectId ?
             _get(this.props.reviewProjects[reviewFilters.projectId],
-                 'name') : reviewFilters.projectName
+                 'displayName') : reviewFilters.projectName
         }
       }
 


### PR DESCRIPTION
In the review table column filter for projects, it was sometimes
showing the project name instead of display name