### PR TITLE
cancel debounce on map move

### DIFF
--- a/src/components/EnhancedMap/EnhancedMap.js
+++ b/src/components/EnhancedMap/EnhancedMap.js
@@ -18,6 +18,7 @@ import _filter from 'lodash/filter'
 import _reduce from 'lodash/reduce'
 import _find from 'lodash/find'
 import _size from 'lodash/size'
+import _noop from  'lodash/noop'
 import AsIdentifiableFeature
        from '../../interactions/TaskFeature/AsIdentifiableFeature'
 import messages from './Messages'
@@ -228,6 +229,7 @@ export class EnhancedMap extends ReactLeafletMap {
     if (this.props.onBoundsChange) {
       this.leafletElement.on('zoomend', this.onZoomOrMoveEnd)
       this.leafletElement.on('moveend', this.onZoomOrMoveEnd)
+      this.leafletElement.on('movestart', this.props.onZoomOrMoveStart)
 
       // Unless requested otherwise, invoke onBoundsChange for the initial
       // bounding box.
@@ -407,6 +409,7 @@ export class EnhancedMap extends ReactLeafletMap {
       this.leafletElement.stop()
       this.leafletElement.off('zoomend', this.onZoomOrMoveEnd)
       this.leafletElement.off('moveend', this.onZoomOrMoveEnd)
+      this.leafletElement.off('movestart', this.props.onZoomOrMoveStart)
     }
     catch(e) {} // Bad custom basemaps can cause problems when stopping Leaflet
 
@@ -431,6 +434,8 @@ EnhancedMap.propTypes = {
   fitBoundsOnlyAsNecessary: PropTypes.bool,
   /** If true, features will be animated when initially added to the map */
   animateFeatures: PropTypes.bool,
+  /** If given, will invoke a method when map is being moved */
+  onZoomOrMoveStart: PropTypes.func,
 }
 
 EnhancedMap.defaultProps = {
@@ -439,6 +444,7 @@ EnhancedMap.defaultProps = {
   setInitialBounds: true,
   justFitFeatures: false,
   animateFeatures: false,
+  onZoomOrMoveStart: _noop,
 }
 
 export default EnhancedMap

--- a/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.js
+++ b/src/components/HOCs/WithChallengeTaskClusters/WithChallengeTaskClusters.js
@@ -154,7 +154,7 @@ export const WithChallengeTaskClusters = function(WrappedComponent, storeTasks=f
     }
 
     debouncedFetchClusters =
-      _debounce((showAsClusters) => this.fetchUpdatedClusters(showAsClusters), 400)
+      _debounce((showAsClusters) => this.fetchUpdatedClusters(showAsClusters), 800)
 
     componentDidUpdate(prevProps) {
       if (!_isEqual(_get(prevProps.criteria, 'searchQuery'), _get(this.props.criteria, 'searchQuery'))) {

--- a/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
+++ b/src/components/HOCs/WithFilterCriteria/WithFilterCriteria.js
@@ -183,7 +183,7 @@ export const WithFilterCriteria = function(WrappedComponent, ignoreURL = true,
                                         false, ignoreLocked).then(() => {
           this.setState({loading: false})
        })
-     }, 400)
+     }, 800)
 
      updateCriteriaFromURL(props) {
        const criteria =

--- a/src/components/TaskClusterMap/TaskClusterMap.js
+++ b/src/components/TaskClusterMap/TaskClusterMap.js
@@ -284,7 +284,7 @@ export class TaskClusterMap extends Component {
 
   closeSearch = () => this.setState({searchOpen: false})
 
-  debouncedUpdateBounds = _debounce(this.props.updateBounds, 400)
+  debouncedUpdateBounds = _debounce(this.props.updateBounds, 800)
 
   spiderIfNeeded = (marker, allMarkers) => {
     if (this.state.spidered.has(marker.options.taskId)) {
@@ -710,6 +710,7 @@ export class TaskClusterMap extends Component {
         onBoundsChange={this.updateBounds}
         justFitFeatures
         onClick={() => this.unspider()}
+        onZoomOrMoveStart={this.debouncedUpdateBounds.cancel}
       >
         <ZoomControl className="mr-z-10" position='topright' />
         {this.props.showFitWorld && <FitWorldControl />}


### PR DESCRIPTION
interrupt any task refresh if the user is moving the map again.  should alleviate some of the instances of https://github.com/osmlab/maproulette3/issues/1659.