### PR TITLE
Exclude tag-fix widget from task review

### DIFF
--- a/src/components/HOCs/WithCooperativeWork/WithCooperativeWork.js
+++ b/src/components/HOCs/WithCooperativeWork/WithCooperativeWork.js
@@ -56,7 +56,10 @@ export const WithCooperativeWork = function(WrappedComponent) {
         }))
       }
       catch(error) {
-        this.props.addErrorWithDetails(AppErrors.task.cooperativeFailure, error.message)
+        this.props.addErrorWithDetails(
+          AppErrors.task.cooperativeFailure,
+          error.message || error.defaultMessage
+        )
         this.setState({loadingOSMData: false})
         return
       }

--- a/src/components/ReviewTaskPane/ReviewTaskPane.js
+++ b/src/components/ReviewTaskPane/ReviewTaskPane.js
@@ -49,6 +49,7 @@ export const defaultWorkspaceSetup = function() {
     ],
     excludeWidgets: [
       'TaskCompletionWidget',
+      'TagDiffWidget',
     ]
   }
 }

--- a/src/components/Widgets/TagDiffWidget/Messages.js
+++ b/src/components/Widgets/TagDiffWidget/Messages.js
@@ -6,7 +6,7 @@ import { defineMessages } from 'react-intl'
 export default defineMessages({
   label: {
     id: "Widgets.TagDiffWidget.label",
-    defaultMessage: "Cooperativees",
+    defaultMessage: "Tag Fix",
   },
 
   title: {

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -1612,7 +1612,7 @@
   "Widgets.SupplementalMapWidget.title": "Supplemental Map",
   "Widgets.TagDiffWidget.controls.editTags.label": "Edit Tags",
   "Widgets.TagDiffWidget.controls.viewAllTags.label": "Show all Tags",
-  "Widgets.TagDiffWidget.label": "Cooperativees",
+  "Widgets.TagDiffWidget.label": "Tag Fix",
   "Widgets.TagDiffWidget.title": "Proposed OSM Tag Changes",
   "Widgets.TagMetricsWidget.label": "Tag Metrics",
   "Widgets.TagMetricsWidget.title": "Tag Metrics",


### PR DESCRIPTION
- Don't allow the TagDiffWidget (Tag Fix widget) to be added to the Task
Review workspace since it's diff display will be vs current OSM data
(not the original OSM data when task was completed) and likely either
blank or misleading

- Check for additional message fields when generating error if loading
cooperative task fails (e.g. OSM element not found on OSM server)

- Fix typo in TagDiffWidget label