### PR TITLE
set up lock storage events

### DIFF
--- a/src/components/HOCs/WithLockedTask/WithLockedTask.js
+++ b/src/components/HOCs/WithLockedTask/WithLockedTask.js
@@ -71,9 +71,11 @@ const WithLockedTask = function(WrappedComponent) {
         return Promise.reject("Invalid task")
       }
 
-      lockStorage.removeLock(task.id)
-
-      return this.props.releaseTask(task.id).catch(err => null)
+      this.props.releaseTask(task.id).then(() => {
+        //wait for lock to be cleared in db and provide some leeway 
+        //time with setTimeout before triggering storage event
+        setTimeout(() => lockStorage.removeLock(task.id), 1000);
+      }).catch(err => null)
     }
 
     /**

--- a/src/components/HOCs/WithLockedTask/WithLockedTask.js
+++ b/src/components/HOCs/WithLockedTask/WithLockedTask.js
@@ -99,8 +99,12 @@ const WithLockedTask = function(WrappedComponent) {
     }
 
     syncLocks = () => {
-      if (!lockStorage.isLocked(this.props.task.id)) {
-        this.refreshTaskLock(this.props.task)
+      const { task } = this.props;
+
+      if (task) {
+        if (!lockStorage.isLocked(task.id)) {
+          this.refreshTaskLock(task)
+        }
       }
     }
 

--- a/src/components/HOCs/WithLockedTask/WithLockedTask.js
+++ b/src/components/HOCs/WithLockedTask/WithLockedTask.js
@@ -6,6 +6,29 @@ import { startTask, releaseTask, refreshTaskLock }
 import _get from 'lodash/get'
 import _omit from 'lodash/omit'
 
+// Used for lock storage events. Users will be locked from other task tabs
+// if logging out, signing back in, or have multiple tabs on one task
+const lockStorage = {
+  setLock: (taskId) => {
+    localStorage.setItem(`lock-${taskId}`, true);
+  },
+
+  removeLock: (taskId) => {
+    localStorage.removeItem(`lock-${taskId}`);
+  },
+
+  isLocked: (taskId) => {
+    const isLocked = localStorage.getItem(`lock-${taskId}`);
+
+    if (isLocked) {
+      return true
+    }
+
+    return false;
+  }
+}
+
+
 /**
  * WithLockedTask provides a means of locking and unlocking a task the user is
  * about to work on. If a lock cannot be acquired, the WrappedCompont will be
@@ -33,6 +56,9 @@ const WithLockedTask = function(WrappedComponent) {
         }
 
         this.setState({tryingLock: false})
+
+        lockStorage.setLock(task.id);
+
         return true
       }).catch(err => {
         this.setState({readOnly: true, tryingLock: false, failureDetails: err.details})
@@ -44,6 +70,8 @@ const WithLockedTask = function(WrappedComponent) {
       if (!task) {
         return Promise.reject("Invalid task")
       }
+
+      lockStorage.removeLock(task.id)
 
       return this.props.releaseTask(task.id).catch(err => null)
     }
@@ -61,6 +89,8 @@ const WithLockedTask = function(WrappedComponent) {
           this.setState({readOnly: false, failureDetails: null})
         }
 
+        lockStorage.setLock(task.id);
+
         return true
       }).catch(err => {
         this.setState({readOnly: true, failureDetails: err.details})
@@ -68,10 +98,20 @@ const WithLockedTask = function(WrappedComponent) {
       })
     }
 
-    componentDidMount() {
-      if (this.props.task) {
-        this.lockTask(this.props.task)
+    syncLocks = () => {
+      if (!lockStorage.isLocked(this.props.task.id)) {
+        this.refreshTaskLock(this.props.task)
       }
+    }
+
+    componentDidMount() {
+      const { task } = this.props;
+
+      if (task) {
+        this.lockTask(task)
+      }
+
+      window.addEventListener('storage', this.syncLocks)
     }
 
     componentDidUpdate(prevProps) {
@@ -87,8 +127,12 @@ const WithLockedTask = function(WrappedComponent) {
     }
 
     componentWillUnmount() {
-      if (this.props.task) {
-        this.unlockTask(this.props.task)
+      const { task } = this.props;
+      window.removeEventListener('storage', this.syncLocks);
+
+      if (task) {
+        this.unlockTask(task)
+        lockStorage.removeLock(task.id)
       }
     }
 

--- a/src/components/HOCs/WithLockedTask/WithLockedTask.js
+++ b/src/components/HOCs/WithLockedTask/WithLockedTask.js
@@ -74,7 +74,7 @@ const WithLockedTask = function(WrappedComponent) {
       this.props.releaseTask(task.id).then(() => {
         //wait for lock to be cleared in db and provide some leeway 
         //time with setTimeout before triggering storage event
-        setTimeout(() => lockStorage.removeLock(task.id), 1000);
+        setTimeout(() => lockStorage.removeLock(task.id), 1500);
       }).catch(err => null)
     }
 

--- a/src/components/SignInButton/SignInButton.js
+++ b/src/components/SignInButton/SignInButton.js
@@ -21,6 +21,13 @@ export class SignInButton extends Component {
     clicked: false,
   }
 
+  handleSignin = () => {
+    this.setState({clicked: true});
+
+    //clear stale locks in localStorage
+    localStorage.clear();
+  }
+
   render() {
     if (this.props.checkingLoginStatus || this.state.clicked) {
       return (
@@ -33,7 +40,7 @@ export class SignInButton extends Component {
     return (
       <a
         className={classNames("mr-button", this.props.className)}
-        onClick={() => this.setState({clicked: true})}
+        onClick={this.handleSignin}
         href={
           `${process.env.REACT_APP_SERVER_OAUTH_URL}${encodeURIComponent(
             this.props.history.location.pathname + this.props.history.location.search

--- a/src/services/User/User.js
+++ b/src/services/User/User.js
@@ -735,7 +735,9 @@ export const unsaveTask = function(userId, taskId) {
  * Logout the current user on both the client and server.
  */
 export const logoutUser = function(userId) {
-  localStorage.removeItem('isLoggedIn')
+  //clear stale locks and isLoggedIn status
+  localStorage.clear();
+
   const logoutURI = `${process.env.REACT_APP_MAP_ROULETTE_SERVER_URL}/auth/signout`
 
   if (_isFinite(userId) && userId !== GUEST_USER_ID) {


### PR DESCRIPTION
Adding additional locking safeguards for situations when users are unknowingly working on unlocked tasks.  storage events will prompt other tabs to notify the user that they may need to refresh their lock or go into preview mode.   Doing this will safeguard task status change flows from buggy edge cases.