### PR TITLE
Prevent multiple tasks fetch in bundle widget

### DIFF
--- a/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.js
+++ b/src/components/HOCs/WithBrowsedChallenge/WithBrowsedChallenge.js
@@ -230,7 +230,7 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
     ),
 
     loadChallengeActions: challengeId => {
-      return dispatch(fetchChallengeActions(challengeId))
+      return dispatch(fetchChallengeActions(challengeId, false, null, false))
     },
   }
 }

--- a/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.js
+++ b/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.js
@@ -30,7 +30,8 @@ import { MAX_ZOOM, UNCLUSTER_THRESHOLD } from '../../TaskClusterMap/TaskClusterM
  *
  * @author [Kelli Rotstan](https://github.com/krotstan)
  */
-export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=false, showClusters=true, ignoreLocked=true) {
+export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=false,
+  showClusters=true, ignoreLocked=true, skipInitialFetch=false) {
   return class extends Component {
     state = {
       loading: false,
@@ -144,8 +145,8 @@ export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=f
     }
 
     componentDidMount() {
-      if (!this.props.skipInitialFetch) {
-        this.fetchUpdatedClusters(this.state.showAsClusters)
+      if (!skipInitialFetch) {
+        this.debouncedFetchClusters(this.state.showAsClusters)
       }
     }
 
@@ -158,7 +159,7 @@ export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=f
       }
       else if (!_isEqual(_omit(prevProps.criteria, ['page', 'pageSize']),
             _omit(this.props.criteria, ['page', 'pageSize']))) {
-        this.fetchUpdatedClusters(this.state.showAsClusters)
+        this.debouncedFetchClusters(this.state.showAsClusters)
       }
     }
 
@@ -226,5 +227,6 @@ export const mapDispatchToProps = dispatch => Object.assign(
   }
 )
 
-export default (WrappedComponent, storeTasks, showClusters, ignoreLocked) =>
-  connect(null, mapDispatchToProps)(WithChallengeTaskClusters(WrappedComponent, storeTasks, showClusters, ignoreLocked))
+export default (WrappedComponent, storeTasks, showClusters, ignoreLocked, skipInitialFetch) =>
+  connect(null, mapDispatchToProps)(WithChallengeTaskClusters(WrappedComponent,
+    storeTasks, showClusters, ignoreLocked, skipInitialFetch))

--- a/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
+++ b/src/components/Widgets/TaskBundleWidget/TaskBundleWidget.js
@@ -64,7 +64,8 @@ const ClusterMap = WithChallengeTaskClusters(
   WithTaskClusterMarkers(TaskClusterMap('taskBundling')),
   false,
   false,
-  false
+  false,
+  true
 )
 
 
@@ -183,7 +184,6 @@ export default class TaskBundleWidget extends Component {
           bundleTasks={this.bundleTasks}
           unbundleTasks={this.unbundleTasks}
           loading={this.props.loading}
-          skipInitialFetch
         />
       </QuickWidget>
     )
@@ -378,7 +378,7 @@ registerWidgetType(
                 ),
                 'filteredClusteredTasks',
                 'taskInfo'
-              ), true, false
+              ), true, false, true
             )
           ),
           'clusteredTasks',

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -384,7 +384,7 @@ export const extendedFind = function(criteria, limit=RESULTS_PER_PAGE) {
  * if none is given).
  */
 export const fetchChallengeActions = function(challengeId = null, suppressReceive = false,
-                                              criteria) {
+                                              criteria, includeByPriority = true) {
   let searchParameters = {}
   if (criteria) {
     searchParameters = generateSearchParametersString(_get(criteria, 'filters', {}),
@@ -397,7 +397,7 @@ export const fetchChallengeActions = function(challengeId = null, suppressReceiv
     const challengeActionsEndpoint = new Endpoint(
       _isFinite(challengeId) ? api.challenge.actions : api.challenges.actions,
       {schema: [ challengeSchema() ], variables: {id: challengeId},
-       params:{...searchParameters, includeByPriority: true}}
+       params:{...searchParameters, includeByPriority}}
     )
 
     return challengeActionsEndpoint.execute().then(normalizedResults => {


### PR DESCRIPTION
* Add debouncing to fetchTasks for WithFilterCriteria

* pass 'priorityByTrue=false' on challenge details page

* Fix 'skipInitialFetch' not being honored