### PR TITLE
Fix task cluster archive filtering

### DIFF
--- a/src/components/ChallengePane/ChallengePane.js
+++ b/src/components/ChallengePane/ChallengePane.js
@@ -38,7 +38,9 @@ const ShowArchivedToggleInternal = (props) => {
         className="mr-checkbox-toggle mr-mr-1 mr-mb-6"
         checked={props.showingArchived}
         onChange={() => {
+          props.setSearchFilters({ archived: !props.showingArchived })
           props.setSearchArchived(!props.showingArchived);
+          
         }}
       />
       <div className="mr-text-sm mr-mx-1">Show Archived</div>

--- a/src/components/ChallengePane/ChallengePane.js
+++ b/src/components/ChallengePane/ChallengePane.js
@@ -39,8 +39,6 @@ const ShowArchivedToggleInternal = (props) => {
         checked={props.showingArchived}
         onChange={() => {
           props.setSearchFilters({ archived: !props.showingArchived })
-          props.setSearchArchived(!props.showingArchived);
-          
         }}
       />
       <div className="mr-text-sm mr-mx-1">Show Archived</div>
@@ -75,8 +73,7 @@ const LocationFilter = WithCurrentUser(FilterByLocation)
  */
 export class ChallengePane extends Component {
   state = {
-    selectedClusters: [],
-    showArchived: false
+    selectedClusters: []
   }
 
   onBulkClusterSelection = clusters => {

--- a/src/components/HOCs/WithChallenges/WithChallenges.js
+++ b/src/components/HOCs/WithChallenges/WithChallenges.js
@@ -20,7 +20,7 @@ const WithChallenges =
 
 export const mapStateToProps = (state, ownProps) => {
   const challenges = _values(_get(state, 'entities.challenges')) || []
-  const showArchived = _get(state, 'currentSearch.challenges.archived', false);
+  const showArchived = _get(state, 'currentSearch.challenges.filters.archived', false);
 
   // By default, only pass through challenges that are enabled (and belong to
   // an enabled project), have some tasks, and are in a usable status (unless

--- a/src/components/HOCs/WithSearch/WithSearch.js
+++ b/src/components/HOCs/WithSearch/WithSearch.js
@@ -13,7 +13,7 @@ import { SORT_NAME, SORT_CREATED, SORT_OLDEST, SORT_POPULARITY, SORT_COOPERATIVE
          setSearch, clearSearch,
          setChallengeSearchMapBounds,
          setTaskMapBounds, setChallengeOwnerMapBounds, clearMapBounds,
-         performSearch, setArchived }
+         performSearch }
        from '../../../services/Search/Search'
 import { addError } from '../../../services/Error/Error'
 import { toLatLngBounds, DEFAULT_MAP_BOUNDS }
@@ -113,7 +113,6 @@ export const mapStateToProps = (state, searchGroup) => {
     searchFilters: _get(state, `currentSearch.${searchGroup}.filters`, {}),
     searchSort: _get(state, `currentSearch.${searchGroup}.sort`, {}),
     searchPage: _get(state, `currentSearch.${searchGroup}.page`, {}),
-    archived: _get(state, `currentSearch.${searchGroup}.archived`, false),
     mapBounds: convertBounds(_get(state, `currentSearch.${searchGroup}.mapBounds`,
                                   {bounds: DEFAULT_MAP_BOUNDS})),
   }
@@ -177,10 +176,6 @@ export const mapDispatchToProps = (dispatch, ownProps, searchGroup) => ({
     }
 
     dispatch(setSort(searchGroup, sort))
-  },
-
-  setSearchArchived: bool => {
-    dispatch(setArchived(bool));
   },
 
   removeSearchSort:

--- a/src/components/HOCs/WithSearch/__snapshots__/WithSearch.test.js.snap
+++ b/src/components/HOCs/WithSearch/__snapshots__/WithSearch.test.js.snap
@@ -13,7 +13,6 @@ Object {
   "setChallengeSearchMapBounds": [Function],
   "setKeywordFilter": [Function],
   "setSearch": [Function],
-  "setSearchArchived": [Function],
   "setSearchFilters": [Function],
   "setSearchPage": [Function],
   "setSearchSort": [Function],
@@ -34,7 +33,6 @@ Object {
   "setChallengeSearchMapBounds": [Function],
   "setKeywordFilter": [Function],
   "setSearch": [Function],
-  "setSearchArchived": [Function],
   "setSearchFilters": [Function],
   "setSearchPage": [Function],
   "setSearchSort": [Function],
@@ -44,7 +42,6 @@ Object {
 
 exports[`mapStateToProps maps currentSearch 1`] = `
 Object {
-  "archived": false,
   "currentSearch": Object {
     "challenges": Object {
       "filters": Object {

--- a/src/components/HOCs/WithSearchRoute/WithSearchRoute.js
+++ b/src/components/HOCs/WithSearchRoute/WithSearchRoute.js
@@ -35,7 +35,7 @@ export const WithSearchRoute = function(WrappedComponent, searchGroup) {
        project: param => this.props.setSearchFilters({project: param, searchType: SEARCH_TYPE_PROJECT}),
        query: param => this.props.setSearch(param),
        challengeSearch: param => this.props.setChallengeSearchMapBounds(toLatLngBounds(param), true),
-       archived: param => this.props.setSearchArchived(param === "true")
+       archived: param => this.props.setSearchFilters({ archived: param === "true" })
     }
 
     state = {
@@ -74,11 +74,6 @@ export const WithSearchRoute = function(WrappedComponent, searchGroup) {
     setSearchSort = (sortCriteria) => {
       this.props.setSearchSort(sortCriteria)
       addSearchCriteriaToRoute(this.props.history, {sort: _get(sortCriteria, 'sortBy')})
-    }
-
-    setSearchArchived = (bool) => {
-      this.props.setSearchArchived(bool)
-      addSearchCriteriaToRoute(this.props.history, { archived: bool })
     }
 
     setSearchFilters = (filterCriteria) => {
@@ -126,7 +121,6 @@ export const WithSearchRoute = function(WrappedComponent, searchGroup) {
                             setSearch={this.setSearch}
                             clearSearch={this.clearSearch}
                             setSearchSort={this.setSearchSort}
-                            setSearchArchived={this.setSearchArchived}
                             setSearchFilters={this.setSearchFilters}
                             removeSearchFilters={this.removeSearchFilters}
                             setKeywordFilter={this.setKeywordFilter}

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -399,6 +399,10 @@ export const extendedFind = function (criteria, limit = RESULTS_PER_PAGE) {
       queryParams.cid = filters.challengeId;
     }
 
+    if (filters.archived) {
+      queryParams.ca = filters.archived;
+    }
+
     // Keywords/tags can come from both the the query and the filter, so we need to
     // combine them into a single keywords array.
     const keywords = queryParts.tagTokens.concat(
@@ -414,7 +418,6 @@ export const extendedFind = function (criteria, limit = RESULTS_PER_PAGE) {
     }
 
     queryParams.sort = sort;
-    queryParams.archived = criteria.archived;
     queryParams.order = direction;
     queryParams.page = page * limit;
 

--- a/src/services/Search/Search.js
+++ b/src/services/Search/Search.js
@@ -29,7 +29,6 @@ export const FETCHING_RESULTS = 'FETCHING_RESULTS'
 export const RECEIVED_RESULTS = 'RECEIVED_RESULTS'
 
 export const SET_SORT = 'SET_SORT'
-export const SET_ARCHIVED = 'SET_ARCHIVED'
 export const REMOVE_SORT = 'REMOVE_SORT'
 
 export const SET_PAGE = 'SET_PAGE'
@@ -371,13 +370,6 @@ export const setSort = function(searchName, sortCriteria) {
   }
 }
 
-export const setArchived = function(bool) {
-  return {
-    type: SET_ARCHIVED,
-    payload: bool
-  }
-}
-
 export const removeSort = function(searchName, criteriaNames) {
   return {
     type: REMOVE_SORT,
@@ -587,11 +579,6 @@ export const currentSearch = function(state={}, action) {
       _set(mergedState, `${action.searchName}.sort`,
             Object.assign({}, _get(state, `${action.searchName}.sort`), action.sortCriteria))
       _set(mergedState, `${action.searchName}.page`, null)
-      return mergedState
-
-    case SET_ARCHIVED:
-      mergedState = _cloneDeep(state)
-      _set(mergedState, `challenges.archived`, action.payload)
       return mergedState
 
     case REMOVE_SORT:

--- a/src/services/Search/Search.js
+++ b/src/services/Search/Search.js
@@ -90,6 +90,7 @@ export const PARAMS_MAP = {
   difficulty: 'cd',
   tags: 'tt',
   excludeTasks: 'tExcl',
+  archived: "ca"
 }
 
 
@@ -149,6 +150,9 @@ export const generateSearchParametersString = (filters, boundingBox, savedChalle
   const searchParameters = {}
   const invf = []
 
+  if (filters.archived) {
+    searchParameters[PARAMS_MAP.archived] = filters.archived;
+  }
   if (filters.reviewRequestedBy) {
     searchParameters[PARAMS_MAP.reviewRequestedBy] = filters.reviewRequestedBy
     if (invertFields.reviewRequestedBy) {


### PR DESCRIPTION
The taskCluster services need to filter out archived challenge task nodes appropriately.

Requires: https://github.com/maproulette/maproulette2/pull/914