### PR TITLE
add osm editor button to coop tasks

### DIFF
--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -307,6 +307,7 @@ export class ActiveTaskControls extends Component {
                <CooperativeWorkControls
                  {...this.props}
                  allowedProgressions={allowedProgressions}
+                 pickEditor={this.pickEditor}
                  complete={this.initiateCompletion}
                  nextTask={this.next}
                  needsRevised={needsRevised}
@@ -324,14 +325,14 @@ export class ActiveTaskControls extends Component {
              />
              }
 
-             {isEditingTask &&
-             <TaskCompletionStep2
-               {...this.props}
-               allowedProgressions={allowedProgressions}
-               complete={this.initiateCompletion}
-               cancelEditing={this.cancelEditing}
-               needsRevised={needsRevised}
-             />
+             {isEditingTask && !AsCooperativeWork(this.props.task).isTagType() &&
+              <TaskCompletionStep2
+                {...this.props}
+                allowedProgressions={allowedProgressions}
+                complete={this.initiateCompletion}
+                cancelEditing={this.cancelEditing}
+                needsRevised={needsRevised}
+              />
              }
 
              {!isEditingTask && isComplete && !needsRevised &&

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/CooperativeWorkControls/CooperativeWorkControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/CooperativeWorkControls/CooperativeWorkControls.js
@@ -18,6 +18,9 @@ import TaskFalsePositiveControl
 import TaskAlreadyFixedControl
        from '../../../../TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskAlreadyFixedControl/TaskAlreadyFixedControl'
 import BusySpinner from '../../../../BusySpinner/BusySpinner'
+import UserEditorSelector
+       from '../../../../UserEditorSelector/UserEditorSelector'
+       import TaskEditControl from '../TaskEditControl/TaskEditControl'
 import messages from './Messages'
 
 export class CooperativeWorkControls extends Component {
@@ -68,6 +71,15 @@ export class CooperativeWorkControls extends Component {
                dropdownContent={dropdown => <ListMoreOptionsItems {...this.props} />}
              />
             }
+          </div>
+
+          <UserEditorSelector
+            {...this.props}
+            className="mr-mb-4"
+          />
+
+          <div className="mr-my-4 mr-grid mr-grid-columns-2 mr-grid-gap-4">
+            <TaskEditControl {...this.props} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
Mappers in a tag fix challenge may want capability to go to OSM from the TaskPane.  Edit button was added to the Completion Widget for coop tasks