### PR TITLE
add dynamic page titles based on url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 MapRoulette is the best known and most widely used microtasking platform for [OpenStreetMap](https://osm.org/). The live website is at [maproulette.org](https://maproulette.org). 
 
+Help build a sustainable MapRoulette by [donating](https://liberapay.com/MapRoulette/donate) as little as USD 1. <img src="https://img.shields.io/liberapay/receives/MapRoulette.svg?logo=liberapay">
+
 ## Using MapRoulette
 
 If you're looking to improve OSM using MapRoulette, you can get started at [maproulette.org](https://maproulette.org) right away. You can log in to MapRoulette with your existing OSM account. If you don't have an OSM account, you probably want to learn the basics of mapping with OSM first. The best way to do this is to [create your very own OSM account](https://www.openstreetmap.org/user/new), move the map to your home town, and click "Edit" on the OSM web site. The OSM web editor has a built in walk-though that teaches you the basics. Once you have mastered basic OSM editing, you can use your new OSM account to log on to MapRoulette and start finding some easy tasks!

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-dropzone": "^11.0.1",
     "react-elastic-carousel": "^0.9.0",
     "react-grid-layout": "^0.18.3",
+    "react-helmet": "^6.1.0",
     "react-intl": "^4.6.9",
     "react-intl-formatted-duration": "^4.0.0",
     "react-leaflet": "^2.7.0",

--- a/src/App.js
+++ b/src/App.js
@@ -34,6 +34,7 @@ import LoadRandomChallengeTask
        from './components/LoadRandomChallengeTask/LoadRandomChallengeTask'
 import LoadRandomVirtualChallengeTask
        from './components/LoadRandomVirtualChallengeTask/LoadRandomVirtualChallengeTask'
+import HeadTitle from './components/Head/Head'
 import Navbar from './components/Navbar/Navbar'
 import SystemNotices from './components/SystemNotices/SystemNotices'
 import Footer from './components/Footer/Footer'
@@ -143,12 +144,20 @@ export class App extends Component {
 /**
  * Simple wrapper for Route that clears the request cache prior to rendering.
  */
-export const CachedRoute=({component: Component, ...rest}) => (
-  <Route {...rest}
-         render={props => {
-           resetCache()
-           return <Component {...props} />
-         }} />
-)
+export const CachedRoute = ({ component: Component, ...rest }) => {
+  return (
+    <Route {...rest}
+      render={props => {
+        resetCache()
+        return (
+          <>
+            <HeadTitle />
+            <Component {...props} />
+          </>
+
+        )
+      }} />
+  )
+}
 
 export default withRouter(App)

--- a/src/components/AdminPane/AdminPane.js
+++ b/src/components/AdminPane/AdminPane.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Switch, withRouter } from "react-router-dom";
+import { Switch, Route, withRouter } from "react-router-dom";
 import MediaQuery from "react-responsive";
 import AsManager from "../../interactions/User/AsManager";
 import SignIn from "../../pages/SignIn/SignIn";
@@ -18,7 +18,7 @@ import ProjectDashboard from "./Manage/ProjectDashboard/ProjectDashboard";
 import ChallengeDashboard from "./Manage/ChallengeDashboard/ChallengeDashboard";
 import BusySpinner from "../BusySpinner/BusySpinner";
 import EmailRequirementNotice from "./Manage/EmailRequirementNotice/EmailRequirementNotice";
-import { CachedRoute } from "../../App";
+import HeadTitle from "../Head/Head";
 import "./Manage/Widgets/widget_registry.js";
 import "./AdminPane.scss";
 
@@ -59,17 +59,17 @@ export class AdminPane extends Component {
         <div className="admin mr-bg-gradient-r-green-dark-blue mr-text-white">
           <div className="admin-pane">
             <Switch>
-              <CachedRoute
+              <CustomRoute
                 exact
                 path="/admin/project/:projectId/challenge/:challengeId"
                 component={ChallengeDashboard}
               />
-              <CachedRoute
+              <CustomRoute
                 exact
                 path={["/admin/projects/new", "/admin/project/:projectId/edit"]}
                 component={EditProject}
               />
-              <CachedRoute
+              <CustomRoute
                 exact
                 path={[
                   "/admin/project/:projectId/challenges/new",
@@ -78,37 +78,37 @@ export class AdminPane extends Component {
                 ]}
                 component={EditChallenge}
               />
-              <CachedRoute
+              <CustomRoute
                 exact
                 path="/admin/project/:projectId/challenges/edit"
                 component={EditChallenges}
               />
-              <CachedRoute
+              <CustomRoute
                 exact
                 path="/admin/project/:projectId/challenge/:challengeId/task/:taskId/edit"
                 component={EditTask}
               />
-              <CachedRoute
+              <CustomRoute
                 exact
                 path="/admin/project/:projectId/challenge/:challengeId/task/:taskId/inspect"
                 component={InspectTask}
               />
-              <CachedRoute
+              <CustomRoute
                 exact
                 path="/admin/virtual/project/:projectId/challenges/manage"
                 component={ManageChallengeList}
               />
-              <CachedRoute
+              <CustomRoute
                 exact
                 path="/admin/projects"
                 component={ProjectsDashboard}
               />
-              <CachedRoute
+              <CustomRoute
                 exact
                 path="/admin/project/:projectId"
                 component={ProjectDashboard}
               />
-              <CachedRoute component={ProjectsDashboard} />
+              <CustomRoute component={ProjectsDashboard} />
             </Switch>
           </div>
         </div>
@@ -124,5 +124,20 @@ AdminPane.propTypes = {
   /** router location */
   location: PropTypes.object.isRequired,
 };
+
+export const CustomRoute = ({ component: Component, ...rest }) => {
+  return (
+    <Route {...rest}
+      render={props => {
+        return (
+          <>
+            <HeadTitle />
+            <Component {...props} />
+          </>
+
+        )
+      }} />
+  )
+}
 
 export default WithStatus(WithCurrentUser(withRouter(AdminPane)));

--- a/src/components/AdminPane/AdminPane.js
+++ b/src/components/AdminPane/AdminPane.js
@@ -18,6 +18,7 @@ import ProjectDashboard from "./Manage/ProjectDashboard/ProjectDashboard";
 import ChallengeDashboard from "./Manage/ChallengeDashboard/ChallengeDashboard";
 import BusySpinner from "../BusySpinner/BusySpinner";
 import EmailRequirementNotice from "./Manage/EmailRequirementNotice/EmailRequirementNotice";
+import { CachedRoute } from "../../App";
 import "./Manage/Widgets/widget_registry.js";
 import "./AdminPane.scss";
 
@@ -58,17 +59,17 @@ export class AdminPane extends Component {
         <div className="admin mr-bg-gradient-r-green-dark-blue mr-text-white">
           <div className="admin-pane">
             <Switch>
-              <Route
+              <CachedRoute
                 exact
                 path="/admin/project/:projectId/challenge/:challengeId"
                 component={ChallengeDashboard}
               />
-              <Route
+              <CachedRoute
                 exact
                 path={["/admin/projects/new", "/admin/project/:projectId/edit"]}
                 component={EditProject}
               />
-              <Route
+              <CachedRoute
                 exact
                 path={[
                   "/admin/project/:projectId/challenges/new",
@@ -77,37 +78,37 @@ export class AdminPane extends Component {
                 ]}
                 component={EditChallenge}
               />
-              <Route
+              <CachedRoute
                 exact
                 path="/admin/project/:projectId/challenges/edit"
                 component={EditChallenges}
               />
-              <Route
+              <CachedRoute
                 exact
                 path="/admin/project/:projectId/challenge/:challengeId/task/:taskId/edit"
                 component={EditTask}
               />
-              <Route
+              <CachedRoute
                 exact
                 path="/admin/project/:projectId/challenge/:challengeId/task/:taskId/inspect"
                 component={InspectTask}
               />
-              <Route
+              <CachedRoute
                 exact
                 path="/admin/virtual/project/:projectId/challenges/manage"
                 component={ManageChallengeList}
               />
-              <Route
+              <CachedRoute
                 exact
                 path="/admin/projects"
                 component={ProjectsDashboard}
               />
-              <Route
+              <CachedRoute
                 exact
                 path="/admin/project/:projectId"
                 component={ProjectDashboard}
               />
-              <Route component={ProjectsDashboard} />
+              <CachedRoute component={ProjectsDashboard} />
             </Switch>
           </div>
         </div>

--- a/src/components/AdminPane/AdminPane.js
+++ b/src/components/AdminPane/AdminPane.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Switch, Route, withRouter } from "react-router-dom";
+import { Switch, withRouter } from "react-router-dom";
 import MediaQuery from "react-responsive";
 import AsManager from "../../interactions/User/AsManager";
 import SignIn from "../../pages/SignIn/SignIn";

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -9,9 +9,9 @@ import { injectIntl } from 'react-intl';
 import _get from 'lodash/get'
 import _isEmpty from 'lodash/isEmpty'
 
-export const HeadTitle = (props) => {
+const REACT_APP_TITLE = 'MapRoulette'
 
-  const REACT_APP_TITLE = 'MapRoulette'
+export const HeadTitle = (props) => {
 
   useEffect(() => {
     pathToTitleFormat(props.match.path)

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -10,23 +10,24 @@ import _get from 'lodash/get'
 import _isEmpty from 'lodash/isEmpty'
 
 const HeadTitle = (props) => {
-
-  const [title, setTitle] = useState(process.env.REACT_APP_TITLE)
+  
+  const REACT_APP_TITLE = 'MapRoulette'
+  const [title, setTitle] = useState(REACT_APP_TITLE)
 
   useEffect(() => {
     getPath(props.match.path)
   }, [props.location.pathname, props.project, props.challenge, props.user])
 
   const findCurrentChallengeName = () => {
-    return props.challenge && props.challenge.name
+    return props.challenge?.name
   }
 
   const findCurrentProjectName = () => {
-    return props.project && props.project.displayName
+    return props.project?.displayName
   }
 
   const findCurrentUserName = () => {
-    return props.user && props.user.osmProfile.displayName
+    return props.user?.osmProfile.displayName
   }
 
   const findCurrentCountryCode = () => {
@@ -71,10 +72,10 @@ const HeadTitle = (props) => {
         return params
       }
     })
-    let newTitle = _isEmpty(pathArr) ? process.env.REACT_APP_TITLE : process.env.REACT_APP_TITLE + '-' + pathArr.join('-')
+    let newTitle = _isEmpty(pathArr) ? REACT_APP_TITLE : REACT_APP_TITLE + '-' + pathArr.join('-')
     setTitle(newTitle)
   }
-  console.log(props)
+ 
   return (
     <>
       <Helmet>

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -3,8 +3,6 @@ import { useState, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { withRouter } from 'react-router';
 import WithCurrentUser from '../HOCs/WithCurrentUser/WithCurrentUser';
-import WithCurrentProject from '../AdminPane/HOCs/WithCurrentProject/WithCurrentProject';
-import WithProjects from '../HOCs/WithProjects/WithProjects'
 import WithProject from '../HOCs/WithProject/WithProject'
 import WithChallenges from '../HOCs/WithChallenges/WithChallenges';
 import WithChallenge from '../HOCs/WithChallenge/WithChallenge';
@@ -74,9 +72,9 @@ const HeadTitle = (props) => {
   )
 }
 
-export default withRouter(WithCurrentUser(WithCurrentProject(WithProjects(WithProject(
+export default withRouter(WithCurrentUser(WithProject(
   WithChallenges(
     WithChallenge(
       WithBrowsedChallenge(injectIntl(HeadTitle))
     )
-  ))))))
+  ))))

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -14,7 +14,7 @@ export const HeadTitle = (props) => {
   const REACT_APP_TITLE = 'MapRoulette'
 
   useEffect(() => {
-    getPath(props.match.path)
+    pathToTitleFormat(props.match.path)
   }, [props.location.pathname, props.project, props.challenge, props.user])
 
   const findCurrentChallengeName = () => {
@@ -39,10 +39,6 @@ export const HeadTitle = (props) => {
 
   const findReviewType = () => {
     return _get(props, 'match.params.showType')
-  }
-
-  const getPath = (path) => {
-    return pathToTitleFormat(path)
   }
 
   /* parse names from url path into array, replace id params with names, and then concatenate with - for title */
@@ -76,11 +72,9 @@ export const HeadTitle = (props) => {
   }
 
   return (
-    <>
-      <Helmet>
-        <title>{getPath(props.match.path)}</title>
-      </Helmet>
-    </>
+    <Helmet>
+      <title>{pathToTitleFormat(props.match.path)}</title>
+    </Helmet>
   )
 }
 

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -3,10 +3,8 @@ import { useState, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { withRouter } from 'react-router';
 import WithCurrentUser from '../HOCs/WithCurrentUser/WithCurrentUser';
-import WithProject from '../HOCs/WithProject/WithProject'
-import WithChallenges from '../HOCs/WithChallenges/WithChallenges';
-import WithChallenge from '../HOCs/WithChallenge/WithChallenge';
-import WithBrowsedChallenge from '../HOCs/WithBrowsedChallenge/WithBrowsedChallenge';
+import WithCurrentProject from '../AdminPane/HOCs/WithCurrentProject/WithCurrentProject';
+import WithCurrentChallenge from '../AdminPane/HOCs/WithCurrentChallenge/WithCurrentChallenge';
 import { injectIntl } from 'react-intl';
 import _get from 'lodash/get'
 import _isEmpty from 'lodash/isEmpty'
@@ -17,10 +15,10 @@ const HeadTitle = (props) => {
 
   useEffect(() => {
     getPath(props.match.path)
-  }, [props.location.pathname, props.project, props.browsedChallenge])
+  }, [props.location.pathname, props.project, props.challenge, props.user])
 
   const findCurrentChallengeName = () => {
-    return props.browsedChallenge && props.browsedChallenge.name
+    return props.challenge && props.challenge.name
   }
 
   const findCurrentProjectName = () => {
@@ -28,11 +26,19 @@ const HeadTitle = (props) => {
   }
 
   const findCurrentUserName = () => {
-    return props.osmProfile && props.osmProfile.displayName
+    return props.user && props.user.osmProfile.displayName
   }
 
   const findCurrentCountryCode = () => {
     return _get(props, 'match.params.countryCode')
+  }
+
+  const findCurrentTaskId = () => {
+    return _get(props, 'match.params.taskId')
+  }
+
+  const findReviewType = () => {
+    return _get(props, 'match.params.showType')
   }
 
   const getPath = (path) => {
@@ -55,6 +61,12 @@ const HeadTitle = (props) => {
       else if (params === ':userId') {
         return findCurrentUserName()
       }
+      else if (params === ':taskId') {
+        return findCurrentTaskId()
+      }
+      else if (params === ':showType') {
+        return findReviewType()
+      }
       else {
         return params
       }
@@ -62,7 +74,7 @@ const HeadTitle = (props) => {
     let newTitle = _isEmpty(pathArr) ? process.env.REACT_APP_TITLE : process.env.REACT_APP_TITLE + '-' + pathArr.join('-')
     setTitle(newTitle)
   }
-
+  console.log(props)
   return (
     <>
       <Helmet>
@@ -72,9 +84,8 @@ const HeadTitle = (props) => {
   )
 }
 
-export default withRouter(WithCurrentUser(WithProject(
-  WithChallenges(
-    WithChallenge(
-      WithBrowsedChallenge(injectIntl(HeadTitle))
-    )
-  ))))
+export default withRouter(WithCurrentUser(WithCurrentProject(
+  WithCurrentChallenge(
+    injectIntl(HeadTitle)))
+)
+)

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { withRouter } from 'react-router';
 import WithCurrentUser from '../HOCs/WithCurrentUser/WithCurrentUser';
@@ -9,10 +9,9 @@ import { injectIntl } from 'react-intl';
 import _get from 'lodash/get'
 import _isEmpty from 'lodash/isEmpty'
 
-const HeadTitle = (props) => {
-  
+export const HeadTitle = (props) => {
+
   const REACT_APP_TITLE = 'MapRoulette'
-  const [title, setTitle] = useState(REACT_APP_TITLE)
 
   useEffect(() => {
     getPath(props.match.path)
@@ -43,7 +42,7 @@ const HeadTitle = (props) => {
   }
 
   const getPath = (path) => {
-    pathToTitleFormat(path)
+    return pathToTitleFormat(path)
   }
 
   /* parse names from url path into array, replace id params with names, and then concatenate with - for title */
@@ -73,13 +72,13 @@ const HeadTitle = (props) => {
       }
     })
     let newTitle = _isEmpty(pathArr) ? REACT_APP_TITLE : REACT_APP_TITLE + '-' + pathArr.join('-')
-    setTitle(newTitle)
+    return newTitle
   }
- 
+
   return (
     <>
       <Helmet>
-        <title>{title}</title>
+        <title>{getPath(props.match.path)}</title>
       </Helmet>
     </>
   )

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -1,0 +1,82 @@
+import React from 'react'
+import { useState, useEffect } from 'react';
+import { Helmet } from 'react-helmet';
+import { withRouter } from 'react-router';
+import WithCurrentUser from '../HOCs/WithCurrentUser/WithCurrentUser';
+import WithCurrentProject from '../AdminPane/HOCs/WithCurrentProject/WithCurrentProject';
+import WithProjects from '../HOCs/WithProjects/WithProjects'
+import WithProject from '../HOCs/WithProject/WithProject'
+import WithChallenges from '../HOCs/WithChallenges/WithChallenges';
+import WithChallenge from '../HOCs/WithChallenge/WithChallenge';
+import WithBrowsedChallenge from '../HOCs/WithBrowsedChallenge/WithBrowsedChallenge';
+import { injectIntl } from 'react-intl';
+import _get from 'lodash/get'
+import _isEmpty from 'lodash/isEmpty'
+
+const HeadTitle = (props) => {
+
+  const [title, setTitle] = useState(process.env.REACT_APP_TITLE)
+
+  useEffect(() => {
+    getPath(props.match.path)
+  }, [props.location.pathname, props.project, props.browsedChallenge])
+
+  const findCurrentChallengeName = () => {
+    return props.browsedChallenge && props.browsedChallenge.name
+  }
+
+  const findCurrentProjectName = () => {
+    return props.project && props.project.displayName
+  }
+
+  const findCurrentUserName = () => {
+    return props.osmProfile && props.osmProfile.displayName
+  }
+
+  const findCurrentCountryCode = () => {
+    return _get(props, 'match.params.countryCode')
+  }
+
+  const getPath = (path) => {
+    pathToTitleFormat(path)
+  }
+
+  /* parse names from url path into array, replace id params with names, and then concatenate with - for title */
+  const pathToTitleFormat = (path) => {
+    let pathArr = path.split('/').filter(element => element)
+    pathArr = pathArr.map(params => {
+      if (params === ':challengeId') {
+        return findCurrentChallengeName()
+      }
+      else if (params === ':projectId') {
+        return findCurrentProjectName()
+      }
+      else if (params === ':countryCode') {
+        return findCurrentCountryCode()
+      }
+      else if (params === ':userId') {
+        return findCurrentUserName()
+      }
+      else {
+        return params
+      }
+    })
+    let newTitle = _isEmpty(pathArr) ? process.env.REACT_APP_TITLE : process.env.REACT_APP_TITLE + '-' + pathArr.join('-')
+    setTitle(newTitle)
+  }
+
+  return (
+    <>
+      <Helmet>
+        <title>{title}</title>
+      </Helmet>
+    </>
+  )
+}
+
+export default withRouter(WithCurrentUser(WithCurrentProject(WithProjects(WithProject(
+  WithChallenges(
+    WithChallenge(
+      WithBrowsedChallenge(injectIntl(HeadTitle))
+    )
+  ))))))

--- a/src/components/Head/HeadTest.js
+++ b/src/components/Head/HeadTest.js
@@ -1,5 +1,5 @@
-let _get = require('lodash/get');
-let _isEmpty = require('lodash/isEmpty')
+const _get = require('lodash/get');
+const _isEmpty = require('lodash/isEmpty')
 
 /* Unit tests for Head.js, export functions from Head.js and run tests with node HeadTest.js */
 let path = '/'
@@ -63,6 +63,6 @@ const titleTest = () => {
     console.log('title can be generated for path with params!')
   }
 }
-console.log(titleTest())
+titleTest()
 
 module.exports = 'titleTest'

--- a/src/components/Head/HeadTest.js
+++ b/src/components/Head/HeadTest.js
@@ -1,0 +1,68 @@
+let _get = require('lodash/get');
+let _isEmpty = require('lodash/isEmpty')
+
+/* Unit tests for Head.js, export functions from Head.js and run tests with node HeadTest.js */
+let path = '/'
+let props = {
+  challenge: {
+    id: 1,
+    name: 'challenge1'
+  },
+  project: {
+    id: 1,
+    displayName: 'project1'
+  },
+  match: {
+    path: path,
+    params: {
+      'challengeId': 1,
+      'projectId': 1,
+      'taskId': 10,
+      'countryCode': 'AL',
+      'showType': 'tag'
+    },
+  },
+  user: {
+    osmProfile: {
+      displayName: 'user1'
+    }
+  }
+}
+const titleTest = () => {
+
+  const pathWithoutParams = 'browse/challenges'
+  const pathWithParams = 'browse/challenge/:challengeId'
+
+  if (findCurrentChallengeName() === 'challenge1') {
+    console.log('findCurrentChallengeName succeed!')
+  }
+  if (findCurrentProjectName() === 'project1') {
+    console.log('findCurrentProjectName succeed!')
+  }
+  if (findCurrentUserName() === 'user1') {
+    console.log('findCurrentUserName succeed!')
+  }
+  if (findCurrentTaskId() === 10) {
+    console.log('findCurrentTask succeed!')
+  }
+  if (findCurrentCountryCode() === 'AL') {
+    console.log('findCurrentCountryCode succeed!')
+  }
+  if (findReviewType() === 'tag') {
+    console.log('findReviewType succeed!')
+  }
+  if (pathToTitleFormat(props.match.path) === 'MapRoulette') {
+    console.log('title can be generated for homepage!')
+  }
+  props.match.path = pathWithoutParams
+  if (pathToTitleFormat(props.match.path) === 'MapRoulette-browse-challenges') {
+    console.log('title can be generated for path without params!')
+  }
+  props.match.path = pathWithParams
+  if (pathToTitleFormat(props.match.path) === 'MapRoulette-browse-challenge-challenge1') {
+    console.log('title can be generated for path with params!')
+  }
+}
+console.log(titleTest())
+
+module.exports = 'titleTest'

--- a/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskNextControl/TaskNextControl.js
+++ b/src/components/TaskPane/ActiveTaskDetails/ActiveTaskControls/TaskNextControl/TaskNextControl.js
@@ -93,24 +93,26 @@ export default class TaskNextControl extends Component {
                 <input
                   type="radio"
                   name="randomnessPreference"
+                  id="randomnessPreference-random"
                   className="mr-radio mr-mr-1"
                   checked={this.props.loadBy === TaskLoadMethod.random}
                   onClick={() => this.props.chooseLoadBy(TaskLoadMethod.random)}
                   onChange={_noop}
                 />
-                <label className="mr-ml-1 mr-mr-4">
+                <label className="mr-ml-1 mr-mr-4" htmlFor="randomnessPreference-random">
                   <FormattedMessage {...messagesByLoadMethod[TaskLoadMethod.random]} />
                 </label>
 
                 <input
                   type="radio"
                   name="randomnessPreference"
+                  id="randomnessPreference-proximity"
                   className="mr-radio mr-mr-1"
                   checked={this.props.loadBy === TaskLoadMethod.proximity}
                   onClick={() => this.props.chooseLoadBy(TaskLoadMethod.proximity)}
                   onChange={_noop}
                 />
-                <label className="mr-ml-1">
+                <label className="mr-ml-1" htmlFor="randomnessPreference-proximity">
                   <FormattedMessage {...messagesByLoadMethod[TaskLoadMethod.proximity]} />
                 </label>
               </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11769,7 +11769,7 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
-react-fast-compare@^3.0.1:
+react-fast-compare@^3.0.1, react-fast-compare@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
@@ -11783,6 +11783,16 @@ react-grid-layout@^0.18.3:
     prop-types "^15.0.0"
     react-draggable "^4.0.0"
     react-resizable "^1.9.0"
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
 
 react-intl-formatted-duration@^4.0.0:
   version "4.0.0"
@@ -12029,6 +12039,11 @@ react-share@^4.2.0:
   dependencies:
     classnames "^2.2.5"
     jsonp "^0.2.1"
+
+react-side-effect@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.2.tgz#dc6345b9e8f9906dc2eeb68700b615e0b4fe752a"
+  integrity sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==
 
 react-swipeable@^5.5.1:
   version "5.5.1"


### PR DESCRIPTION
fixes #1807 


Details:
 - react-helmet is used for head tag management as suggested.
 - Following the comment,  page title is generated based on url path, challenge/project/country code ids are swapped with names.