### PR TITLE
New task review statuses and task review history csv

### DIFF
--- a/src/components/ReviewTaskControls/Messages.js
+++ b/src/components/ReviewTaskControls/Messages.js
@@ -62,7 +62,7 @@ export default defineMessages({
 
   approvedWithRevisions: {
     id: "Admin.TaskReview.controls.approvedWithRevisions",
-    defaultMessage: "Approve with revisions",
+    defaultMessage: "Approve revisions",
   },
 
   rejected: {
@@ -72,6 +72,11 @@ export default defineMessages({
 
   approvedWithFixes: {
     id: "Admin.TaskReview.controls.approvedWithFixes",
+    defaultMessage: "Approve (with fixes)",
+  },
+
+  approvedWithFixesAfterRevisions: {
+    id: "Admin.TaskReview.controls.approvedWithFixesAfterRevisions",
     defaultMessage: "Approve (with fixes)",
   },
 

--- a/src/components/ReviewTaskControls/Messages.js
+++ b/src/components/ReviewTaskControls/Messages.js
@@ -60,6 +60,11 @@ export default defineMessages({
     defaultMessage: "Approve",
   },
 
+  approvedWithRevisions: {
+    id: "Admin.TaskReview.controls.approvedWithRevisions",
+    defaultMessage: "Approve with revisions",
+  },
+
   rejected: {
     id: "Admin.TaskReview.controls.rejected",
     defaultMessage: "Reject",

--- a/src/components/ReviewTaskControls/ReviewTaskControls.js
+++ b/src/components/ReviewTaskControls/ReviewTaskControls.js
@@ -166,12 +166,16 @@ export class ReviewTaskControls extends Component {
     const fromInbox = _get(this.props.history, 'location.state.fromInbox')
     const tags = _map(this.props.task.tags, (tag) => tag.name)
 
+    const isRevision = (!this.props.metaReviewEnabled && Boolean(this.props.task?.review?.reviewedBy)) ||
+    (this.props.metaReviewEnabled && Boolean(this.props.task?.review?.metaReviewedBy));
+
     return (
       <div className={classNames("review-task-controls", this.props.className)}>
         <div className="mr-text-sm mr-text-white mr-mt-4 mr-whitespace-no-wrap">
           <FormattedMessage
             {...messages.currentTaskStatus}
-          /> <FormattedMessage
+          /> 
+          <FormattedMessage
             {...messagesByStatus[this.props.task.status]}
           />
         </div>
@@ -179,7 +183,8 @@ export class ReviewTaskControls extends Component {
         <div className="mr-text-sm mr-text-white mr-whitespace-no-wrap">
           <FormattedMessage
             {...messages.currentReviewStatus}
-          /> <FormattedMessage
+          /> 
+          <FormattedMessage
             {...messagesByReviewStatus[this.props.task.reviewStatus]}
           />
         </div>
@@ -188,7 +193,8 @@ export class ReviewTaskControls extends Component {
           <div className="mr-text-sm mr-text-white mr-whitespace-no-wrap">
             <FormattedMessage
               {...messages.currentMetaReviewStatus}
-            /> { _isUndefined(this.props.task.metaReviewStatus) ?
+            /> 
+            { _isUndefined(this.props.task.metaReviewStatus) ?
               <span/> :
               <FormattedMessage
                 {...messagesByReviewStatus[this.props.task.metaReviewStatus]}
@@ -224,10 +230,17 @@ export class ReviewTaskControls extends Component {
         }
 
         <div className="mr-my-4 mr-grid mr-grid-columns-2 mr-grid-gap-4">
-          <button className="mr-button mr-button--blue-fill"
-                  onClick={() => this.updateReviewStatus(TaskReviewStatus.approved)}>
-            <FormattedMessage {...messages.approved} />
-          </button>
+          {
+            isRevision 
+              ?  <button className="mr-button mr-button--blue-fill"
+                    onClick={() => this.updateReviewStatus(TaskReviewStatus.approvedWithRevisions)}>
+                  <FormattedMessage {...messages.approvedWithRevisions} />
+                </button>
+              : <button className="mr-button mr-button--blue-fill"
+                    onClick={() => this.updateReviewStatus(TaskReviewStatus.approved)}>
+                  <FormattedMessage {...messages.approved} />
+                </button>
+          }
           <button className="mr-button mr-button--blue-fill"
                   onClick={() => this.updateReviewStatus(TaskReviewStatus.rejected)}>
             <FormattedMessage {...messages.rejected} />

--- a/src/components/ReviewTaskControls/ReviewTaskControls.js
+++ b/src/components/ReviewTaskControls/ReviewTaskControls.js
@@ -165,9 +165,11 @@ export class ReviewTaskControls extends Component {
 
     const fromInbox = _get(this.props.history, 'location.state.fromInbox')
     const tags = _map(this.props.task.tags, (tag) => tag.name)
+    const isMetaReview = this.props.history?.location?.pathname?.includes("meta-review")
+    const reviewData = this.props.task?.review;
 
-    const isRevision = (!this.props.metaReviewEnabled && Boolean(this.props.task?.review?.reviewedBy)) ||
-    (this.props.metaReviewEnabled && Boolean(this.props.task?.review?.metaReviewedBy));
+    const isRevision = (!isMetaReview && Boolean(reviewData?.reviewedBy) && reviewData?.reviewStatus !== TaskReviewStatus.approved) ||
+      (isMetaReview && Boolean(reviewData?.metaReviewedBy));
 
     return (
       <div className={classNames("review-task-controls", this.props.className)}>
@@ -189,7 +191,7 @@ export class ReviewTaskControls extends Component {
           />
         </div>
 
-        {this.props.metaReviewEnabled &&
+        {isMetaReview &&
           <div className="mr-text-sm mr-text-white mr-whitespace-no-wrap">
             <FormattedMessage
               {...messages.currentMetaReviewStatus}
@@ -245,10 +247,17 @@ export class ReviewTaskControls extends Component {
                   onClick={() => this.updateReviewStatus(TaskReviewStatus.rejected)}>
             <FormattedMessage {...messages.rejected} />
           </button>
-          <button className="mr-button mr-button--blue-fill"
-                  onClick={() => this.updateReviewStatus(TaskReviewStatus.approvedWithFixes)}>
-            <FormattedMessage {...messages.approvedWithFixes} />
-          </button>
+          {
+            isRevision 
+              ?  <button className="mr-button mr-button--blue-fill"
+                    onClick={() => this.updateReviewStatus(TaskReviewStatus.approvedWithFixesAfterRevisions)}>
+                  <FormattedMessage {...messages.approvedWithFixesAfterRevisions} />
+                </button>
+              : <button className="mr-button mr-button--blue-fill"
+                    onClick={() => this.updateReviewStatus(TaskReviewStatus.approvedWithFixes)}>
+                  <FormattedMessage {...messages.approvedWithFixes} />
+                </button>
+          }
           <button className="mr-button mr-button--white"
                   onClick={() => this.skipReview()}>
             {this.props.asMetaReview ?

--- a/src/components/TaskAnalysisTable/Messages.js
+++ b/src/components/TaskAnalysisTable/Messages.js
@@ -209,6 +209,11 @@ export default defineMessages({
     defaultMessage: "Export Meta-Review Coverage CSV",
   },
 
+  exportTaskReviewHistoryLabel: {
+    id: "Admin.manageTasks.controls.exportTaskReviewHistory.label",
+    defaultMessage: "Export Task Review History CSV",
+  },
+
   timezoneLabel: {
     id: "Admin.manageTasks.controls.timezone.label",
     defaultMessage: "Timezone",

--- a/src/components/TaskAnalysisTable/TaskAnalysisTableHeader.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTableHeader.js
@@ -17,7 +17,8 @@ import SavedFiltersList from '../SavedFilters/SavedFiltersList'
 import ManageSavedFilters from '../SavedFilters/ManageSavedFilters'
 import { TaskStatus, statusLabels } from '../../services/Task/TaskStatus/TaskStatus'
 import { buildLinkToMapperExportCSV,
-         buildLinkToReviewerMetaExportCSV } from '../../services/Task/TaskReview/TaskReview'
+         buildLinkToReviewerMetaExportCSV,
+         buildLinkTaskReviewHistoryCSV } from '../../services/Task/TaskReview/TaskReview'
 import { buildLinkToExportCSV, buildLinkToExportGeoJSON } from '../../services/Challenge/Challenge'
 import messages from './Messages'
 
@@ -262,6 +263,17 @@ export class TaskAnalysisTableHeader extends Component {
                         </li>
                       </ul>
                     }
+                    <ul className="mr-list-dropdown">
+                      <li className="mr-mt-2">
+                        <a target="_blank"
+                            rel="noopener noreferrer"
+                            href={`${buildLinkTaskReviewHistoryCSV(_get(this.props, 'challenge.id'))}`}
+                            className="mr-flex mr-items-center">
+                          <SvgSymbol sym='download-icon' viewBox='0 0 20 20' className="mr-w-4 mr-h-4 mr-fill-current mr-mr-2" />
+                          <FormattedMessage {...messages.exportTaskReviewHistoryLabel} />
+                        </a>
+                      </li>
+                    </ul>
                   </React.Fragment>
                 }
               />

--- a/src/components/TaskAnalysisTable/TaskTableHelpers.js
+++ b/src/components/TaskAnalysisTable/TaskTableHelpers.js
@@ -9,16 +9,18 @@ import messages from './Messages'
  */
 
 
- export const StatusLabel = props => (
-    <span
-      className={classNames('mr-inline-flex mr-items-center', props.className)}
-    >
-      <span className="mr-w-2 mr-h-2 mr-rounded-full mr-bg-current" />
-      <span className="mr-ml-2 mr-text-xs mr-uppercase mr-tracking-wide">
-        <FormattedMessage {...props.intlMessage} />
+ export const StatusLabel = props => {
+   return (
+      <span
+        className={classNames('mr-inline-flex mr-items-center', props.className)}
+      >
+        <span className="mr-w-2 mr-h-2 mr-rounded-full mr-bg-current" />
+        <span className="mr-ml-2 mr-text-xs mr-uppercase mr-tracking-wide">
+          <FormattedMessage {...props.intlMessage} />
+        </span>
       </span>
-    </span>
-  )
+   )
+ }
 
  export const ViewCommentsButton = function(props) {
    return (

--- a/src/components/TaskConfirmationModal/TaskConfirmationModal.js
+++ b/src/components/TaskConfirmationModal/TaskConfirmationModal.js
@@ -258,18 +258,18 @@ export class TaskConfirmationModal extends Component {
 
                   {this.props.status !== TaskStatus.skipped && !reviewConfirmation &&
                     this.props.user.settings.needsReview !== needsReviewType.mandatory &&
-                  <div className="form mr-mt-2 mr-flex mr-items-baseline">
-                    <input
-                      type="checkbox"
-                      className="mr-mr-2"
-                      checked={this.props.needsReview}
-                      onClick={this.props.toggleNeedsReview}
-                      onChange={_noop}
-                    />
-                    <label className="mr-text-white-50">
-                      <FormattedMessage {...messages.reviewLabel} />
-                    </label>
-                  </div>
+                      <div className="form mr-mt-2 mr-flex mr-items-baseline">
+                        <input
+                          type="checkbox"
+                          className="mr-mr-2"
+                          checked={this.props.needsReview}
+                          onClick={this.props.toggleNeedsReview}
+                          onChange={_noop}
+                        />
+                        <label className="mr-text-white-50">
+                          <FormattedMessage {...messages.reviewLabel} />
+                        </label>
+                      </div>
                   }
 
                   <div className="mr-flex mr-items-center mr-mt-8">

--- a/src/services/Task/TaskReview/Messages.js
+++ b/src/services/Task/TaskReview/Messages.js
@@ -24,6 +24,11 @@ export default defineMessages({
     defaultMessage: "Approved with Fixes"
   },
 
+  approvedWithRevisions: {
+    id: "Task.reviewStatus.approvedWithRevisions",
+    defaultMessage: "Approved with Revisions"
+  },
+
   disputed: {
     id: "Task.reviewStatus.disputed",
     defaultMessage: "Contested"

--- a/src/services/Task/TaskReview/Messages.js
+++ b/src/services/Task/TaskReview/Messages.js
@@ -29,6 +29,11 @@ export default defineMessages({
     defaultMessage: "Approved with Revisions"
   },
 
+  approvedWithFixesAfterRevisions: {
+    id: "Task.reviewStatus.approvedWithFixesAfterRevisions",
+    defaultMessage: "Approved with Fixes after Revisions"
+  },
+
   disputed: {
     id: "Task.reviewStatus.disputed",
     defaultMessage: "Contested"

--- a/src/services/Task/TaskReview/TaskReview.js
+++ b/src/services/Task/TaskReview/TaskReview.js
@@ -146,6 +146,10 @@ export const buildLinkToReviewerMetaExportCSV = function(criteria) {
   return `${process.env.REACT_APP_MAP_ROULETTE_SERVER_URL}/api/v2/tasks/metareview/reviewers/export?${queryString.stringify(queryFilters)}`
 }
 
+export const buildLinkTaskReviewHistoryCSV = function(challengeId) {
+  return `${process.env.REACT_APP_MAP_ROULETTE_SERVER_URL}/api/v2/challenge/${challengeId}/extractReviewHistory`
+}
+
 const generateReviewSearch = function(criteria = {}, reviewTasksType = ReviewTasksType.allReviewedTasks, userId)  {
   const searchParameters = generateSearchParametersString(_get(criteria, 'filters', {}),
                                                        criteria.boundingBox,

--- a/src/services/Task/TaskReview/TaskReviewStatus.js
+++ b/src/services/Task/TaskReview/TaskReviewStatus.js
@@ -10,6 +10,7 @@ export const REVIEW_STATUS_REJECTED = 2
 export const REVIEW_STATUS_APPROVED_WITH_FIXES = 3
 export const REVIEW_STATUS_DISPUTED = 4
 export const REVIEW_STATUS_UNNECESSARY = 5
+export const REVIEW_STATUS_APPROVED_WITH_REVISIONS = 6
 
 export const REVIEW_STATUS_NOT_SET = -1
 export const META_REVIEW_STATUS_NOT_SET = -2
@@ -21,6 +22,7 @@ export const TaskReviewStatus = Object.freeze({
   approvedWithFixes: REVIEW_STATUS_APPROVED_WITH_FIXES,
   disputed: REVIEW_STATUS_DISPUTED,
   unnecessary: REVIEW_STATUS_UNNECESSARY,
+  approvedWithRevisions: REVIEW_STATUS_APPROVED_WITH_REVISIONS,
 })
 
 export const TaskReviewStatusWithUnset = Object.freeze({
@@ -31,6 +33,7 @@ export const TaskReviewStatusWithUnset = Object.freeze({
   disputed: REVIEW_STATUS_DISPUTED,
   unnecessary: REVIEW_STATUS_UNNECESSARY,
   unset: REVIEW_STATUS_NOT_SET,
+  approvedWithRevisions: REVIEW_STATUS_APPROVED_WITH_REVISIONS,
 })
 
 export const TaskMetaReviewStatusWithUnset = Object.freeze({
@@ -40,6 +43,7 @@ export const TaskMetaReviewStatusWithUnset = Object.freeze({
   metaRejected: REVIEW_STATUS_REJECTED,
   metaUnnecessary: REVIEW_STATUS_UNNECESSARY,
   metaUnset: META_REVIEW_STATUS_NOT_SET,
+  approvedWithRevisions: REVIEW_STATUS_APPROVED_WITH_REVISIONS,
 })
 
 export const keysByReviewStatus = Object.freeze(_invert(TaskReviewStatusWithUnset))

--- a/src/services/Task/TaskReview/TaskReviewStatus.js
+++ b/src/services/Task/TaskReview/TaskReviewStatus.js
@@ -11,6 +11,7 @@ export const REVIEW_STATUS_APPROVED_WITH_FIXES = 3
 export const REVIEW_STATUS_DISPUTED = 4
 export const REVIEW_STATUS_UNNECESSARY = 5
 export const REVIEW_STATUS_APPROVED_WITH_REVISIONS = 6
+export const REVIEW_STATUS_APPROVED_WITH_FIXES_AFTER_REVISIONS = 7
 
 export const REVIEW_STATUS_NOT_SET = -1
 export const META_REVIEW_STATUS_NOT_SET = -2
@@ -23,6 +24,7 @@ export const TaskReviewStatus = Object.freeze({
   disputed: REVIEW_STATUS_DISPUTED,
   unnecessary: REVIEW_STATUS_UNNECESSARY,
   approvedWithRevisions: REVIEW_STATUS_APPROVED_WITH_REVISIONS,
+  approvedWithFixesAfterRevisions: REVIEW_STATUS_APPROVED_WITH_FIXES_AFTER_REVISIONS
 })
 
 export const TaskReviewStatusWithUnset = Object.freeze({
@@ -34,6 +36,7 @@ export const TaskReviewStatusWithUnset = Object.freeze({
   unnecessary: REVIEW_STATUS_UNNECESSARY,
   unset: REVIEW_STATUS_NOT_SET,
   approvedWithRevisions: REVIEW_STATUS_APPROVED_WITH_REVISIONS,
+  approvedWithFixesAfterRevisions: REVIEW_STATUS_APPROVED_WITH_FIXES_AFTER_REVISIONS
 })
 
 export const TaskMetaReviewStatusWithUnset = Object.freeze({
@@ -44,6 +47,7 @@ export const TaskMetaReviewStatusWithUnset = Object.freeze({
   metaUnnecessary: REVIEW_STATUS_UNNECESSARY,
   metaUnset: META_REVIEW_STATUS_NOT_SET,
   approvedWithRevisions: REVIEW_STATUS_APPROVED_WITH_REVISIONS,
+  approvedWithFixesAfterRevisions: REVIEW_STATUS_APPROVED_WITH_FIXES_AFTER_REVISIONS
 })
 
 export const keysByReviewStatus = Object.freeze(_invert(TaskReviewStatusWithUnset))
@@ -97,7 +101,9 @@ export const isNeedsReviewStatus = function(status) {
  */
 export const isMetaReviewStatus = function(status) {
   return status === TaskReviewStatus.approved ||
+         status === TaskReviewStatus.approvedWithRevisions ||
          status === TaskReviewStatus.approvedWithFixes ||
+         status === TaskReviewStatus.approvedWithFixesAfterRevision ||
          status === TaskReviewStatus.rejected ||
          status === TaskReviewStatus.needed ||
          status === TaskReviewStatus.unnecessary


### PR DESCRIPTION
This feature adds two new review approval statuses and a new task review history csv report that pulls data directly from the task review history table for tasks of a challenge.

Requires https://github.com/maproulette/maproulette2/pull/920