### PR TITLE
handle null locations for task activity

### DIFF
--- a/src/components/ActivityMap/ActivityMap.js
+++ b/src/components/ActivityMap/ActivityMap.js
@@ -33,7 +33,7 @@ export const ActivityMap = props => {
   let coloredMarkers = null
   if (hasTaskMarkers) {
     coloredMarkers = _map(props.activity, entry => {
-      if (!entry.task) {
+      if (!entry?.task?.location) {
         return null
       }
 


### PR DESCRIPTION
for the activity map, if a task has a null location property, simply return null in the marker component so the whole map doesn't break.