### PR TITLE
add page selector to CSV export link

### DIFF
--- a/src/components/PagePicker/PagePicker.js
+++ b/src/components/PagePicker/PagePicker.js
@@ -1,0 +1,37 @@
+import React from 'react'
+
+const PagePickerOptions = (props) => {
+  if (props.numItems > props.itemLimit) {
+    let options = [];
+    let numberOfPages = Math.ceil(props.numItems / props.itemLimit);
+
+    for (let i = 0; i < numberOfPages; i++) {
+      options.push(
+        <option key={i} value={i}>
+          Page {i + 1}
+        </option>
+      )
+    }
+
+    return options;
+  }
+
+  return null;
+}
+
+const PagePicker = props => {
+  return (
+    <select
+      onChange={e => props.changePage(e.target.value)}
+      defaultValue={-1}
+      className="mr-w-24 mr-select mr-text-xs mr-pr-5"
+    >
+      <option key="all" value="-1">
+        All
+      </option>
+      <PagePickerOptions {...props} />
+    </select>
+  )
+}
+
+export default PagePicker

--- a/src/components/TaskAnalysisTable/TaskAnalysisTableHeader.js
+++ b/src/components/TaskAnalysisTable/TaskAnalysisTableHeader.js
@@ -12,6 +12,7 @@ import SvgSymbol from '../SvgSymbol/SvgSymbol'
 import TriStateCheckbox from '../Bulma/TriStateCheckbox'
 import ConfirmAction from '../ConfirmAction/ConfirmAction'
 import TimezonePicker from '../TimezonePicker/TimezonePicker'
+import PagePicker from '../PagePicker/PagePicker'
 import WithSavedFilters from '../HOCs/WithSavedFilters/WithSavedFilters'
 import SavedFiltersList from '../SavedFilters/SavedFiltersList'
 import ManageSavedFilters from '../SavedFilters/ManageSavedFilters'
@@ -22,13 +23,21 @@ import { buildLinkToMapperExportCSV,
 import { buildLinkToExportCSV, buildLinkToExportGeoJSON } from '../../services/Challenge/Challenge'
 import messages from './Messages'
 
+const CSV_ITEM_LIMIT = 10000;
+
 /**
  * TaskAnalysisTableHeader renders a header for the task analysis table.
  *
  * @author [Ryan Scherler](https://github.com/ryanscherler)
  */
 export class TaskAnalysisTableHeader extends Component {
-  state = {}
+  state = {
+    csvPage: -1
+  }
+
+  handleChangeCSVPage = (pageKey) => {
+    this.setState({ csvPage: pageKey })
+  }
 
   render() {
     const {countShown, configureColumns} = this.props
@@ -213,15 +222,24 @@ export class TaskAnalysisTableHeader extends Component {
                     </div>
                     <ul className="mr-list-dropdown">
                       <li>
-                        <form method="post" action={buildLinkToExportCSV(_get(this.props, 'challenge.id'), this.props.criteria, this.props.currentTimezone)}>
+                        <form method="post" action={buildLinkToExportCSV(_get(this.props, 'challenge.id'), this.props.criteria, this.props.currentTimezone, this.state.csvPage, CSV_ITEM_LIMIT)}>
                           <input type="hidden" name="taskPropertySearch"
                             value={JSON.stringify(_get(this.props,
                               'criteria.filters.taskPropertySearch', {}))}
                           />
-                          <button type="submit" className="mr-flex mr-items-center mr-text-green-lighter mr-bg-transparent mr-align-top mr-pb-2">
-                            <SvgSymbol sym='download-icon' viewBox='0 0 20 20' className="mr-w-4 mr-h-4 mr-fill-current mr-mr-2" />
-                            <FormattedMessage {...messages.exportCSVLabel} />
-                          </button>
+                          <div className="mr-flex">
+                            <button type="submit" className="mr-flex mr-items-center mr-text-green-lighter mr-bg-transparent mr-align-top mr-pb-2">
+                              <SvgSymbol sym='download-icon' viewBox='0 0 20 20' className="mr-w-4 mr-h-4 mr-fill-current mr-mr-2" />
+                              <FormattedMessage {...messages.exportCSVLabel} />
+                            </button>
+                            <div className="mr-ml-2">
+                              <PagePicker
+                                changePage={this.handleChangeCSVPage}
+                                numItems={totalTaskCount}
+                                itemLimit={CSV_ITEM_LIMIT}
+                              />
+                            </div>
+                          </div>
                         </form>
                       </li>
                     </ul>

--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -77,14 +77,22 @@ export const challengeDenormalizationSchema = function () {
 export const buildLinkToExportCSV = function (
   challengeId,
   criteria,
-  timezone = null
+  timezone = null,
+  page = -1,
+  limit
 ) {
+  let pageString = '';
+
+  if (page > -1) {
+    pageString = `&page=${page}&limit=${limit}`
+  }
+
   const queryFilters = buildQueryFilters(criteria);
   return (
     `${process.env.REACT_APP_MAP_ROULETTE_SERVER_URL}/api/v2/challenge/` +
     `${challengeId}/tasks/extract?${queryFilters}&timezone=${encodeURIComponent(
       timezone
-    )}`
+    )}${pageString}`
   );
 };
 


### PR DESCRIPTION
Proposed fix for https://github.com/osmlab/maproulette3/issues/1709 would allow very large CSV exports to be downloaded 10k tasks at a time to fall within nginx/api upstream timeouts.

Requires https://github.com/maproulette/maproulette2/pull/938