### PR TITLE
fix condition for challenge custom basemap

### DIFF
--- a/src/interactions/Challenge/AsMappableChallenge.js
+++ b/src/interactions/Challenge/AsMappableChallenge.js
@@ -14,8 +14,8 @@ export class AsMappableChallenge {
     if (!_isFinite(this.id)) {
       return null
     }
-    return basemapLayerSource(this.defaultBasemap,
-                              this.defaultBasemapId)
+    
+    return basemapLayerSource(this.defaultBasemap, this.defaultBasemapId, this.customBasemap)
   }
 }
 

--- a/src/services/VisibleLayer/LayerSources.js
+++ b/src/services/VisibleLayer/LayerSources.js
@@ -193,22 +193,25 @@ export const createDynamicLayerSource = function(layerId, layerName, url, overla
  * customBasemap settings, including generating a dynamic layer source with the
  * given customBasemap and customLayerId if appropriate.
  */
-export const basemapLayerSource = function(defaultBasemap, defaultBasemapId) {
+export const basemapLayerSource = function(defaultBasemap, defaultBasemapId, customMapUrl) {
   if (defaultBasemap === ChallengeBasemap.none) {
     return null
-  }
-  else if (defaultBasemap === ChallengeBasemap.identified) {
+  } else if (defaultBasemap === ChallengeBasemap.identified) {
     return layerSourceWithId(defaultBasemapId)
-  }
-  else if (_isFinite(defaultBasemap)) {
-    return layerSourceWithId(basemapLayerSources()[defaultBasemap])
-  }
-  else if (defaultBasemap && defaultBasemap.url) {
+
+    // if challenge basemap setting is custom and a customMapUrl is provided
+    // we need to set this as default basemap.  It will show up in the map layers
+    // as "Challenge Default" under the User custom basemeps, but will be preselected
+  } else if (defaultBasemap === ChallengeBasemap.custom && customMapUrl) {
+    return createDynamicLayerSource(100, "Challenge Default", customMapUrl, false)
+  } else if (_isFinite(defaultBasemap)) {
+    const basemap = basemapLayerSources()[defaultBasemap]
+    return layerSourceWithId(basemap)
+  } else if (defaultBasemap && defaultBasemap.url) {
     return createDynamicLayerSource(
       defaultBasemap.name, defaultBasemap.name, defaultBasemap.url,
       defaultBasemap.overlay)
-  }
-  else {
+  } else {
     return null
   }
 }


### PR DESCRIPTION
We originally had support for challenge custom basemaps, but the condition that sets it as default seems to have been broken when user basemaps were created.

Challenge custom basemaps will now function as the global default when a user comes to a new challenge/task.

Resolves https://github.com/osmlab/maproulette3/issues/1610 https://github.com/osmlab/maproulette3/issues/1730