### PR TITLE
See Tag Fix Suggestions User Setting

### DIFF
--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/ActiveTaskControls.js
@@ -303,7 +303,7 @@ export class ActiveTaskControls extends Component {
             <FormattedMessage {...messages.readOnly} />
            </div> :
            <React.Fragment>
-             {AsCooperativeWork(this.props.task).isTagType() && (!isFinal || needsRevised) &&
+             {AsCooperativeWork(this.props.task).isTagType() && (!isFinal || needsRevised) && this.props.user.settings.seeTagFixSuggestions &&
                <CooperativeWorkControls
                  {...this.props}
                  allowedProgressions={allowedProgressions}
@@ -313,19 +313,19 @@ export class ActiveTaskControls extends Component {
                  needsRevised={needsRevised}
                />
              }
-             {!AsCooperativeWork(this.props.task).isTagType() && !isEditingTask && (!isFinal || needsRevised) &&
-             <TaskCompletionStep1
-               {...this.props}
-               allowedEditors={this.allowedEditors()}
-               allowedProgressions={allowedProgressions}
-               pickEditor={this.pickEditor}
-               complete={this.initiateCompletion}
-               nextTask={this.next}
-               needsRevised={needsRevised}
-             />
+             {(!AsCooperativeWork(this.props.task).isTagType() || !this.props.user.settings.seeTagFixSuggestions) && !isEditingTask && (!isFinal || needsRevised) &&
+              <TaskCompletionStep1
+                {...this.props}
+                allowedEditors={this.allowedEditors()}
+                allowedProgressions={allowedProgressions}
+                pickEditor={this.pickEditor}
+                complete={this.initiateCompletion}
+                nextTask={this.next}
+                needsRevised={needsRevised}
+              />
              }
 
-             {isEditingTask && !AsCooperativeWork(this.props.task).isTagType() &&
+             {isEditingTask && (!AsCooperativeWork(this.props.task).isTagType() || !this.props.user.settings.seeTagFixSuggestions) &&
               <TaskCompletionStep2
                 {...this.props}
                 allowedProgressions={allowedProgressions}

--- a/src/components/Widgets/TagDiffWidget/Messages.js
+++ b/src/components/Widgets/TagDiffWidget/Messages.js
@@ -14,6 +14,11 @@ export default defineMessages({
     defaultMessage: "Proposed OSM Tag Changes",
   },
 
+  disabledDescription: {
+    id: "Widgets.TagDiffWidget.disabledDescription",
+    defaultMessage: "This task has proposed tag fixes, but you've disabled seeing them for your user. You can re-enable this in User Settings.",
+  },
+
   viewAllTagsLabel: {
     id: "Widgets.TagDiffWidget.controls.viewAllTags.label",
     defaultMessage: "Show all Tags",

--- a/src/components/Widgets/TagDiffWidget/TagDiffWidget.js
+++ b/src/components/Widgets/TagDiffWidget/TagDiffWidget.js
@@ -40,21 +40,23 @@ export default class TagDiffWidget extends Component {
           <FormattedMessage {...messages.title} />
         }
         rightHeaderControls={
-          <div className="mr-flex">
-            <button
-              className="mr-button mr-button--xsmall mr-mr-4"
-              onClick={() => this.setState({showDiffModal: true})}
-            >
-              <FormattedMessage {...messages.viewAllTagsLabel} />
-            </button>
+          this.props.user.settings.seeTagFixSuggestions
+            ? <div className="mr-flex">
+                <button
+                  className="mr-button mr-button--xsmall mr-mr-4"
+                  onClick={() => this.setState({showDiffModal: true})}
+                >
+                  <FormattedMessage {...messages.viewAllTagsLabel} />
+                </button>
 
-            <button
-              className="mr-button mr-button--xsmall"
-              onClick={() => this.setState({showDiffModal: true, editMode: true})}
-            >
-              <FormattedMessage {...messages.editTagsLabel} />
-            </button>
-          </div>
+                <button
+                  className="mr-button mr-button--xsmall"
+                  onClick={() => this.setState({showDiffModal: true, editMode: true})}
+                >
+                  <FormattedMessage {...messages.editTagsLabel} />
+                </button>
+              </div>
+            : null
         }
       >
         <TagDiff {...this.props} />
@@ -72,6 +74,14 @@ export default class TagDiffWidget extends Component {
 }
 
 export const TagDiff = props => {
+  if (!props.user.settings.seeTagFixSuggestions) {
+    return (
+      <div className="mr-mb-4">
+        <FormattedMessage {...messages.disabledDescription} />
+      </div>
+    )
+  }
+
   const needsRevised = props.task.reviewStatus === TaskReviewStatus.rejected
   if (AsCooperativeWork(props.task).isTagType() && (!isFinalStatus(props.task.status) || needsRevised)) {
     if (props.loadingOSMData) {

--- a/src/pages/Profile/Messages.js
+++ b/src/pages/Profile/Messages.js
@@ -115,6 +115,18 @@ export default defineMessages({
     "If no, users will not be able to follow your MapRoulette activity."
   },
 
+  seeTagFixSuggestionsDescription: {
+    id: "Profile.form.seeTagFixSuggestions.description",
+    defaultMessage:
+    "User will see tag fix suggestions if they are provided."
+  },
+
+  seeTagFixSuggestionsLabel: {
+    id: "Profile.form.seeTagFixSuggestions.label",
+    defaultMessage:
+    "See Tag Fix Suggestions"
+  },
+
   apiKey: {
     id: "Profile.apiKey.header",
     defaultMessage: "API Key",

--- a/src/pages/Profile/UserSettings/UserSettingsSchema.js
+++ b/src/pages/Profile/UserSettings/UserSettingsSchema.js
@@ -106,6 +106,11 @@ export const jsSchema = (intl, user, editor) => {
         type: "boolean",
         default: false,
       },
+      seeTagFixSuggestions: {
+        title: "See Tag Fix Suggestions",
+        type: "boolean",
+        default: false
+      }
     },
   }
 
@@ -183,9 +188,13 @@ export const uiSchema = (intl, user, editor) => {
       "ui:widget": "radio",
       "ui:help": intl.formatMessage(messages.allowFollowingDescription),
     },
+    seeTagFixSuggestions: {
+      "ui:widget": "radio",
+      "ui:help": intl.formatMessage(messages.seeTagFixSuggestionsDescription),
+    },
     "ui:order": [
       "locale", "allowFollowing", "defaultEditor", "leaderboardOptOut",
-      "defaultBasemap", "isReviewer", "customBasemaps"
+      "defaultBasemap", "isReviewer", "customBasemaps", "seeTagFixSuggestions"
     ],
   }
 

--- a/src/pages/Profile/UserSettings/UserSettingsSchema.js
+++ b/src/pages/Profile/UserSettings/UserSettingsSchema.js
@@ -107,9 +107,9 @@ export const jsSchema = (intl, user, editor) => {
         default: false,
       },
       seeTagFixSuggestions: {
-        title: "See Tag Fix Suggestions",
+        title: intl.formatMessage(messages.seeTagFixSuggestionsLabel),
         type: "boolean",
-        default: false
+        default: true
       }
     },
   }


### PR DESCRIPTION
This will add a "See Tag Fix Suggestions" user setting, allowing tag fix widgets to be disabled so user only sees a normal task edit interface.

Requires https://github.com/maproulette/maproulette2/pull/923
Resolves https://github.com/osmlab/maproulette3/issues/1650