### PR TITLE
consolidate overlapping markers

### DIFF
--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { FormattedMessage } from 'react-intl'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { ZoomControl, Marker, LayerGroup, Rectangle, Polyline, Pane }
+import { ZoomControl, Marker, LayerGroup, Rectangle, Polyline, Pane, Tooltip }
        from 'react-leaflet'
 import { latLng } from 'leaflet'
 import bbox from '@turf/bbox'
@@ -337,11 +337,50 @@ export class TaskClusterMap extends Component {
     return distance(firstPosition, secondPosition, {units: 'degrees'})
   }
 
+  // Overlapping, unlike clustering, means the markers are in the EXACT same position.
+  labelOverlappingMarkers = (markers) => {
+    // Collect a dictionary of unique coordinates
+    const uniqueCoords = {};
+
+    // Get the overlapping marker count for each unique set of coordinates
+    // and store in the dictionary
+    for (let i = 0; i < markers.length; i++) {
+      const marker = markers[i];
+      const stringCoords = marker.position.join(',');
+      const count = uniqueCoords[stringCoords];
+
+      if (count) {
+        uniqueCoords[stringCoords]++;
+      } else {
+        uniqueCoords[stringCoords] = 1;
+      }
+    }
+
+    // Loop back through the markers and apply the overlapping count to each of them
+    for (let i = 0; i < markers.length; i++) {
+      const marker = markers[i];
+      const stringCoords = marker.position.join(',');
+      const count = uniqueCoords[stringCoords];
+
+      marker.overlappingCount = count;
+    }
+
+    return markers;
+  }
+
   consolidateMarkers = markers => {
     // Make sure conditions are appropriate for consolidation
     if (!this.props.showAsClusters ||
         this.props.totalTaskCount <= CLUSTER_POINTS ||
         !markers || !this.currentBounds || !this.currentSize) {
+
+      // Depending on zoom level and env variables, the API may still be clustering.
+      // Double-check the first indexed marker for clustering before 
+      // checking overlapping markers
+      if (!markers[0]?.options?.clusterId) {
+        return this.labelOverlappingMarkers(markers)
+      }
+
       return markers
     }
 
@@ -466,6 +505,8 @@ export class TaskClusterMap extends Component {
       consolidatedMarkers.push(...[...this.state.spidered.values()])
     }
 
+    const uniqueCoords = {};
+
     const mapMarkers = _map(consolidatedMarkers, mark => {
       let onClick = null
       let popup = null
@@ -497,6 +538,25 @@ export class TaskClusterMap extends Component {
         const nearestToCenter = AsMappableTask(mark.options).nearestPointToCenter()
         if (nearestToCenter) {
           position = [nearestToCenter.geometry.coordinates[1], nearestToCenter.geometry.coordinates[0]]
+        }
+      }
+
+      // It's an overlapping mark icon if it's not clustered, has an overlapping count, and isn't already spidered
+      const overlappingMark = !mark.options.clusterId && mark.overlappingCount > 1 && !this.state.spidered.has(mark.options.taskId)
+
+      if (overlappingMark) {
+        const stringCoords = mark.position.join(',');
+
+        //since these markers are overlapping, this will ensure only one marker renders as necessary
+        if (!uniqueCoords[stringCoords]) {
+          uniqueCoords[stringCoords] = true;
+
+          return (
+            <Marker key={markerId} position={position}
+                        onClick={onClick}><Tooltip>{mark.overlappingCount} overlapping tasks</Tooltip></Marker>
+          );
+        } else {
+          return null;
         }
       }
 

--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -73,6 +73,37 @@ export const CLUSTER_POINTS = 25
  */
 export const CLUSTER_ICON_PIXELS = 40
 
+// Overlapping, unlike clustering, means the markers are in the EXACT same position.
+export const labelOverlappingMarkers = (markers) => {
+  // Collect a dictionary of unique coordinates
+  const uniqueCoords = {};
+
+  // Get the overlapping marker count for each unique set of coordinates
+  // and store in the dictionary
+  for (let i = 0; i < markers.length; i++) {
+    const marker = markers[i];
+    const stringCoords = marker.position.join(',');
+    const count = uniqueCoords[stringCoords];
+
+    if (count) {
+      uniqueCoords[stringCoords]++;
+    } else {
+      uniqueCoords[stringCoords] = 1;
+    }
+  }
+
+  // Loop back through the markers and apply the overlapping count to each of them
+  for (let i = 0; i < markers.length; i++) {
+    const marker = markers[i];
+    const stringCoords = marker.position.join(',');
+    const count = uniqueCoords[stringCoords];
+
+    marker.overlappingCount = count;
+  }
+
+  return markers;
+}
+
 /**
  * TaskClusterMap allows a user to browse tasks and task clusters
  * geographically, optionally calling back when map bounds are modified
@@ -337,37 +368,6 @@ export class TaskClusterMap extends Component {
     return distance(firstPosition, secondPosition, {units: 'degrees'})
   }
 
-  // Overlapping, unlike clustering, means the markers are in the EXACT same position.
-  labelOverlappingMarkers = (markers) => {
-    // Collect a dictionary of unique coordinates
-    const uniqueCoords = {};
-
-    // Get the overlapping marker count for each unique set of coordinates
-    // and store in the dictionary
-    for (let i = 0; i < markers.length; i++) {
-      const marker = markers[i];
-      const stringCoords = marker.position.join(',');
-      const count = uniqueCoords[stringCoords];
-
-      if (count) {
-        uniqueCoords[stringCoords]++;
-      } else {
-        uniqueCoords[stringCoords] = 1;
-      }
-    }
-
-    // Loop back through the markers and apply the overlapping count to each of them
-    for (let i = 0; i < markers.length; i++) {
-      const marker = markers[i];
-      const stringCoords = marker.position.join(',');
-      const count = uniqueCoords[stringCoords];
-
-      marker.overlappingCount = count;
-    }
-
-    return markers;
-  }
-
   consolidateMarkers = markers => {
     // Make sure conditions are appropriate for consolidation
     if (!this.props.showAsClusters ||
@@ -378,7 +378,7 @@ export class TaskClusterMap extends Component {
       // Double-check the first indexed marker for clustering before 
       // checking overlapping markers
       if (!markers[0]?.options?.clusterId) {
-        return this.labelOverlappingMarkers(markers)
+        return labelOverlappingMarkers(markers)
       }
 
       return markers

--- a/src/components/TaskClusterMap/TaskClusterMap.test.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.test.js
@@ -1,0 +1,46 @@
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { TaskClusterMap, labelOverlappingMarkers } from "./TaskClusterMap";
+
+describe("TaskClusterMap", () => {
+  it("renders TaskClusterMap UI", () => {
+    const { getByText } = global.withProvider(
+      <TaskClusterMap
+        getUserAppSetting={() => null}
+        taskMarkers={[]}
+      />
+    );
+    const text = getByText("Leaflet");
+    expect(text).toBeInTheDocument();
+  });
+
+  it("provides an overlapping count value to markers", () => {
+    const markers = labelOverlappingMarkers([{
+      position: [
+        "123",
+        "456"
+      ]
+    }]);
+
+    expect(markers[0].overlappingCount).toBe(1);
+  });
+
+  it("gives overlapping count of 2 for markers with same position", () => {
+    const markers = labelOverlappingMarkers([
+      {
+        position: [
+          "123",
+          "456"
+        ]
+      }, {
+        position: [
+          "123",
+          "456"
+        ]
+      }
+    ]);
+
+    expect(markers[0].overlappingCount).toBe(2);
+  });
+});


### PR DESCRIPTION
This feature gives distinction to a coordinate with overlapping markers, meaning markers that are in the exact same position no matter how much you zoom in.  The marker is bigger, and provides a tooltip for the number of nodes it represents.  It still allows you to click it and show the nodes in a spidered fashion