### PR TITLE
add flex wrap to tags input fields

### DIFF
--- a/src/components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter.scss
+++ b/src/components/Bulma/RJSFFormFieldAdapter/RJSFFormFieldAdapter.scss
@@ -341,3 +341,7 @@ form.rjsf {
   display: flex;
   flex-direction: column;
 }
+
+.tags-field > div > span {
+  flex-wrap: wrap;
+}


### PR DESCRIPTION
This resolves a wrapping issue for tags input fields on the Challenge create screen.