### PR TITLE
disable analytics for projects with over 100 challenges

### DIFF
--- a/src/components/AdminPane/Manage/Widgets/BurndownChartWidget/BurndownChartWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/BurndownChartWidget/BurndownChartWidget.js
@@ -9,6 +9,7 @@ import WithChallengeMetrics
        from '../../../HOCs/WithChallengeMetrics/WithChallengeMetrics'
 import messages from './Messages'
 import './BurndownChartWidget.scss'
+import { PROJECT_CHALLENGE_LIMIT } from '../../../../../services/Project/Project'
 
 const descriptor = {
   widgetKey: 'BurndownChartWidget',
@@ -25,6 +26,9 @@ export default class BurndownChartWidget extends Component {
     if (this.props.singleProject) {
       if (!this.props.project) {
         content = <BusySpinner />
+      }
+      else if (this.props.challengeLimitExceeded) {
+        content = <div classname="mr-text-red">Sorry, project statistics are not available for projects with more than {PROJECT_CHALLENGE_LIMIT} challenges.</div>
       }
       else if (!this.props.challengeStatsAvailable) {
         content = (

--- a/src/components/AdminPane/Manage/Widgets/StatusRadarWidget/StatusRadarWidget.js
+++ b/src/components/AdminPane/Manage/Widgets/StatusRadarWidget/StatusRadarWidget.js
@@ -9,6 +9,7 @@ import WithChallengeMetrics
        from '../../../HOCs/WithChallengeMetrics/WithChallengeMetrics'
 import messages from './Messages'
 import './StatusRadarWidget.scss'
+import { PROJECT_CHALLENGE_LIMIT } from '../../../../../services/Project/Project'
 
 const descriptor = {
   widgetKey: 'StatusRadarWidget',
@@ -25,6 +26,9 @@ export default class StatusRadarWidget extends Component {
     if (this.props.singleProject) {
       if (!this.props.project) {
         content = <BusySpinner />
+      }
+      else if (this.props.challengeLimitExceeded) {
+        content = <div classname="mr-text-red">Sorry, project statistics are not available for projects with more than {PROJECT_CHALLENGE_LIMIT} challenges.</div>
       }
       else if (!this.props.challengeStatsAvailable) {
         content = (

--- a/src/components/HOCs/WithProject/WithProject.js
+++ b/src/components/HOCs/WithProject/WithProject.js
@@ -13,6 +13,7 @@ import { fetchProject } from '../../../services/Project/Project'
 import { fetchProjectChallenges,
          fetchProjectChallengeActions }
        from '../../../services/Challenge/Challenge'
+import { PROJECT_CHALLENGE_LIMIT } from '../../../services/Project/Project'
 
 
 /**
@@ -46,7 +47,7 @@ const WithProject = function(WrappedComponent, options={}) {
         })
     }
 
-    loadProject = props => {
+    loadProject = async (props) => {
       const projectId = this.currentProjectId(props)
 
       if (_isFinite(projectId)) {
@@ -54,7 +55,7 @@ const WithProject = function(WrappedComponent, options={}) {
           loadingChallenges: options.includeChallenges,
         })
 
-        props.fetchProject(projectId).then(normalizedProject => {
+        props.fetchProject(projectId).then(async normalizedProject => {
           const project = normalizedProject.entities.projects[normalizedProject.result]
           this.setState({project: project})
 
@@ -62,8 +63,11 @@ const WithProject = function(WrappedComponent, options={}) {
             const retrievals = []
             retrievals.push(props.fetchProjectChallenges(projectId))
 
-            // Used to display completion progress for each challenge
-            retrievals.push(props.fetchProjectChallengeActions(projectId))
+            const challenges = await props.fetchProjectChallenges(projectId)
+
+            if (challenges.result.length < PROJECT_CHALLENGE_LIMIT + 1) {
+              retrievals.push(props.fetchProjectChallengeActions(projectId))
+            }
 
             Promise.all(retrievals).then(() => {
               this.setState({loadingChallenges: false})

--- a/src/components/ProjectDetail/ProjectDetail.js
+++ b/src/components/ProjectDetail/ProjectDetail.js
@@ -17,6 +17,7 @@ import WithProject from '../HOCs/WithProject/WithProject'
 import WithCurrentUser from '../HOCs/WithCurrentUser/WithCurrentUser'
 import WithComputedMetrics from '../AdminPane/HOCs/WithComputedMetrics/WithComputedMetrics'
 import ChallengeResultList from '../ChallengePane/ChallengeResultList/ChallengeResultList'
+import { PROJECT_CHALLENGE_LIMIT } from '../../services/Project/Project'
 
 const ProjectProgress = WithComputedMetrics(ChallengeProgress)
 
@@ -125,7 +126,12 @@ export class ProjectDetail extends Component {
                     />
                   </div>
 
-                  <ProjectProgress className="mr-my-4" {...this.props} />
+                  {this.props.challenges?.length > PROJECT_CHALLENGE_LIMIT 
+                    ?  <div className="mr-text-red">
+                        Sorry, project statistics are not available for projects with more than {PROJECT_CHALLENGE_LIMIT} challenges.
+                      </div>
+                    :  <ProjectProgress className="mr-my-4" {...this.props} />}
+                 
 
                   <ul className="mr-card-challenge__actions mr-mt-4 mr-leading-none mr-text-base">
                     <li>

--- a/src/components/Widgets/CompletionProgressWidget/CompletionProgressWidget.js
+++ b/src/components/Widgets/CompletionProgressWidget/CompletionProgressWidget.js
@@ -8,6 +8,7 @@ import QuickWidget from '../../QuickWidget/QuickWidget'
 import messages from './Messages'
 import WithChallengeMetrics
        from '../../AdminPane/HOCs/WithChallengeMetrics/WithChallengeMetrics'
+import { PROJECT_CHALLENGE_LIMIT } from '../../../services/Project/Project'
 
 const descriptor = {
   widgetKey: 'CompletionProgressWidget',
@@ -42,6 +43,9 @@ export default class CompletionProgressWidget extends Component {
     if (this.props.singleProject) {
       if (!this.props.project) {
         content = <BusySpinner />
+      }
+      else if (this.props.challengeLimitExceeded) {
+        content = <div classname="mr-text-red">Sorry, project statistics are not available for projects with more than {PROJECT_CHALLENGE_LIMIT} challenges.</div>
       }
       else if (!this.props.challengeStatsAvailable) {
         content = (

--- a/src/services/Project/Project.js
+++ b/src/services/Project/Project.js
@@ -26,6 +26,8 @@ export const projectSchema = function () {
 const RECEIVE_PROJECTS = "RECEIVE_PROJECTS";
 const REMOVE_PROJECT = "REMOVE_PROJECT";
 
+export const PROJECT_CHALLENGE_LIMIT = 100
+
 // redux action creators
 
 /**


### PR DESCRIPTION
The analytics endpoints take a heavy performance hit when projects reach a certain size.  This feature will disable any analytics calls for projects with over 100 challenges.