### PR TITLE
TaskBundleWidget should not show locked tasks

### DIFF
--- a/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.js
+++ b/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.js
@@ -30,7 +30,7 @@ import { MAX_ZOOM, UNCLUSTER_THRESHOLD } from '../../TaskClusterMap/TaskClusterM
  *
  * @author [Kelli Rotstan](https://github.com/krotstan)
  */
-export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=false, showClusters=true) {
+export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=false, showClusters=true, ignoreLocked=true) {
   return class extends Component {
     state = {
       loading: false,
@@ -100,7 +100,7 @@ export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=f
         searchCriteria.page = 0
 
         // Fetch up to threshold+1 individual tasks (eg. 1001 tasks)
-        this.props.fetchBoundedTasks(searchCriteria, UNCLUSTER_THRESHOLD + 1, !storeTasks, true, true).then(results => {
+        this.props.fetchBoundedTasks(searchCriteria, UNCLUSTER_THRESHOLD + 1, !storeTasks, ignoreLocked, true).then(results => {
           if (currentFetchId >= this.state.fetchId) {
             // If we retrieved 1001 tasks then there might be more tasks and
             // they should be clustered. So fetch as clusters
@@ -226,5 +226,5 @@ export const mapDispatchToProps = dispatch => Object.assign(
   }
 )
 
-export default (WrappedComponent, storeTasks, showClusters) =>
-  connect(null, mapDispatchToProps)(WithChallengeTaskClusters(WrappedComponent, storeTasks, showClusters))
+export default (WrappedComponent, storeTasks, showClusters, ignoreLocked) =>
+  connect(null, mapDispatchToProps)(WithChallengeTaskClusters(WrappedComponent, storeTasks, showClusters, ignoreLocked))

--- a/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
+++ b/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
@@ -26,7 +26,7 @@ const DEFAULT_CRITERIA = {sortCriteria: {sortBy: 'name', direction: 'DESC'},
  *
  * @author [Kelli Rotstan](https://github.com/krotstan)
  */
-export const WithFilterCriteria = function(WrappedComponent, ignoreURL = true) {
+export const WithFilterCriteria = function(WrappedComponent, ignoreURL = true, ignoreLocked = true) {
    return class extends Component {
      state = {
        loading: false,
@@ -169,7 +169,7 @@ export const WithFilterCriteria = function(WrappedComponent, ignoreURL = true) {
        this.props.augmentClusteredTasks(challengeId, false,
                                         criteria,
                                         this.state.criteria.pageSize,
-                                        false).then((results) => {
+                                        false, ignoreLocked).then((results) => {
          this.setState({loading: false})
        })
      }
@@ -279,4 +279,4 @@ export const WithFilterCriteria = function(WrappedComponent, ignoreURL = true) {
    }
  }
 
-export default (WrappedComponent, ignoreURL) => WithFilterCriteria(WrappedComponent, ignoreURL)
+export default (WrappedComponent, ignoreURL, ignoreLocked) => WithFilterCriteria(WrappedComponent, ignoreURL, ignoreLocked)

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -63,6 +63,7 @@ const descriptor = {
 const ClusterMap = WithChallengeTaskClusters(
   WithTaskClusterMarkers(TaskClusterMap('taskBundling')),
   false,
+  false,
   false
 )
 
@@ -377,7 +378,7 @@ registerWidgetType(
                 ),
                 'filteredClusteredTasks',
                 'taskInfo'
-              )
+              ), true, false
             )
           ),
           'clusteredTasks',

--- a/src/services/Task/BoundedTask.js
+++ b/src/services/Task/BoundedTask.js
@@ -50,7 +50,7 @@ export const receiveBoundedTasks = function(tasks,
  * criteria, which should at least include a boundingBox field, and may
  * optionally include a filters field with additional constraints
  */
-export const fetchBoundedTasks = function(criteria, limit=50, skipDispatch=false, excludeLocked=true, withGeometries) {
+export const fetchBoundedTasks = function(criteria, limit=50, skipDispatch=false, ignoreLocked=true, withGeometries) {
   return function(dispatch) {
     if (!skipDispatch) {
       // The map is either showing task clusters or bounded tasks so we shouldn't
@@ -122,8 +122,8 @@ export const fetchBoundedTasks = function(criteria, limit=50, skipDispatch=false
           top: normalizedBounds.getNorth(),
         },
         params: {limit, page: (page * limit), sort: sortBy, order: direction,
-                 includeTotal: true, excludeLocked, ...searchParameters, includeGeometries,
-                 includeTags},
+                 includeTotal: true, excludeLocked: ignoreLocked, ...searchParameters, 
+                 includeGeometries, includeTags},
         json: filters.taskPropertySearch ?
           {taskPropertySearch: filters.taskPropertySearch} : null,
       }

--- a/src/services/Task/ClusteredTask.js
+++ b/src/services/Task/ClusteredTask.js
@@ -61,7 +61,7 @@ export const clearClusteredTasks = function() {
  * clustered tasks
  */
 export const augmentClusteredTasks = function(challengeId, isVirtualChallenge=false, criteria, limit=15000,
-                                              mergeTasks=true) {
+                                              mergeTasks=true, ignoreLocked=true) {
   return function(dispatch) {
     if (isVirtualChallenge) {
       return
@@ -70,7 +70,7 @@ export const augmentClusteredTasks = function(challengeId, isVirtualChallenge=fa
     const fetchId = uuidv1()
     const augmentedCriteria = _cloneDeep(criteria)
     _set(augmentedCriteria, 'filters.challengeId', challengeId)
-    return fetchBoundedTasks(augmentedCriteria, limit, true)(dispatch).then(result => {
+    return fetchBoundedTasks(augmentedCriteria, limit, true, ignoreLocked)(dispatch).then(result => {
       if (result) {
         // Add parent field
         _each(result.tasks, task => task.parent = challengeId)


### PR DESCRIPTION
Pass in 'false' for excludeLocked when fetching tasks for the
bundle widget so that the server will not ignore locked tasks
in it's queries.
