### PR TITLE
add task specific properties to custom url widget

### DIFF
--- a/src/components/CustomUrlList/CustomUrlList.js
+++ b/src/components/CustomUrlList/CustomUrlList.js
@@ -24,8 +24,12 @@ const CustomUrlList = props => {
       _map(urls, url => {
         let disabled = false
         let replacedUrl = null
+        let replacedDescription = null
+        let replacedName = null
         try {
           replacedUrl = replacePropertyTags(url.url, properties, true)
+          replacedDescription = replacePropertyTags(url.description, properties, true)
+          replacedName = replacePropertyTags(url.name, properties, true)
         }
         catch(err) {
           disabled = true
@@ -37,14 +41,14 @@ const CustomUrlList = props => {
             className="mr-my-2 mr-flex mr-justify-between mr-items-center"
           >
             {disabled ?
-             <span className="mr-text-grey-light" title={url.description}>{url.name}</span> :
+             <span className="mr-text-grey-light" title={replacedDescription}>{replacedName}</span> :
              <a
                href={encodeURI(replacedUrl)}
                target="_blank"
                rel="noopener noreferrer"
-               title={url.description}
+               title={replacedDescription}
              >
-               {url.name}
+               {replacedName}
              </a>
             }
             <div className="mr-h-5">

--- a/src/hooks/UseMRProperties/UseMRProperties.js
+++ b/src/hooks/UseMRProperties/UseMRProperties.js
@@ -30,6 +30,15 @@ const useMRProperties = workspaceContext => {
       mrProperties['#mrTaskId'] = task.id
       mrProperties['#osmId'] = primaryFeature.osmId()
       mrProperties['#osmType'] = primaryFeature.osmType()
+
+      //map the task specific properties to the workspace properties
+      const { properties } = primaryFeature;
+      if (properties) {
+        Object.keys(properties).map((key, index) => {
+          mrProperties[key] = properties[key];
+          return null;
+        });
+      }
     }
 
     const mapBounds = workspaceContext['taskMapBounds']


### PR DESCRIPTION
Fixes https://github.com/osmlab/maproulette3/issues/1699

The Custom URL widget did not have any connectivity to the task specific properties.  Also, "name" and "description" now honor the mustache tags in addition to the "URL" field.