### PR TITLE
Instructions widget bugfix

### DIFF
--- a/src/components/Widgets/TaskInstructionsWidget/TaskInstructionsWidget.js
+++ b/src/components/Widgets/TaskInstructionsWidget/TaskInstructionsWidget.js
@@ -1,25 +1,27 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-import { FormattedMessage } from 'react-intl'
-import classNames from 'classnames'
-import _get from 'lodash/get'
-import _isFinite from 'lodash/isFinite'
-import { WidgetDataTarget, registerWidgetType }
-       from '../../../services/Widget/Widget'
-import TaskInstructions from '../../TaskPane/TaskInstructions/TaskInstructions'
-import QuickWidget from '../../QuickWidget/QuickWidget'
-import messages from './Messages'
-import SvgSymbol from '../../SvgSymbol/SvgSymbol'
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { FormattedMessage } from "react-intl";
+import classNames from "classnames";
+import _get from "lodash/get";
+import _isFinite from "lodash/isFinite";
+import {
+  WidgetDataTarget,
+  registerWidgetType,
+} from "../../../services/Widget/Widget";
+import TaskInstructions from "../../TaskPane/TaskInstructions/TaskInstructions";
+import QuickWidget from "../../QuickWidget/QuickWidget";
+import messages from "./Messages";
+import SvgSymbol from "../../SvgSymbol/SvgSymbol";
 
 const descriptor = {
-  widgetKey: 'TaskInstructionsWidget',
+  widgetKey: "TaskInstructionsWidget",
   label: messages.label,
   targets: [WidgetDataTarget.task],
   minWidth: 3,
   defaultWidth: 3,
   minHeight: 2,
   defaultHeight: 6,
-}
+};
 
 export default class TaskInstructionsWidget extends Component {
   state = {
@@ -28,11 +30,12 @@ export default class TaskInstructionsWidget extends Component {
      * and needs a loader to account for it.
      */
     collapsing: false,
-  }
+    expandedOnLoad: false,
+  };
 
   resetLoader = () => {
     this.setState({ collapsing: false });
-  }
+  };
 
   /**
    * Invoked to toggle minimization of the challenge instructions. If the user
@@ -43,41 +46,49 @@ export default class TaskInstructionsWidget extends Component {
    */
   toggleMinimized = () => {
     this.setState({ collapsing: true });
-    const challengeId = _get(this.props.task, 'parent.id')
+    const challengeId = _get(this.props.task, "parent.id");
     if (_isFinite(challengeId)) {
       if (!this.props.collapseInstructions) {
         // Save our current height before collapsing so that we can restore it
         // later (as our actual height from the widget workspace will reflect
         // our collapsed state)
-        this.props.updateWidgetConfiguration({expandedHeight: this.props.widgetLayout.h})
+        this.props.updateWidgetConfiguration({
+          expandedHeight: this.props.widgetLayout.h,
+        });
       }
 
-      this.props.setInstructionsCollapsed(challengeId, false, !this.props.collapseInstructions)
+      this.props.setInstructionsCollapsed(
+        challengeId,
+        false,
+        !this.props.collapseInstructions
+      );
     }
 
     //this is not ideal, but it will prevent spam clicks until a more asynchronous flow is built for this toggle
     setTimeout(this.resetLoader, 800);
-  }
+  };
 
   adjustHeightForMinimization = () => {
-    if (this.props.collapseInstructions &&
-        this.props.widgetLayout.h > descriptor.minHeight) {
-      this.props.updateWidgetHeight(this.props.widgetLayout.i, descriptor.minHeight) 
+    if (
+      this.props.collapseInstructions &&
+      this.props.widgetLayout.h > descriptor.minHeight
+    ) {
+      this.props.updateWidgetHeight(
+        this.props.widgetLayout.i,
+        descriptor.minHeight
+      );
+    } else if (
+      !this.props.collapseInstructions &&
+      this.props.widgetLayout.h === descriptor.minHeight
+    ) {
+      this.props.updateWidgetHeight(
+        this.props.widgetLayout.i,
+        _isFinite(this.props.widgetConfiguration.expandedHeight)
+          ? this.props.widgetConfiguration.expandedHeight
+          : descriptor.defaultHeight
+      );
     }
-    else if (!this.props.collapseInstructions &&
-             this.props.widgetLayout.h === descriptor.minHeight) {
-
-      //users who spam clicked get stuck in a corrupt user settings state where
-      //expandedHeight equals minHeight.  This check will stop the infinite render and api call.
-      if (this.props.widgetConfiguration?.expandedHeight !== descriptor.minHeight) {
-        this.props.updateWidgetHeight(
-          this.props.widgetLayout.i,
-          _isFinite(this.props.widgetConfiguration.expandedHeight) ?
-            this.props.widgetConfiguration.expandedHeight : descriptor.defaultHeight
-        )
-      }
-    }
-  }
+  };
 
   componentDidMount() {
     this.adjustHeightForMinimization();
@@ -86,12 +97,19 @@ export default class TaskInstructionsWidget extends Component {
   componentDidUpdate(prevProps) {
     //When the page loads, the instructions widget should be expanded. Unfortunately this can't be checked
     //onmount so it is checked here for now.  Refactor needed.
-    if (!this.props.collapseInstructions && this.props.widgetConfiguration?.expandedHeight) {
-      if (this.props.widgetLayout.h !== this.props.widgetConfiguration?.expandedHeight)
-      return this.props.updateWidgetHeight(
-        this.props.widgetLayout.i,
-        descriptor.expandedHeight
-      )
+    if (!this.state.expandedOnLoad) {
+      this.setState({ expandedOnLoad: true });
+
+      const { expandedHeight } = this.props.widgetConfiguration;
+
+      //Users who spam clicked and have bad user settings need this check.
+      //Ssomehow expandedHeight becomes the minHeight when a race condition occurs
+      const height =
+        expandedHeight === descriptor.minHeight
+          ? descriptor.defaultHeight
+          : expandedHeight;
+
+      return this.props.updateWidgetHeight(this.props.widgetLayout.i, height);
     }
 
     if (prevProps.collapseInstructions !== this.props.collapseInstructions) {
@@ -101,34 +119,39 @@ export default class TaskInstructionsWidget extends Component {
 
   render() {
     const minimizeControl = (
-      <button className="mr-text-green-lighter" onClick={this.toggleMinimized} disabled={this.state.collapsing}>
+      <button
+        className="mr-text-green-lighter"
+        onClick={this.toggleMinimized}
+        disabled={this.state.collapsing}
+      >
         <SvgSymbol
           sym="icon-cheveron-down"
           viewBox="0 0 20 20"
           className="mr-transition mr-fill-current mr-min-w-6 mr-w-6 mr-h-6"
         />
       </button>
-    )
+    );
 
     return (
       <QuickWidget
         {...this.props}
-        className={classNames(
-          "task-instructions-widget",
-          {"is-expanded": !this.props.collapseInstructions}
-        )}
+        className={classNames("task-instructions-widget", {
+          "is-expanded": !this.props.collapseInstructions,
+        })}
         widgetTitle={<FormattedMessage {...messages.title} />}
         rightHeaderControls={minimizeControl}
       >
-        {!this.props.collapseInstructions && <TaskInstructions {...this.props} />}
+        {!this.props.collapseInstructions && (
+          <TaskInstructions {...this.props} />
+        )}
       </QuickWidget>
-    )
+    );
   }
 }
 
 TaskInstructionsWidget.propTypes = {
   collapseInstructions: PropTypes.bool,
   setInstructionsCollapsed: PropTypes.func.isRequired,
-}
+};
 
-registerWidgetType(TaskInstructionsWidget, descriptor)
+registerWidgetType(TaskInstructionsWidget, descriptor);


### PR DESCRIPTION
The user layout settings are updated via the API every time the user clicks on the instruction widget "expand" icon, and there is no loader present to prevent spam clicking.  A simple setTimeout loader is being added to prevent spam clicks, with the intention to refactor the toggle flow into something more asynchronous.  It would also be good to get rid of the ComponentDidUpdate lifecycle method in the TaskInstructionsWidget component and handle these edge cases more directly instead of reactively.

Notes were added to the implementation indicating what improvements to be made.