### PR TITLE
Passing wrong param to server when filtering on 'mappers'

### DIFF
--- a/src/services/Task/TaskReview/TaskReviewed.js
+++ b/src/services/Task/TaskReview/TaskReviewed.js
@@ -71,7 +71,7 @@ export const fetchReviewedTasks = function(userId, criteria, asReviewer=false,
       api.tasks.reviewed,
       {
         schema: {tasks: [taskSchema()]},
-        params: {mappers, reviewers, metaReviewers, limit, sort, order, page,
+        params: {users: mappers, reviewers, metaReviewers, limit, sort, order, page,
                  ...searchParameters, includeTags, asMetaReview,
                  allowReviewNeeded: (!asReviewer && !asMetaReviewer && !asMetaReview)},
       }


### PR DESCRIPTION
Call to fetch reviewed tasks for a mapper was pulling back
all results because it was passing the user id in as 'mappers'
instead of 'users'