### PR TITLE
Admin metrics(project, date filter, feature updates for challenge)

### DIFF
--- a/src/components/ChallengePane/ChallengePane.js
+++ b/src/components/ChallengePane/ChallengePane.js
@@ -104,6 +104,10 @@ export class ChallengePane extends Component {
   }
 
   resetSelectedClusters = () => this.setState({selectedClusters: []})
+  componentDidMount() {
+    this.props.clearSearch()
+    this.props.clearSearchFilters()
+  }
 
   componentDidUpdate() {
     if (!_isEqual(this.state.bounds, _get(this.props, 'mapBounds.bounds'))) {

--- a/src/components/ChallengePane/ChallengePane.js
+++ b/src/components/ChallengePane/ChallengePane.js
@@ -104,9 +104,11 @@ export class ChallengePane extends Component {
   }
 
   resetSelectedClusters = () => this.setState({selectedClusters: []})
+
   componentDidMount() {
     this.props.clearSearch()
     this.props.clearSearchFilters()
+    this.props.setSearchSort({sortBy: 'default'})
   }
 
   componentDidUpdate() {

--- a/src/components/ChallengePane/ChallengePane.test.js
+++ b/src/components/ChallengePane/ChallengePane.test.js
@@ -9,6 +9,7 @@ describe("ChallengePane", () => {
         setSearchFilters={() => null}
         clearSearchFilters={() => null}
         clearSearch={() => null}
+        setSearchSort={() => null}
         history={{ location: { pathname: "", search: "" } }}
       />
     );

--- a/src/components/ChallengePane/ChallengePane.test.js
+++ b/src/components/ChallengePane/ChallengePane.test.js
@@ -7,6 +7,8 @@ describe("ChallengePane", () => {
     const { getByText } = global.withProvider(
       <ChallengePane
         setSearchFilters={() => null}
+        clearSearchFilters={() => null}
+        clearSearch={() => null}
         history={{ location: { pathname: "", search: "" } }}
       />
     );

--- a/src/components/HOCs/WithSearch/WithSearch.js
+++ b/src/components/HOCs/WithSearch/WithSearch.js
@@ -147,7 +147,6 @@ export const mapDispatchToProps = (dispatch, ownProps, searchGroup) => ({
   setSearchSort: (sortCriteria) => {
     const sortBy = _get(sortCriteria, 'sortBy')
     let sort = null
-    console.log(sortBy)
     switch(sortBy) {
       case SORT_NAME:
         sort = {sortBy, direction: 'asc'}
@@ -177,7 +176,6 @@ export const mapDispatchToProps = (dispatch, ownProps, searchGroup) => ({
         sort = {sortBy: null, direction: null}
         break
     }
-    console.log(sort)
     dispatch(setSort(searchGroup, sort))
   },
 

--- a/src/components/HOCs/WithSearch/WithSearch.js
+++ b/src/components/HOCs/WithSearch/WithSearch.js
@@ -7,13 +7,13 @@ import _isFunction from 'lodash/isFunction'
 import _isEmpty from 'lodash/isEmpty'
 import _isEqual from 'lodash/isEqual'
 import _includes from 'lodash/includes'
-import { SORT_NAME, SORT_CREATED, SORT_OLDEST, SORT_POPULARITY, SORT_COOPERATIVE_WORK, SORT_COMPLETION, SORT_TASKS_REMAINING,
+import { SORT_NAME, SORT_CREATED, SORT_OLDEST, SORT_POPULARITY, SORT_COOPERATIVE_WORK, SORT_COMPLETION, SORT_TASKS_REMAINING, SORT_NUM_OF_CHALLENGES,
          setSort, removeSort, setPage,
          setFilters, removeFilters, clearFilters,
          setSearch, clearSearch,
          setChallengeSearchMapBounds,
          setTaskMapBounds, setChallengeOwnerMapBounds, clearMapBounds,
-         performSearch }
+         performSearch}
        from '../../../services/Search/Search'
 import { addError } from '../../../services/Error/Error'
 import { toLatLngBounds, DEFAULT_MAP_BOUNDS }
@@ -147,7 +147,7 @@ export const mapDispatchToProps = (dispatch, ownProps, searchGroup) => ({
   setSearchSort: (sortCriteria) => {
     const sortBy = _get(sortCriteria, 'sortBy')
     let sort = null
-
+    console.log(sortBy)
     switch(sortBy) {
       case SORT_NAME:
         sort = {sortBy, direction: 'asc'}
@@ -170,11 +170,14 @@ export const mapDispatchToProps = (dispatch, ownProps, searchGroup) => ({
       case SORT_COOPERATIVE_WORK:
         sort = {sortBy, direction: 'desc'}
         break
+      case SORT_NUM_OF_CHALLENGES:
+        sort = {sortBy, direction: 'desc'}
+        break
       default:
         sort = {sortBy: null, direction: null}
         break
     }
-
+    console.log(sort)
     dispatch(setSort(searchGroup, sort))
   },
 

--- a/src/components/HOCs/WithSearchResults/WithSearchResults.js
+++ b/src/components/HOCs/WithSearchResults/WithSearchResults.js
@@ -63,7 +63,7 @@ export const WithSearchResults = function(WrappedComponent, searchName,
       let items, searchType
       if(admin){
         const params = queryString.parse(this.props.location.search)
-        searchType = params['searchType']
+        searchType = params['searchType'] || 'challenges'
         items = this.props[searchType]
       }
       else{

--- a/src/components/SuperAdmin/Messages.js
+++ b/src/components/SuperAdmin/Messages.js
@@ -7,9 +7,9 @@ export default defineMessages({
     id: 'Metrics.header',
     defaultMessage: 'Metrics',
   },
-  visible: {
+  discoverable: {
     id: 'Metrics.discoverable',
-    defaultMessage: 'Visible',
+    defaultMessage: 'Discoverable',
   },
   archived: {
     id: 'Metrics.archived',
@@ -18,6 +18,14 @@ export default defineMessages({
   virtual: {
     id: 'Metrics.virtual',
     defaultMessage: 'Virtual',
+  },
+  hideUndiscoverable: {
+    id: 'Metrics.hideUndiscoverable',
+    defaultMessage: 'Hide Undiscoverable'
+  },
+  hideArchived: {
+    id: 'Metrics.hideArchived',
+    defaultMessage: 'Hide Archived'
   },
   download: {
     id: 'Metrics.download',

--- a/src/components/SuperAdmin/Messages.js
+++ b/src/components/SuperAdmin/Messages.js
@@ -28,15 +28,15 @@ export default defineMessages({
     defaultMessage: 'download',
   },
   challengeLabel: {
-    id: 'Metrics.challenge',
-    defaultMessage: 'Challenge',
+    id: 'Metrics.challenges',
+    defaultMessage: 'Challenges',
   },
   projectLabel: {
-    id: 'Metrics.project',
-    defaultMessage: 'Project',
+    id: 'Metrics.projects',
+    defaultMessage: 'Projects',
   },
   userLabel: {
-    id: 'Metrics.user',
-    defaultMessage: 'User',
+    id: 'Metrics.users',
+    defaultMessage: 'Users',
   }
 })

--- a/src/components/SuperAdmin/Messages.js
+++ b/src/components/SuperAdmin/Messages.js
@@ -46,5 +46,9 @@ export default defineMessages({
   userLabel: {
     id: 'Metrics.users',
     defaultMessage: 'Users',
+  },
+  sortByLabel: {
+    id: 'Metrics.sortBy',
+    defaultMessage: 'Sort By'
   }
 })

--- a/src/components/SuperAdmin/Messages.js
+++ b/src/components/SuperAdmin/Messages.js
@@ -31,9 +31,9 @@ export default defineMessages({
     id: 'Metrics.download',
     defaultMessage: 'download',
   },
-  download: {
-    id: 'Metrics.download',
-    defaultMessage: 'download',
+  clear: {
+    id: 'Metrics.clear',
+    defaultMessage: 'clear'
   },
   challengeLabel: {
     id: 'Metrics.challenges',

--- a/src/components/SuperAdmin/MetricsData.js
+++ b/src/components/SuperAdmin/MetricsData.js
@@ -53,7 +53,7 @@ const setChallengeTab = () => {
     {
       id: 'project',
       Header: 'PROJECT',
-      accessor: challenge => challenge.parent,
+      accessor: challenge => challenge.parent.displayName,
       maxWidth: 120,
       sortable: true,
       Cell: props => {
@@ -62,7 +62,6 @@ const setChallengeTab = () => {
             <a href={`/admin/project/${props.value}`}> {props.value} </a>
           )
         }
-
         return null
       }
     },

--- a/src/components/SuperAdmin/MetricsData.js
+++ b/src/components/SuperAdmin/MetricsData.js
@@ -21,7 +21,7 @@ const setChallengeTab = () => {
         if (props.value) {
           return (
             <a href={`/admin/project/${props.original.parent}` +
-            `/challenge/${props.original.id}`}> {props.value} </a>
+            `/challenge/${props.original.id}`} target='_blank'> {props.value} </a>
           )
         }
 
@@ -59,7 +59,7 @@ const setChallengeTab = () => {
       Cell: props => {
         if (props.value) {
           return (
-            <a href={`/admin/project/${props.original?.parent?.id}`}> {props.value} </a>
+            <a href={`/admin/project/${props.original?.parent?.id}` } target='_blank'> {props.value} </a>
           )
         }
         return null
@@ -134,7 +134,7 @@ const setProjectTab = (challenges) => {
       id: 'name',
       Header: 'NAME',
       accessor: project => {
-        return <a href={`/admin/project/${project.id}`}> {project.displayName} </a>
+        return <a href={`/admin/project/${project.id}`} target='_blank'> {project.displayName} </a>
       },
     },
     {

--- a/src/components/SuperAdmin/MetricsData.js
+++ b/src/components/SuperAdmin/MetricsData.js
@@ -20,8 +20,8 @@ const setChallengeTab = () => {
       Cell: props => {
         if (props.value) {
           return (
-            <a href={`/admin/project/${props.original.parent}` +
-            `/challenge/${props.original.id}`} target='_blank'> {props.value} </a>
+            <a href={`/admin/project/${props.original?.parent?.id}` +
+            `/challenge/${props.original.id}`} target='_blank' rel='noopener noreferrer'> {props.value} </a>
           )
         }
 
@@ -59,7 +59,7 @@ const setChallengeTab = () => {
       Cell: props => {
         if (props.value) {
           return (
-            <a href={`/admin/project/${props.original?.parent?.id}` } target='_blank'> {props.value} </a>
+            <a href={`/admin/project/${props.original?.parent?.id}` } target='_blank' rel='noopener noreferrer'> {props.value} </a>
           )
         }
         return null
@@ -134,7 +134,7 @@ const setProjectTab = (challenges) => {
       id: 'name',
       Header: 'NAME',
       accessor: project => {
-        return <a href={`/admin/project/${project.id}`} target='_blank'> {project.displayName} </a>
+        return <a href={`/admin/project/${project.id}`} target='_blank' rel='noopener noreferrer'> {project.displayName} </a>
       },
     },
     {
@@ -204,7 +204,7 @@ const setUserTab = () => {
       id: 'name',
       Header: 'NAME',
       accessor: user => user.osmProfile.displayName,
-      Cell: cell => <a href={OSM_USER_LINK + cell.value} target='_blank' rel='noreferrer' > {cell.value} </a>,
+      Cell: cell => <a href={OSM_USER_LINK + cell.value} target='_blank' rel='noopener noreferrer' > {cell.value} </a>,
       maxWidth: 100,
     },
     {

--- a/src/components/SuperAdmin/MetricsData.js
+++ b/src/components/SuperAdmin/MetricsData.js
@@ -66,10 +66,10 @@ const setChallengeTab = () => {
       }
     },
     {
-      id: 'visible',
-      Header: 'VISIBLE',
+      id: 'discoverable',
+      Header: 'DISCOVERABLE',
       accessor: challenge => challenge.enabled.toString(),
-      maxWidth: 120,
+      maxWidth: 150,
     },
     {
       id: 'archived',
@@ -153,10 +153,10 @@ const setProjectTab = (challenges) => {
       maxWidth: 150,
     },
     {
-      id: 'visible',
-      Header: 'VISIBLE',
+      id: 'discoverable',
+      Header: 'DISCOVERABLE',
       accessor: project => project.enabled.toString(),
-      maxWidth: 120,
+      maxWidth: 150,
     },
     {
       id: 'archived',

--- a/src/components/SuperAdmin/MetricsData.js
+++ b/src/components/SuperAdmin/MetricsData.js
@@ -53,13 +53,13 @@ const setChallengeTab = () => {
     {
       id: 'project',
       Header: 'PROJECT',
-      accessor: challenge => challenge.parent.displayName,
+      accessor: challenge => challenge.parent?.displayName,
       maxWidth: 120,
       sortable: true,
       Cell: props => {
         if (props.value) {
           return (
-            <a href={`/admin/project/${props.value}`}> {props.value} </a>
+            <a href={`/admin/project/${props.original?.parent?.id}`}> {props.value} </a>
           )
         }
         return null

--- a/src/components/SuperAdmin/MetricsHeader.js
+++ b/src/components/SuperAdmin/MetricsHeader.js
@@ -10,10 +10,11 @@ const MetricsHeader = (props) => {
   const handleTabToggle = (val) => {
     props.clearSearchFilters()
     props.clearSearch()
+    const searchQuery = `?tab=${val}&searchType=${val}`
     props.history.push({
       pathname: '/superadmin',
-      search: `?tab=${val}`
-    }) 
+      search: searchQuery
+    })
   }
 
   return (
@@ -29,6 +30,12 @@ const MetricsHeader = (props) => {
               onClick={() => handleTabToggle('challenges')}
             >
               <FormattedMessage {...messages.challengeLabel} />
+            </button>
+            <button
+              className='mr-button mr-button--dark mr-button--small mr-mr-4'
+              onClick={() => handleTabToggle('projects')}
+            >
+              <FormattedMessage {...messages.projectLabel} />
             </button>
           </div>
           {props.currentTab === 'challenges' && <>

--- a/src/components/SuperAdmin/MetricsHeader.js
+++ b/src/components/SuperAdmin/MetricsHeader.js
@@ -6,36 +6,15 @@ import SortChallengesSelector from '../ChallengePane/ChallengeFilterSubnav/SortC
 import FilterByDifficulty from '../ChallengePane/ChallengeFilterSubnav/FilterByDifficulty'
 import FilterByKeyword from '../ChallengePane/ChallengeFilterSubnav/FilterByKeyword'
 import SortProjectsSelector from './SortProjectsSelector'
-import DatePicker from "react-datepicker";
-import { useState } from 'react'
-import SvgSymbol from '../SvgSymbol/SvgSymbol'
 
 const MetricsHeader = (props) => {
-
-  const [startDate, setStartDate] = useState(new Date());
-  const [endDate, setEndDate] = useState(new Date());
-
-  const formatDate = (date) => {
-    const offset = date.getTimezoneOffset()
-    date = new Date(date.getTime() - (offset * 60 * 1000))
-    return date.toISOString().split('T')[0]
-  }
-
-  const handleStartDate = (date) => {
-    setStartDate(date)
-    const formattedDate = formatDate(date)
-    props.toggleStartDate(formattedDate)
-  }
-
-  const handleEndDate = (date) => {
-    setEndDate(date)
-    const formattedDate = formatDate(date)
-    props.toggleEndDate(formattedDate)
-  }
 
   const handleTabToggle = (val) => {
     props.clearSearchFilters()
     props.clearSearch()
+    props.clearDateFilter()
+    props.setStartDate(null)
+    props.setEndDate(null)
     const searchQuery = `?tab=${val}&searchType=${val}`
     props.history.push({
       pathname: '/superadmin',
@@ -73,20 +52,6 @@ const MetricsHeader = (props) => {
           {props.currentTab === 'projects' && <>
             <SortProjectsSelector {...props}/>
           </>}
-          <div>
-            <span className="mr-block mr-text-left mr-mb-1 mr-text-xs mr-uppercase mr-text-white">
-              Date Range
-            </span>
-            <div className='mr-flex mr-items-center'>
-            <DatePicker selected={startDate} onChange={(date) => handleStartDate(date)} maxDate={endDate}/>
-            <SvgSymbol
-              viewBox='0 0 20 20'
-              sym="arrow-right-icon"
-              className="mr-fill-current mr-w-4 mr-h-4 mr-ml-2 mr-mr-2"
-            />
-            <DatePicker selected={endDate} onChange={(date) => handleEndDate(date)} minDate={startDate}/>
-            </div>
-          </div>
           <SearchBox 
             {...props}
             setSearch={props.setSearch}

--- a/src/components/SuperAdmin/MetricsHeader.js
+++ b/src/components/SuperAdmin/MetricsHeader.js
@@ -6,8 +6,33 @@ import SortChallengesSelector from '../ChallengePane/ChallengeFilterSubnav/SortC
 import FilterByDifficulty from '../ChallengePane/ChallengeFilterSubnav/FilterByDifficulty'
 import FilterByKeyword from '../ChallengePane/ChallengeFilterSubnav/FilterByKeyword'
 import SortProjectsSelector from './SortProjectsSelector'
+import DatePicker from "react-datepicker";
+import { useState } from 'react'
+import SvgSymbol from '../SvgSymbol/SvgSymbol'
 
 const MetricsHeader = (props) => {
+
+  const [startDate, setStartDate] = useState(new Date());
+  const [endDate, setEndDate] = useState(new Date());
+
+  const formatDate = (date) => {
+    const offset = date.getTimezoneOffset()
+    date = new Date(date.getTime() - (offset * 60 * 1000))
+    return date.toISOString().split('T')[0]
+  }
+
+  const handleStartDate = (date) => {
+    setStartDate(date)
+    const formattedDate = formatDate(date)
+    props.toggleStartDate(formattedDate)
+  }
+
+  const handleEndDate = (date) => {
+    setEndDate(date)
+    const formattedDate = formatDate(date)
+    props.toggleEndDate(formattedDate)
+  }
+
   const handleTabToggle = (val) => {
     props.clearSearchFilters()
     props.clearSearch()
@@ -48,10 +73,25 @@ const MetricsHeader = (props) => {
           {props.currentTab === 'projects' && <>
             <SortProjectsSelector {...props}/>
           </>}
+          <div>
+            <span className="mr-block mr-text-left mr-mb-1 mr-text-xs mr-uppercase mr-text-white">
+              Date Range
+            </span>
+            <div className='mr-flex mr-items-center'>
+            <DatePicker selected={startDate} onChange={(date) => handleStartDate(date)} maxDate={endDate}/>
+            <SvgSymbol
+              viewBox='0 0 20 20'
+              sym="arrow-right-icon"
+              className="mr-fill-current mr-w-4 mr-h-4 mr-ml-2 mr-mr-2"
+            />
+            <DatePicker selected={endDate} onChange={(date) => handleEndDate(date)} minDate={startDate}/>
+            </div>
+          </div>
           <SearchBox 
             {...props}
             setSearch={props.setSearch}
-          />
+        
+            />
         </div>
       </div>
     </header>

--- a/src/components/SuperAdmin/MetricsHeader.js
+++ b/src/components/SuperAdmin/MetricsHeader.js
@@ -5,6 +5,7 @@ import messages from './Messages'
 import SortChallengesSelector from '../ChallengePane/ChallengeFilterSubnav/SortChallengesSelector'
 import FilterByDifficulty from '../ChallengePane/ChallengeFilterSubnav/FilterByDifficulty'
 import FilterByKeyword from '../ChallengePane/ChallengeFilterSubnav/FilterByKeyword'
+import SortProjectsSelector from './SortProjectsSelector'
 
 const MetricsHeader = (props) => {
   const handleTabToggle = (val) => {
@@ -42,6 +43,9 @@ const MetricsHeader = (props) => {
             <SortChallengesSelector {...props} />
             <FilterByKeyword {...props} />
             <FilterByDifficulty {...props} />
+          </>}
+          {props.currentTab === 'projects' && <>
+            <SortProjectsSelector {...props}/>
           </>}
           <SearchBox 
             {...props}

--- a/src/components/SuperAdmin/MetricsHeader.js
+++ b/src/components/SuperAdmin/MetricsHeader.js
@@ -16,6 +16,7 @@ const MetricsHeader = (props) => {
       pathname: '/superadmin',
       search: searchQuery
     })
+    props.setSearchSort({sortBy: 'default'})
   }
 
   return (
@@ -24,7 +25,7 @@ const MetricsHeader = (props) => {
         <h1 className='mr-hidden xl:mr-flex mr-text-3xl mr-leading-tight mr-font-normal mr-mr-6'>
           <FormattedMessage {...messages.header} />
         </h1>
-        <div className={'mr-flex mr-items-center ' + (props.currentTab !== 'challenges' ? 'mr-py-6' : '')}>
+        <div className={'mr-flex mr-items-center '}>
           <div className='admin__manage__controls mr-flex'>
             <button
               className='mr-button mr-button--dark mr-button--small mr-mr-4'

--- a/src/components/SuperAdmin/MetricsHeader.js
+++ b/src/components/SuperAdmin/MetricsHeader.js
@@ -7,9 +7,13 @@ import FilterByDifficulty from '../ChallengePane/ChallengeFilterSubnav/FilterByD
 import FilterByKeyword from '../ChallengePane/ChallengeFilterSubnav/FilterByKeyword'
 
 const MetricsHeader = (props) => {
-
   const handleTabToggle = (val) => {
-    props.setCurrentTab(val)
+    props.clearSearchFilters()
+    props.clearSearch()
+    props.history.push({
+      pathname: '/superadmin',
+      search: `?tab=${val}`
+    }) 
   }
 
   return (
@@ -18,7 +22,7 @@ const MetricsHeader = (props) => {
         <h1 className='mr-hidden xl:mr-flex mr-text-3xl mr-leading-tight mr-font-normal mr-mr-6'>
           <FormattedMessage {...messages.header} />
         </h1>
-        <div className={'mr-flex mr-items-center ' + (props.currentTab !== 'challenge' ? 'mr-py-6' : '')}>
+        <div className={'mr-flex mr-items-center ' + (props.currentTab !== 'challenges' ? 'mr-py-6' : '')}>
           <div className='admin__manage__controls mr-flex'>
             <button
               className='mr-button mr-button--dark mr-button--small mr-mr-4'

--- a/src/components/SuperAdmin/MetricsTable.js
+++ b/src/components/SuperAdmin/MetricsTable.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import WithSortedChallenges from '../HOCs/WithSortedChallenges/WithSortedChallenges'
 import WithSearchResults from '../HOCs/WithSearchResults/WithSearchResults'
+import WithSortedProjects from './WithSortedProjects'
 import ReactTable from 'react-table-6'
 import { setChallengeTab, setProjectTab } from './MetricsData'
 import { injectIntl } from 'react-intl'
@@ -35,6 +36,6 @@ const MetricsTable = (props) => {
 
 // WithSearchResults for search box
 // WithSortedChallenges for sort by
-export default WithSearchResults(WithSortedChallenges(
+export default WithSearchResults(WithSortedProjects(WithSortedChallenges(
   injectIntl(MetricsTable), 'challenges', null, { frontendSearch: true }
-), 'challenges', 'challenges')
+), 'projects', null), 'challenges', 'challenges')

--- a/src/components/SuperAdmin/MetricsTable.js
+++ b/src/components/SuperAdmin/MetricsTable.js
@@ -1,6 +1,5 @@
 
 import React from 'react'
-import WithPagedChallenges from '../HOCs/WithPagedChallenges/WithPagedChallenges'
 import WithSortedChallenges from '../HOCs/WithSortedChallenges/WithSortedChallenges'
 import WithSearchResults from '../HOCs/WithSearchResults/WithSearchResults'
 import ReactTable from 'react-table-6'

--- a/src/components/SuperAdmin/MetricsTable.js
+++ b/src/components/SuperAdmin/MetricsTable.js
@@ -33,6 +33,9 @@ const MetricsTable = (props) => {
   )
 }
 
+
+// WithSearchResults for search box
+// WithSortedChallenges for sort by
 export default WithSearchResults(WithSortedChallenges(
-  WithPagedChallenges(injectIntl(MetricsTable),'challenges', 'pagedChallenges'), 'challenges', null, { frontendSearch: true }
+  injectIntl(MetricsTable), 'challenges', null, { frontendSearch: true }
 ),'challenges', 'challenges')

--- a/src/components/SuperAdmin/MetricsTable.js
+++ b/src/components/SuperAdmin/MetricsTable.js
@@ -37,4 +37,4 @@ const MetricsTable = (props) => {
 // WithSortedChallenges for sort by
 export default WithSearchResults(WithSortedChallenges(
   injectIntl(MetricsTable), 'challenges', null, { frontendSearch: true }
-),'challenges', 'challenges')
+), 'challenges', 'challenges')

--- a/src/components/SuperAdmin/SortProjectsSelector.js
+++ b/src/components/SuperAdmin/SortProjectsSelector.js
@@ -1,0 +1,72 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { FormattedMessage, injectIntl } from 'react-intl'
+import _map from 'lodash/map'
+import _get from 'lodash/get'
+import { sortLabels, SORT_DEFAULT, PROJECT_SORT_OPTIONS} from '../../services/Search/Search'
+import Dropdown from '../Dropdown/Dropdown'
+import ButtonFilter from '../ChallengePane/ChallengeFilterSubnav/ButtonFilter'
+import messages from './Messages'
+
+/**
+ * SortProjectsSelector renders an unmanaged dropdown button that can be used
+ * to modify the sort order of challenge results.
+ *
+ * @author [Kelli Rotstan](https://github.com/krotstan)
+ */
+export class SortProjectsSelector extends Component {
+  makeSelection = (option, closeDropdownMenu) => {
+    this.props.setSearchSort({sortBy: option})
+    closeDropdownMenu()
+  }
+
+  render() {
+    const localizedLabels = sortLabels(this.props.intl)
+    const currentSortCriteria = _get(this.props, 'searchSort.sortBy')
+        console.log(currentSortCriteria)
+    const activeLabel = currentSortCriteria ? localizedLabels[currentSortCriteria] :
+                        localizedLabels[SORT_DEFAULT]
+    return (
+      <Dropdown
+        className="mr-dropdown--flush xl:mr-border-l xl:mr-border-white-10 mr-p-6 mr-pl-0 xl:mr-pl-6"
+        dropdownButton={dropdown =>
+          <ButtonFilter
+            type={<FormattedMessage {...messages.sortByLabel} />}
+            selection={activeLabel}
+            onClick={dropdown.toggleDropdownVisible}
+          />
+        }
+        dropdownContent={dropdown =>
+          <ListSortItems
+            sortLabels={localizedLabels}
+            makeSelection={this.makeSelection}
+            closeDropdown={dropdown.closeDropdown}
+          />
+        }
+      />
+    )
+  }
+}
+
+const ListSortItems = function(props) {
+  const menuItems = _map(PROJECT_SORT_OPTIONS, sortByOption => (
+    <li key={sortByOption}>
+      <a onClick={() => props.makeSelection(sortByOption, props.closeDropdown)}>
+        {props.sortLabels[sortByOption]}
+      </a>
+    </li>
+  ))
+
+  return (
+    <ol className="mr-list-dropdown mr-list-dropdown--ruled">
+      {menuItems}
+    </ol>
+  )
+}
+
+SortProjectsSelector.propTypes = {
+  /** Invoked to sort the challenges when a value is selected */
+  setSearchSort: PropTypes.func.isRequired,
+}
+
+export default injectIntl(SortProjectsSelector)

--- a/src/components/SuperAdmin/SortProjectsSelector.js
+++ b/src/components/SuperAdmin/SortProjectsSelector.js
@@ -23,7 +23,6 @@ export class SortProjectsSelector extends Component {
   render() {
     const localizedLabels = sortLabels(this.props.intl)
     const currentSortCriteria = _get(this.props, 'searchSort.sortBy')
-        console.log(currentSortCriteria)
     const activeLabel = currentSortCriteria ? localizedLabels[currentSortCriteria] :
                         localizedLabels[SORT_DEFAULT]
     return (

--- a/src/components/SuperAdmin/SuperAdmin.js
+++ b/src/components/SuperAdmin/SuperAdmin.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
-import { useState } from 'react'
 import AsManager from '../../interactions/User/AsManager'
 import SignIn from '../../pages/SignIn/SignIn'
 import MetricsTable from './MetricsTable'
@@ -9,6 +8,8 @@ import BusySpinner from '../BusySpinner/BusySpinner'
 import internalFilterToggle from './internalFilterToggle'
 import MetricsHeader from './MetricsHeader'
 import messages from './Messages'
+import { useEffect } from 'react'
+import queryString from 'query-string'
 /**
  * SuperAdminPane is the top-level component for super administration functions. It has a
  * User/Project/Challenge metrics tab for management of users, projects and challenges, and display of various summary metrics. 
@@ -16,7 +17,13 @@ import messages from './Messages'
  *
  */
 export const SuperAdminPane = (props) => {
-  const [currentTab, setCurrentTab] = useState('challenges')
+  useEffect( () => {
+  props.clearSearch()
+  props.clearSearchFilters()
+  } , [props.match.path])
+
+  const params = queryString.parse(props.location.search)
+  const currentTab = params['tab'] ? params['tab'] : 'challenges'
   //HOC
   const VisibleFilterToggle = internalFilterToggle('challenge', 'visible');
   const ArchivedFilterToggle = internalFilterToggle('challenge', 'archived');
@@ -34,8 +41,8 @@ export const SuperAdminPane = (props) => {
 
   return manager.isSuperUser() ? (
     <div className='mr-bg-gradient-r-green-dark-blue mr-text-white mr-px-6 mr-py-8 mr-cards-inverse'>
-      <MetricsHeader {...props} setCurrentTab={setCurrentTab} currentTab={currentTab} />
-      {currentTab !== 'user' && <div className='mr-flex mr-justify-end mr-p-4 mr-pt-6'>
+      <MetricsHeader {...props} currentTab={currentTab} />
+      {currentTab !== 'users' && <div className='mr-flex mr-justify-end mr-p-4 mr-pt-6'>
         <VisibleFilterToggle
           {...props}
           dashboardEntityFilters={props.entityFilters}
@@ -48,7 +55,7 @@ export const SuperAdminPane = (props) => {
           toggleEntityFilter={props.toggleFilter}
           filterToggleLabel={<FormattedMessage {...messages.archived} />}
         />
-        {currentTab === 'project' && <VirtualProjectFilterToggle
+        {currentTab === 'projects' && <VirtualProjectFilterToggle
           {...props}
           dashboardEntityFilters={props.entityFilters}
           toggleEntityFilter={props.toggleFilter}

--- a/src/components/SuperAdmin/SuperAdmin.js
+++ b/src/components/SuperAdmin/SuperAdmin.js
@@ -47,13 +47,13 @@ export const SuperAdminPane = (props) => {
           {...props}
           dashboardEntityFilters={props.entityFilters}
           toggleEntityFilter={props.toggleFilter}
-          filterToggleLabel={<FormattedMessage {...messages.visible} />}
+          filterToggleLabel={<FormattedMessage {...messages.hideUndiscoverable} />}
         />
         <ArchivedFilterToggle
           {...props}
           dashboardEntityFilters={props.entityFilters}
           toggleEntityFilter={props.toggleFilter}
-          filterToggleLabel={<FormattedMessage {...messages.archived} />}
+          filterToggleLabel={<FormattedMessage {...messages.hideArchived} />}
         />
         {currentTab === 'projects' && <VirtualProjectFilterToggle
           {...props}

--- a/src/components/SuperAdmin/SuperAdmin.js
+++ b/src/components/SuperAdmin/SuperAdmin.js
@@ -10,6 +10,9 @@ import MetricsHeader from './MetricsHeader'
 import messages from './Messages'
 import { useEffect } from 'react'
 import queryString from 'query-string'
+import DatePicker from "react-datepicker";
+import { useState } from 'react'
+import SvgSymbol from '../SvgSymbol/SvgSymbol'
 /**
  * SuperAdminPane is the top-level component for super administration functions. It has a
  * User/Project/Challenge metrics tab for management of users, projects and challenges, and display of various summary metrics. 
@@ -17,7 +20,7 @@ import queryString from 'query-string'
  *
  */
 export const SuperAdminPane = (props) => {
-
+ 
   useEffect(() => {
     if (props.location.search === '') {
       props.clearSearch()
@@ -43,10 +46,61 @@ export const SuperAdminPane = (props) => {
     );
   }
 
+  const [startDate, setStartDate] = useState(null);
+  const [endDate, setEndDate] = useState(null);
+    const formatDate = (date) => {
+    const offset = date.getTimezoneOffset()
+    date = new Date(date.getTime() - (offset * 60 * 1000))
+    return date.toISOString().split('T')[0]
+  }
+
+  const handleStartDate = (date) => {
+    setStartDate(date)
+    const formattedDate = formatDate(date)
+    props.toggleStartDate(formattedDate)
+  }
+
+  const handleEndDate = (date) => {
+    setEndDate(date)
+    const formattedDate = formatDate(date)
+    props.toggleEndDate(formattedDate)
+  }
+
+  const clearDateFilter = () => {
+    props.clearDateFilter()
+    setStartDate(null)
+    setEndDate(null)
+  }
+
   return manager.isSuperUser() ? (
     <div className='mr-bg-gradient-r-green-dark-blue mr-text-white mr-px-6 mr-py-8 mr-cards-inverse'>
-      <MetricsHeader {...props} currentTab={currentTab} />
-      {currentTab !== 'users' && <div className='mr-flex mr-justify-end mr-p-4 mr-pt-6'>
+      <MetricsHeader {...props} currentTab={currentTab} setStartDate={setStartDate} setEndDate={setEndDate}/>
+      {currentTab !== 'users' && <div className='mr-flex mr-justify-between mr-p-4 mr-pt-6'>
+        <div>
+          <div className='mr-flex mr-items-center'>
+            <div className='mr-w-32'>
+              <DatePicker selected={startDate} placeholderText={'Start date'} onChange={(date) => handleStartDate(date)} maxDate={endDate} />
+            </div>
+            <SvgSymbol
+              viewBox='0 0 20 20'
+              sym="arrow-right-icon"
+              className="mr-fill-current mr-w-4 mr-h-4 mr-ml-2 mr-mr-2"
+            />
+            <div className='mr-w-32'>
+              <DatePicker selected={endDate} placeholderText={'End date'} onChange={(date) => handleEndDate(date)} minDate={startDate} />
+            </div>
+            <button
+          color='primary'
+          type='button'
+          className='mr-leading-none mr-button--dark mr-ml-4 mr-mr-1'
+          onClick={() => {
+            clearDateFilter()
+          }}>
+          <FormattedMessage {...messages.clear} />
+        </button>
+          </div>
+        </div>
+        <div className='mr-flex mr-items-center'>
         <VisibleFilterToggle
           {...props}
           dashboardEntityFilters={props.entityFilters}
@@ -74,6 +128,7 @@ export const SuperAdminPane = (props) => {
           }}>
           <FormattedMessage {...messages.download} />
         </button>
+      </div>
       </div>}
       <MetricsTable {...props} currentTab={currentTab}/>
     </div>

--- a/src/components/SuperAdmin/SuperAdmin.js
+++ b/src/components/SuperAdmin/SuperAdmin.js
@@ -20,8 +20,12 @@ export const SuperAdminPane = (props) => {
   useEffect( () => {
   props.clearSearch()
   props.clearSearchFilters()
+  const searchQuery = '?tab=challenges&searchType=challenges'
+  props.history?.push({
+      pathname: '/superadmin',
+      search: searchQuery
+    })  
   } , [props.match.path])
-
   const params = queryString.parse(props.location.search)
   const currentTab = params['tab'] ? params['tab'] : 'challenges'
   //HOC

--- a/src/components/SuperAdmin/SuperAdmin.js
+++ b/src/components/SuperAdmin/SuperAdmin.js
@@ -17,16 +17,15 @@ import queryString from 'query-string'
  *
  */
 export const SuperAdminPane = (props) => {
-console.log(props)
-  useEffect( () => {
-  props.clearSearch()
-  props.clearSearchFilters()
-  const searchQuery = '?tab=challenges&searchType=challenges'
-  props.history?.push({
-      pathname: '/superadmin',
-      search: searchQuery
-    })  
-  } , [props.match.path])
+
+  useEffect(() => {
+    if (props.location.search === '') {
+      props.clearSearch()
+      props.clearSearchFilters()
+      props.setSearchSort({ sortBy: 'default' })
+    }
+  }, [])
+
   const params = queryString.parse(props.location.search)
   const currentTab = params['tab'] ? params['tab'] : 'challenges'
   //HOC

--- a/src/components/SuperAdmin/SuperAdmin.js
+++ b/src/components/SuperAdmin/SuperAdmin.js
@@ -17,6 +17,7 @@ import queryString from 'query-string'
  *
  */
 export const SuperAdminPane = (props) => {
+console.log(props)
   useEffect( () => {
   props.clearSearch()
   props.clearSearchFilters()

--- a/src/components/SuperAdmin/SuperAdmin.test.js
+++ b/src/components/SuperAdmin/SuperAdmin.test.js
@@ -1,11 +1,48 @@
 import '@testing-library/jest-dom'
 import * as React from 'react'
 import { SuperAdminPane } from './SuperAdmin'
+import { fireEvent } from "@testing-library/react";
 
+const props = {
+  user: {
+    id: 1, grants: [{
+      "id": 13,
+      "name": "Super User Override",
+      "grantee": {
+        "granteeType": 5,
+        "granteeId": 1
+      },
+      "role": -1,
+      "target": {
+        "objectType": 0,
+        "objectId": 0
+      }
+    }]
+  },
+  location: {search: '?tab=challenges&searchType=challenges'},
+  history: { push: () => null, location: { search: null } },
+  match: {},
+  clearSearchFilters: () => null,
+  clearSearch: () => null,
+  filterName: { visible: null, archived: null },
+  showingFilter: () => null,
+  setSearch: () => null,
+  clearSearch: () => null,
+  setSearchSort: () => null,
+  setKeywordFilter: () => null,
+  removeSearchFilters: () => null,
+  setSearchFilters: () => null,
+  allUsers: {},
+  dashboardEntityFilters: { visible: null },
+  toggleFilter: () => null,
+  filterToggleLabel: null,
+  projects: [],
+  challenges: [{id: 1, name: 'challenge1', isArchived: true}, {id: 2, name: 'challenge2', isArchived: true}, {id: 3, name: 'challenge3', isArchived: false}]
+}
 describe("SuperAdminPane", () => {
   it("redirects to Sign In if no user data", () => {
     const { getByText } = global.withProvider(
-      <SuperAdminPane location={{}} match={{}} clearSearchFilters={() => null} clearSearch={() => null} dashboardEntityFilters = {{visible: null, archived: null}}/>
+      <SuperAdminPane location={props.location} match={props.match} clearSearchFilters={props.clearSearch} clearSearch={props.clearSearch} dashboardEntityFilters={props.dashboardEntityFilters} />
     );
     const text = getByText("Sign in");
     expect(text).toBeInTheDocument();
@@ -13,40 +50,90 @@ describe("SuperAdminPane", () => {
 
   it("grants super user access to Metrics page", () => {
     const { getByText } = global.withProvider(
-      <SuperAdminPane 
-        user={{ id: 1, grants: [{
-          "id": 13,
-          "name": "Super User Override",
-          "grantee": {
-            "granteeType": 5,
-            "granteeId": 1
-          },
-          "role": -1,
-          "target": {
-            "objectType": 0,
-            "objectId": 0
-          }
-        }] }} 
-        location={{}}
-        match={{}}
-        clearSearchFilters={() => null}
-        clearSearch={() => null}
-        filterName={{visible: null, archived: null}}
-        showingFilter={() => null}
-        setSearch={() => null}
-        clearSearch={() => null}
-        setSearchSort={() => null}
-        setKeywordFilter={() => null}
-        removeSearchFilters={() => null}
-        setSearchFilters={() => null}
-        allUsers={{}}
-        dashboardEntityFilters = {{visible: null}}
-        toggleEntityFilter={() => null} 
-        filterToggleLabel={null}
+      <SuperAdminPane
+        user={props.user}
+        location={props.location}
+        match={props.match}
+        clearSearchFilters={props.clearSearchFilters}
+        clearSearch={props.clearSearch}
+        filterName={props.filterName}
+        showingFilter={props.showingFilter}
+        setSearch={props.setSearch}
+        clearSearch={props.clearSearch}
+        setSearchSort={props.setSearchSort}
+        setKeywordFilter={props.setKeywordFilter}
+        removeSearchFilters={props.removeSearchFilters}
+        setSearchFilters={props.setSearchFilters}
+        allUsers={props.allUsers}
+        dashboardEntityFilters={props.dashboardEntityFilters}
+        toggleFilter={props.toggleFilter}
+        filterToggleLabel={props.filterToggleLabel}
       />
     );
 
     const text = getByText("Metrics");
     expect(text).toBeInTheDocument();
+  });
+
+  it("can switch tab", () => {
+    const clearSearch = jest.fn()
+    const { container } = global.withProvider(
+      <SuperAdminPane
+        user={props.user}
+        location={props.location}
+        match={props.match}
+        clearSearchFilters={props.clearSearchFilters}
+        clearSearch={props.clearSearch}
+        filterName={props.filterName}
+        showingFilter={props.showingFilter}
+        setSearch={props.setSearch}
+        clearSearch={() => clearSearch()}
+        setSearchSort={props.setSearchSort}
+        history={props.history}
+        setKeywordFilter={props.setKeywordFilter}
+        removeSearchFilters={props.removeSearchFilters}
+        setSearchFilters={props.setSearchFilters}
+        allUsers={props.allUsers}
+        dashboardEntityFilters={props.dashboardEntityFilters}
+        toggleFilter={props.toggleFilter}
+        filterToggleLabel={props.filterToggleLabel}
+      />
+    );
+
+    const element = Array.from(container.querySelectorAll('button'))
+      .find(e => e.textContent === 'Projects');
+    fireEvent.click(element);
+    expect(clearSearch).toHaveBeenCalledTimes(2);
+  });
+
+  it("can toggle for challenge table", () => {
+    const toggleFilter = jest.fn()
+    const { container } = global.withProvider(
+      <SuperAdminPane
+        user={props.user}
+        location={props.location}
+        match={props.match}
+        clearSearchFilters={props.clearSearchFilters}
+        clearSearch={props.clearSearch}
+        filterName={props.filterName}
+        showingFilter={props.showingFilter}
+        setSearch={props.setSearch}
+        clearSearch={props.clearSearch}
+        setSearchSort={props.setSearchSort}
+        history={props.history}
+        setKeywordFilter={props.setKeywordFilter}
+        removeSearchFilters={props.removeSearchFilters}
+        setSearchFilters={props.setSearchFilters}
+        allUsers={props.allUsers}
+        entityFilters = {{visible: true, archived: true, virtual: true}}
+        toggleFilter={() => toggleFilter()}
+        filterToggleLabel={props.filterToggleLabel}
+        challenges={props.challenges}
+      />
+    );
+    
+    const element = container.querySelectorAll('input[type=checkbox]')[1]
+    fireEvent.click(element);
+    expect(toggleFilter).toHaveBeenCalledTimes(1)
   });
 });

--- a/src/components/SuperAdmin/SuperAdmin.test.js
+++ b/src/components/SuperAdmin/SuperAdmin.test.js
@@ -1,20 +1,17 @@
 import '@testing-library/jest-dom'
 import * as React from 'react'
 import { SuperAdminPane } from './SuperAdmin'
-import DashboardFilterToggle from '../AdminPane/Manage/DashboardFilterToggle/DashboardFilterToggle'
 
 describe("SuperAdminPane", () => {
   it("redirects to Sign In if no user data", () => {
     const { getByText } = global.withProvider(
-      <SuperAdminPane location={{}}  dashboardEntityFilters = {{visible: null, archived: null}}/>
+      <SuperAdminPane location={{}} match={{}} clearSearchFilters={() => null} clearSearch={() => null} dashboardEntityFilters = {{visible: null, archived: null}}/>
     );
     const text = getByText("Sign in");
     expect(text).toBeInTheDocument();
   });
 
   it("grants super user access to Metrics page", () => {
-    const VisibleFilterToggle = DashboardFilterToggle("challenge", "visible");
-    const archivedFilterToggle = DashboardFilterToggle("challenge", "archived");
     const { getByText } = global.withProvider(
       <SuperAdminPane 
         user={{ id: 1, grants: [{
@@ -31,6 +28,9 @@ describe("SuperAdminPane", () => {
           }
         }] }} 
         location={{}}
+        match={{}}
+        clearSearchFilters={() => null}
+        clearSearch={() => null}
         filterName={{visible: null, archived: null}}
         showingFilter={() => null}
         setSearch={() => null}

--- a/src/components/SuperAdmin/SuperAdmin.test.js
+++ b/src/components/SuperAdmin/SuperAdmin.test.js
@@ -103,7 +103,7 @@ describe("SuperAdminPane", () => {
     const element = Array.from(container.querySelectorAll('button'))
       .find(e => e.textContent === 'Projects');
     fireEvent.click(element);
-    expect(clearSearch).toHaveBeenCalledTimes(2);
+    expect(clearSearch).toHaveBeenCalledTimes(1);
   });
 
   it("can toggle for challenge table", () => {

--- a/src/components/SuperAdmin/SuperAdmin.test.js
+++ b/src/components/SuperAdmin/SuperAdmin.test.js
@@ -35,6 +35,7 @@ const props = {
   allUsers: {},
   dashboardEntityFilters: { visible: null },
   toggleFilter: () => null,
+  clearDateFilter: () => null,
   filterToggleLabel: null,
   projects: [],
   challenges: [{id: 1, name: 'challenge1', isArchived: true}, {id: 2, name: 'challenge2', isArchived: true}, {id: 3, name: 'challenge3', isArchived: false}]
@@ -89,6 +90,7 @@ describe("SuperAdminPane", () => {
         setSearch={props.setSearch}
         clearSearch={() => clearSearch()}
         setSearchSort={props.setSearchSort}
+        clearDateFilter={props.clearDateFilter}
         history={props.history}
         setKeywordFilter={props.setKeywordFilter}
         removeSearchFilters={props.removeSearchFilters}

--- a/src/components/SuperAdmin/SuperAdminContainer.js
+++ b/src/components/SuperAdmin/SuperAdminContainer.js
@@ -10,6 +10,8 @@ import WithFilteredChallenges from '../HOCs/WithFilteredChallenges/WithFilteredC
 import WithMetricsFilter from './WithMetricsFilter'
 import WithExportCsv from './WithExportCsv'
 import { injectIntl } from 'react-intl'
+import { denormalize } from 'normalizr'
+import { challengeSchema } from '../../services/Challenge/Challenge'
 
 const WrappedSuperAdminPane = 
   WithCurrentUser(
@@ -40,8 +42,12 @@ class SuperAdminContainer extends Component {
 }
 
 const mapStateToProps = state => {
+  const adminChallenges = state.entities?.adminChallenges?.data.map(challenge =>
+    denormalize(challenge, challengeSchema(), state.entities)
+  )
+  
   return {
-    adminChallenges: state.entities?.adminChallenges?.data || [],
+    adminChallenges: adminChallenges || [],
     adminProjects: state.entities?.adminProjects?.data || [],
     loadingChallenges: state.entities?.adminChallenges?.loading,
     loadingProjects: state.entities?.adminProjects?.loading

--- a/src/components/SuperAdmin/WithExportCsv.js
+++ b/src/components/SuperAdmin/WithExportCsv.js
@@ -14,7 +14,7 @@ const WithExportCsv = function (WrappedComponent) {
             'OWNER': item.owner,
             'TASKS REMAINING': item.tasksRemaining,
             '% COMPLETED TASKS': item.completionPercentage,
-            'PROJECT': item.parent,
+            'PROJECT': item.parent?.displayName,
             'VISIBLE': item.enabled.toString(),
             'ARCHIVED': item.isArchived.toString(),
             'DATE CREATED': `${created.getMonth() + 1}/${created.getDate()}/${created.getFullYear()}`,

--- a/src/components/SuperAdmin/WithMetricsFilter.js
+++ b/src/components/SuperAdmin/WithMetricsFilter.js
@@ -1,6 +1,10 @@
 import React, { Component } from 'react'
 import queryString from 'query-string'
 
+/**
+ * Deals with superadmin query routes for super admin metrics.
+ * Toggle filter logic here as well.
+ */
 const WithMetricsFilter = function(WrappedComponent) {
   return class extends Component {
     render() {

--- a/src/components/SuperAdmin/WithMetricsFilter.js
+++ b/src/components/SuperAdmin/WithMetricsFilter.js
@@ -9,15 +9,27 @@ const WithMetricsFilter = function(WrappedComponent) {
   return class extends Component {
     render() {
       const params = queryString.parse(this.props.location.search)
-      const tab = params['tab']
+      const tab = params['tab'] 
+      let startYear, startMonth, startDate, endYear, endMonth, endDate
+
+      if(params['from']){
+        [startYear, startMonth, startDate] = params['from'].split('-')
+      }
+      if(params['to']){
+        [endYear, endMonth, endDate] = params['to'].split('-')
+      }
+      console.log(startYear, startMonth, startDate)
       let entityFilters = {
         visible: params['hideUndiscoverable'] === 'true',
         archived: params['hideArchived'] === 'true',
-        virtual: params['virtual'] === 'true'
+        virtual: params['virtual'] === 'true',
+        from : params['from'],
+        to: params['to']
       }
 
       const toggleFilter = (filterName) => {
         entityFilters[filterName] = !entityFilters[filterName]
+        // const newQueries = { ...params, [filterName]: entityFilters[filterName]};
         let searchquery = `?`
         searchquery += `tab=${tab}&`
         searchquery += `hideUndiscoverable=${entityFilters.visible}&`
@@ -28,16 +40,54 @@ const WithMetricsFilter = function(WrappedComponent) {
           search: searchquery
         })  
       }
+
+      const toggleStartDate = (startDate) => {
+        entityFilters.from = startDate
+        console.log('yes', entityFilters)
+        const newQueries = { ...params, from: startDate }
+        this.props.history.push({
+          pathname: '/superadmin',
+          search: queryString.stringify(newQueries)
+        })
+      }
+
+      const toggleEndDate = (endDate) => {
+        entityFilters.to = endDate
+        const newQueries = { ...params, to: endDate }
+        this.props.history.push({
+          pathname: '/superadmin',
+          search: queryString.stringify(newQueries)
+        })
+      }
+
       let challenges = this.props.challenges
       let projects = this.props.projects
+
       if (tab === 'challenges') {
+        console.log('hello', entityFilters)
         challenges = entityFilters.visible ? this.props.challenges.filter(c => c.enabled) : this.props.challenges
         challenges = entityFilters.archived ? challenges.filter(c => !c.isArchived) : challenges
+        challenges = entityFilters.from ? challenges.filter(c => {
+          const date = new Date(c.created)
+          return date.getFullYear() >= startYear && date.getMonth() + 1 >= startMonth && date.getDate() + 1 >= startDate
+        }) : challenges
+        challenges = entityFilters.to ? challenges.filter(c => {
+          const date = new Date(c.created)
+          return date.getFullYear() <= endYear && date.getMonth() + 1 <= endMonth && date.getDate() + 1 <= endDate
+        }) : challenges
       }
       else if (tab === 'projects') {
         projects = entityFilters.visible ? this.props.projects.filter(p => p.enabled) : this.props.projects
         projects = entityFilters.archived ? projects.filter(p => !p.isArchived) : projects
         projects = entityFilters.virtual ? projects.filter(p => p.isVirtual) : projects
+        projects = entityFilters.from ? projects.filter(p => {
+          const date = new Date(p.created)
+          return date.getFullYear() >= startYear && date.getMonth() + 1 >= startMonth && date.getDate() + 1 >= startDate
+        }) : projects
+        projects = entityFilters.to ? projects.filter(p => {
+          const date = new Date(p.created)
+          return date.getFullYear() <= endYear && date.getMonth() + 1 <= endMonth && date.getDate() + 1 <= endDate
+        }) : projects
       }
       return (
         <WrappedComponent {...this.props} 
@@ -45,6 +95,8 @@ const WithMetricsFilter = function(WrappedComponent) {
           projects={projects}
           entityFilters = {entityFilters}
           toggleFilter = {toggleFilter}
+          toggleStartDate = {toggleStartDate}
+          toggleEndDate = {toggleEndDate}
         />
       )
     }

--- a/src/components/SuperAdmin/WithMetricsFilter.js
+++ b/src/components/SuperAdmin/WithMetricsFilter.js
@@ -28,14 +28,19 @@ const WithMetricsFilter = function(WrappedComponent) {
           search: searchquery
         })  
       }
-
-      let challenges = entityFilters.visible ? this.props.challenges.filter(c => c.enabled) : this.props.challenges
-      challenges = entityFilters.archived ? challenges.filter(c => !c.isArchived) : challenges
-
-      let projects = entityFilters.visible? this.props.projects.filter(p => p.enabled): this.props.projects
-      projects = entityFilters.archived? projects.filter(p => !p.isArchived): projects
-      projects = entityFilters.virtual? projects.filter(p => p.isVirtual): projects
-
+      let challenges = this.props.challenges
+      let projects = this.props.projects
+      if (tab === 'challenges') {
+        console.log('here challenges')
+        challenges = entityFilters.visible ? this.props.challenges.filter(c => c.enabled) : this.props.challenges
+        challenges = entityFilters.archived ? challenges.filter(c => !c.isArchived) : challenges
+      }
+      else if (tab === 'projects') {
+        console.log('here projects')
+        projects = entityFilters.visible ? this.props.projects.filter(p => p.enabled) : this.props.projects
+        projects = entityFilters.archived ? projects.filter(p => !p.isArchived) : projects
+        projects = entityFilters.virtual ? projects.filter(p => p.isVirtual) : projects
+      }
       return (
         <WrappedComponent {...this.props} 
           challenges = {challenges} 

--- a/src/components/SuperAdmin/WithMetricsFilter.js
+++ b/src/components/SuperAdmin/WithMetricsFilter.js
@@ -31,12 +31,10 @@ const WithMetricsFilter = function(WrappedComponent) {
       let challenges = this.props.challenges
       let projects = this.props.projects
       if (tab === 'challenges') {
-        console.log('here challenges')
         challenges = entityFilters.visible ? this.props.challenges.filter(c => c.enabled) : this.props.challenges
         challenges = entityFilters.archived ? challenges.filter(c => !c.isArchived) : challenges
       }
       else if (tab === 'projects') {
-        console.log('here projects')
         projects = entityFilters.visible ? this.props.projects.filter(p => p.enabled) : this.props.projects
         projects = entityFilters.archived ? projects.filter(p => !p.isArchived) : projects
         projects = entityFilters.virtual ? projects.filter(p => p.isVirtual) : projects

--- a/src/components/SuperAdmin/WithMetricsFilter.js
+++ b/src/components/SuperAdmin/WithMetricsFilter.js
@@ -18,7 +18,6 @@ const WithMetricsFilter = function(WrappedComponent) {
       if(params['to']){
         [endYear, endMonth, endDate] = params['to'].split('-')
       }
-      console.log(startYear, startMonth, startDate)
       let entityFilters = {
         visible: params['hideUndiscoverable'] === 'true',
         archived: params['hideArchived'] === 'true',
@@ -29,7 +28,6 @@ const WithMetricsFilter = function(WrappedComponent) {
 
       const toggleFilter = (filterName) => {
         entityFilters[filterName] = !entityFilters[filterName]
-        // const newQueries = { ...params, [filterName]: entityFilters[filterName]};
         let searchquery = `?`
         searchquery += `tab=${tab}&`
         searchquery += `hideUndiscoverable=${entityFilters.visible}&`
@@ -43,7 +41,6 @@ const WithMetricsFilter = function(WrappedComponent) {
 
       const toggleStartDate = (startDate) => {
         entityFilters.from = startDate
-        console.log('yes', entityFilters)
         const newQueries = { ...params, from: startDate }
         this.props.history.push({
           pathname: '/superadmin',
@@ -60,11 +57,18 @@ const WithMetricsFilter = function(WrappedComponent) {
         })
       }
 
+      const clearDateFilter = () => {
+        const newQueries = {...params, from: undefined, to: undefined}
+         this.props.history.push({
+          pathname: '/superadmin',
+          search: queryString.stringify(newQueries)
+        })
+      }
+
       let challenges = this.props.challenges
       let projects = this.props.projects
 
       if (tab === 'challenges') {
-        console.log('hello', entityFilters)
         challenges = entityFilters.visible ? this.props.challenges.filter(c => c.enabled) : this.props.challenges
         challenges = entityFilters.archived ? challenges.filter(c => !c.isArchived) : challenges
         challenges = entityFilters.from ? challenges.filter(c => {
@@ -90,13 +94,14 @@ const WithMetricsFilter = function(WrappedComponent) {
         }) : projects
       }
       return (
-        <WrappedComponent {...this.props} 
-          challenges = {challenges} 
+        <WrappedComponent {...this.props}
+          challenges={challenges}
           projects={projects}
-          entityFilters = {entityFilters}
-          toggleFilter = {toggleFilter}
-          toggleStartDate = {toggleStartDate}
-          toggleEndDate = {toggleEndDate}
+          entityFilters={entityFilters}
+          toggleFilter={toggleFilter}
+          toggleStartDate={toggleStartDate}
+          toggleEndDate={toggleEndDate}
+          clearDateFilter={clearDateFilter}
         />
       )
     }

--- a/src/components/SuperAdmin/WithMetricsFilter.js
+++ b/src/components/SuperAdmin/WithMetricsFilter.js
@@ -9,7 +9,7 @@ const WithMetricsFilter = function(WrappedComponent) {
   return class extends Component {
     render() {
       const params = queryString.parse(this.props.location.search)
-
+      const tab = params['tab']
       let entityFilters = {
         visible: params['hideUndiscoverable'] === 'true',
         archived: params['hideArchived'] === 'true',
@@ -19,6 +19,7 @@ const WithMetricsFilter = function(WrappedComponent) {
       const toggleFilter = (filterName) => {
         entityFilters[filterName] = !entityFilters[filterName]
         let searchquery = `?`
+        searchquery += `tab=${tab}&`
         searchquery += `hideUndiscoverable=${entityFilters.visible}&`
         searchquery += `hideArchived=${entityFilters.archived}&`
         searchquery += `virtual=${entityFilters.virtual}`
@@ -27,11 +28,12 @@ const WithMetricsFilter = function(WrappedComponent) {
           search: searchquery
         })  
       }
+
       let challenges = entityFilters.visible ? this.props.challenges.filter(c => c.enabled) : this.props.challenges
       challenges = entityFilters.archived ? challenges.filter(c => !c.isArchived) : challenges
 
       let projects = entityFilters.visible? this.props.projects.filter(p => p.enabled): this.props.projects
-      projects = entityFilters.archived? projects.filter(p => p.isArchived): projects
+      projects = entityFilters.archived? projects.filter(p => !p.isArchived): projects
       projects = entityFilters.virtual? projects.filter(p => p.isVirtual): projects
 
       return (

--- a/src/components/SuperAdmin/WithMetricsFilter.js
+++ b/src/components/SuperAdmin/WithMetricsFilter.js
@@ -11,16 +11,16 @@ const WithMetricsFilter = function(WrappedComponent) {
       const params = queryString.parse(this.props.location.search)
 
       let entityFilters = {
-        visible: params['visible'] === 'true',
-        archived: params['archived'] === 'true',
+        visible: params['hideUndiscoverable'] === 'true',
+        archived: params['hideArchived'] === 'true',
         virtual: params['virtual'] === 'true'
       }
 
       const toggleFilter = (filterName) => {
         entityFilters[filterName] = !entityFilters[filterName]
         let searchquery = `?`
-        searchquery += `visible=${entityFilters.visible}&`
-        searchquery += `archived=${entityFilters.archived}&`
+        searchquery += `hideUndiscoverable=${entityFilters.visible}&`
+        searchquery += `hideArchived=${entityFilters.archived}&`
         searchquery += `virtual=${entityFilters.virtual}`
         this.props.history.push({
           pathname: '/superadmin',
@@ -28,7 +28,7 @@ const WithMetricsFilter = function(WrappedComponent) {
         })  
       }
       let challenges = entityFilters.visible ? this.props.challenges.filter(c => c.enabled) : this.props.challenges
-      challenges = entityFilters.archived ? challenges.filter(c => c.isArchived) : challenges
+      challenges = entityFilters.archived ? challenges.filter(c => !c.isArchived) : challenges
 
       let projects = entityFilters.visible? this.props.projects.filter(p => p.enabled): this.props.projects
       projects = entityFilters.archived? projects.filter(p => p.isArchived): projects

--- a/src/components/SuperAdmin/WithSortedProjects.js
+++ b/src/components/SuperAdmin/WithSortedProjects.js
@@ -27,7 +27,7 @@ export const sortProjects = function(props, projectsProp='projects') {
      sortedProjects = (_sortBy(sortedProjects, 
       p => {
         const projectManage= AsManageableProject(p)
-        return(projectManage.childChallenges(challenges).length)
+        return(projectManage.childChallenges(props.challenges).length)
       }))
   }
   return sortedProjects

--- a/src/components/SuperAdmin/WithSortedProjects.js
+++ b/src/components/SuperAdmin/WithSortedProjects.js
@@ -1,0 +1,60 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types'
+import _get from 'lodash/get'
+import _findIndex from 'lodash/findIndex'
+import _sortBy from 'lodash/sortBy'
+import _reverse from 'lodash/reverse'
+import _isEmpty from 'lodash/isEmpty'
+import _omit from 'lodash/omit'
+import _isFinite from 'lodash/isFinite'
+import _toLower from 'lodash/toLower'
+import { SORT_NAME, SORT_CREATED, SORT_OLDEST, SORT_NUM_OF_CHALLENGES } from '../../services/Search/Search';
+import AsManageableProject from '../../interactions/Project/AsManageableProject';
+
+export const sortProjects = function(props, projectsProp='projects') {
+  const sortCriteria = _get(props, 'searchSort.sortBy')
+  let sortedProjects = props[projectsProp]
+  if (sortCriteria === SORT_NAME) {
+    sortedProjects = _sortBy(sortedProjects, (p) => _toLower(p.name))
+  }
+  else if (sortCriteria === SORT_CREATED) {
+    sortedProjects = _reverse(_sortBy(sortedProjects,
+      p => p.created ? p.created : ''))
+  }
+  else if (sortCriteria === SORT_OLDEST) {
+    sortedProjects = (_sortBy(sortedProjects, 
+      p => p.created ? p.created : ''))
+  }
+  else if (sortCriteria === SORT_NUM_OF_CHALLENGES) {
+     sortedProjects = (_sortBy(sortedProjects, 
+      p => {
+        const projectManage= AsManageableProject(p)
+        return(projectManage.childChallenges(challenges).length)
+      }))
+  }
+  return sortedProjects
+}
+
+export default function(WrappedComponent,
+                        projectsProp='projects',
+                        outputProp) {
+  class WithSortedProjects extends Component {
+    render() {
+      const sortedProjects = sortProjects(this.props, projectsProp)
+
+      if (_isEmpty(outputProp)) {
+        outputProp = projectsProp
+      }
+
+      return <WrappedComponent {...{[outputProp]: sortedProjects}}
+                               {..._omit(this.props, outputProp)} />
+    }
+  }
+
+  WithSortedProjects.propTypes = {
+    user: PropTypes.object,
+    projects: PropTypes.array,
+  }
+
+  return WithSortedProjects
+}

--- a/src/components/SuperAdmin/WithSortedProjects.js
+++ b/src/components/SuperAdmin/WithSortedProjects.js
@@ -1,12 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types'
 import _get from 'lodash/get'
-import _findIndex from 'lodash/findIndex'
 import _sortBy from 'lodash/sortBy'
 import _reverse from 'lodash/reverse'
 import _isEmpty from 'lodash/isEmpty'
 import _omit from 'lodash/omit'
-import _isFinite from 'lodash/isFinite'
 import _toLower from 'lodash/toLower'
 import { SORT_NAME, SORT_CREATED, SORT_OLDEST, SORT_NUM_OF_CHALLENGES } from '../../services/Search/Search';
 import AsManageableProject from '../../interactions/Project/AsManageableProject';

--- a/src/services/Search/Messages.js
+++ b/src/services/Search/Messages.js
@@ -32,6 +32,10 @@ export default defineMessages({
     id: "Challenge.sort.cooperativeWork",
     defaultMessage: "Cooperative",
   },
+  num_of_challenges: {
+    id: "Project.sort.numOfChallenges",
+    defaultMessage: "numOfChallenges"
+  },
   default: {
     id: "Challenge.sort.default",
     defaultMessage: "Default",

--- a/src/services/Search/Search.js
+++ b/src/services/Search/Search.js
@@ -54,7 +54,9 @@ export const SORT_COMPLETION = 'completion_percentage'
 export const SORT_TASKS_REMAINING = 'tasks_remaining'
 export const SORT_COOPERATIVE_WORK = 'cooperative_type'
 export const SORT_DEFAULT = 'default'
+export const SORT_NUM_OF_CHALLENGES = 'num_of_challenges'
 export const ALL_SORT_OPTIONS = [SORT_NAME, SORT_CREATED, SORT_OLDEST, SORT_POPULARITY, SORT_COOPERATIVE_WORK, SORT_COMPLETION, SORT_TASKS_REMAINING, SORT_DEFAULT]
+export const PROJECT_SORT_OPTIONS = [SORT_NAME, SORT_CREATED, SORT_OLDEST, SORT_NUM_OF_CHALLENGES, SORT_DEFAULT]
 
 // Default Results Per page
 export const RESULTS_PER_PAGE = 50
@@ -92,12 +94,10 @@ export const PARAMS_MAP = {
   archived: "ca"
 }
 
-
 /** Returns object containing localized labels  */
 export const sortLabels = intl => _fromPairs(
   _map(messages, (message, key) => [key, intl.formatMessage(message)])
 )
-
 
 /**
  * Parse the given raw query text that may include hashtags for keywords and


### PR DESCRIPTION
Developed with @javtran 

#### Project table: 
- A sortable list of  all projects with core metrics (id,  name, owner, # of challenges, discoverable, archived, virtual, date created, date last modified).
- Clicking on a project will take you to the existing project admin page.
- Sort projects by name, newest/oldest date, default.
- Hide undiscoverable/archived projects with toggle.
- Filter virtual only projects with toggle.
- Search to filter by project name.
- Filter projects by dates created
- Export table as CSV.
- Customizable paginations(default to 50).

#### New features/changes to challenge table: 
- Filter challenges by dates created.
- Hide undiscoverable/archived challenges with toggle.
- Display project name by name.