### PR TITLE
Add "Show Archived" toggle to challenge browsing

### DIFF
--- a/src/components/ChallengePane/ChallengePane.js
+++ b/src/components/ChallengePane/ChallengePane.js
@@ -56,6 +56,7 @@ const LocationFilter = WithCurrentUser(FilterByLocation)
 export class ChallengePane extends Component {
   state = {
     selectedClusters: [],
+    showArchived: false
   }
 
   onBulkClusterSelection = clusters => {
@@ -133,11 +134,23 @@ export class ChallengePane extends Component {
           <ChallengeEndModal />
         }
         <ChallengeFilterSubnav {...this.props} />
-
         <div className="mr-p-6 lg:mr-flex mr-cards-inverse">
           <div className="mr-flex-0">
             <LocationFilter {...this.props} />
-            <ChallengeResults {...this.props} />
+            
+            <div className="mr-flex">
+              <input
+                type="checkbox"
+                className="mr-checkbox-toggle mr-mr-1 mr-mb-6"
+                checked={this.state.showArchived}
+                onChange={() => {
+                  this.setState({ showArchived: !this.state.showArchived })
+                }}
+              />
+              <div className="mr-text-sm mr-mx-1">Show Archived</div>
+            </div>
+
+            <ChallengeResults {...this.props} showArchived={this.state.showArchived} />
           </div>
           <div className="mr-flex-1">
             <MapPane>

--- a/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.js
+++ b/src/components/ChallengePane/ChallengeResultList/ChallengeResultList.js
@@ -37,7 +37,12 @@ export class ChallengeResultList extends Component {
   }
 
   render() {
-    const challengeResults = _clone(this.props.pagedChallenges)
+    let challengeResults = _clone(this.props.pagedChallenges);
+
+    if (!this.props.showArchived) {
+      challengeResults = challengeResults.filter(challenge => !challenge.isArchived)
+    }
+    
     const isFetching = _get(this.props, 'fetchingChallenges', []).length > 0
 
     const search = _get(this.props, 'currentSearch.challenges', {})
@@ -138,6 +143,9 @@ ChallengeResultList.propTypes = {
 
   /** Remaining challenges after challenges have been paged */
   pagedChallenges: PropTypes.array.isRequired,
+
+  /** Show archived challenges in the results */
+  showArchived: PropTypes.bool,
 }
 
 export default


### PR DESCRIPTION
Archived tasks will be invisible by default on the challenge search page.  A toggle is added to make them visible if user wants to see them.

Resolves https://github.com/osmlab/maproulette3/issues/1580
Rolls out with https://github.com/maproulette/maproulette2/pull/905