### PR TITLE
Remove references to end-of-life'd node 12

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,14 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14]
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ This is the repository that holds the front-end code. The back-end and API are d
 
 ### Basic Dependencies:
 
-* [Node 12 LTS](https://nodejs.org/)
+* [Node 14 LTS](https://nodejs.org/)
 * [yarn](https://yarnpkg.com/)
 * [jq](https://stedolan.github.io/jq/)
 * [curl](https://curl.haxx.se/)


### PR DESCRIPTION
Node 12 is EOL'd and not supported and this patch updates things to Node 14.x. Note that to move to Node 16 LTS we'll need to update node-sass from 4.14 to 6.0+ as documented here https://www.npmjs.com/package/node-sass