### PR TITLE
add missing override for nonManagers

### DIFF
--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -73,4 +73,4 @@ export const HeadTitle = (props) => {
   )
 }
 
-export default withRouter(WithCurrentUser(WithCurrentProject(WithCurrentChallenge(injectIntl(HeadTitle)))))
+export default withRouter(WithCurrentUser(WithCurrentProject(WithCurrentChallenge(injectIntl(HeadTitle)), { allowNonManagers: true })))


### PR DESCRIPTION
add omitted override for Head component.  should have been included in https://github.com/osmlab/maproulette3/pull/1842