### PR TITLE
fix super admin metrics override

### DIFF
--- a/src/services/Challenge/Challenge.js
+++ b/src/services/Challenge/Challenge.js
@@ -345,8 +345,7 @@ export const fetchProjectChallengeListing = function (
  */
 export const performChallengeSearch = function (
   searchObject,
-  limit = RESULTS_PER_PAGE,
-  admin
+  limit = RESULTS_PER_PAGE
 ) {
   const sortCriteria = _get(searchObject, "sort", {});
   const archived = _get(searchObject, "archived", false);
@@ -354,6 +353,7 @@ export const performChallengeSearch = function (
   const queryString = _get(searchObject, "query");
   const page = _get(searchObject, "page.currentPage");
   const onlyEnabled = _get(searchObject, "onlyEnabled", true);
+  const admin = _get(searchObject, "admin", false);
   let bounds = null;
 
   if (filters && !_isUndefined(filters.location)) {

--- a/src/services/SuperAdmin/SuperAdminChallenges.js
+++ b/src/services/SuperAdmin/SuperAdminChallenges.js
@@ -23,7 +23,7 @@ export const receiveAdminChallenges = function (
 export const fetchAdminChallenges = function(query) {
   return function(dispatch) {
     return (
-      dispatch(performChallengeSearch(query, 50000, true)).then(normalizedResults => {
+      dispatch(performChallengeSearch({ ...query, admin: true }, 50000)).then(normalizedResults => {
         return dispatch(receiveAdminChallenges(normalizedResults.entities, dispatch))
       })
     )


### PR DESCRIPTION
This fixes a regression with the admin override in extendedFind service.  Other props were getting passed in via the admin argument in some scenarios, so it's been moved to the searchObject in the first argument.  This was causing some results in the discoverability page to not be passed into redux.

Resolves https://github.com/osmlab/maproulette3/issues/1866